### PR TITLE
Use liquiddump as a basis to create a Prometheus metrics exporter

### DIFF
--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -16,19 +16,8 @@ Usage:
   liquidexport --version
 
 Options:
-  --interval <seconds>    Update interval in seconds [default: 2]
-  --hid <module>          Override API for USB HIDs: usb, hid or hidraw
   --legacy-690lc          Use Asetek 690LC in legacy mode (old Krakens)
-  --match <name>          Filter devices by name
-  --vendor <id>           Filter devices by vendor id
-  --product <id>          Filter devices by product id
-  --release <number>      Filter devices by release number
-  --serial <number>       Filter devices by serial number
-  --bus <bus>             Filter devices by bus
-  --address <address>     Filter devices by address in bus
-  --usb-port <port>       Filter devices by USB port in bus
-  --pick <number>         Pick among many results for a given filter
-  --port <number>         Port for the HTTP /metrics endpoint
+  --server-port <number>  Port for the HTTP /metrics endpoint
   -v, --verbose           Output additional information
   -g, --debug             Show debug information on stderr
   --version               Display the version number
@@ -44,19 +33,15 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import logging
+import re
 import sys
 import time
-
-import liquidctl.cli as _borrow
 import usb
 
 from docopt import docopt
 from liquidctl.driver import *
-
 from prometheus_client import start_http_server
 from prometheus_client.core import GaugeMetricFamily, REGISTRY
-
-import re
 
 LOGGER = logging.getLogger(__name__)
 
@@ -66,9 +51,8 @@ def gauge_name_sanitize(name):
 
 
 class LiquidCollector(object):
-    def __init__(self, args):
+    def __init__(self):
         self.description = 'liquidctl exported metrics'
-        self.args = args
 
     def collect(self):
         labels = ['device', 'sensor', 'unit']
@@ -95,9 +79,7 @@ class LiquidCollector(object):
 
 if __name__ == '__main__':
     args = docopt(__doc__, version='0.1.0')
-    frwd = _borrow._make_opts(args)
-    devs = list(find_liquidctl_devices(**frwd))
-    update_interval = float(args['--interval'])
+    devs = list(find_liquidctl_devices())
 
     if args['--debug']:
         args['--verbose'] = True
@@ -108,10 +90,10 @@ if __name__ == '__main__':
         logging.basicConfig(level=logging.WARNING, format='%(message)s')
         sys.tracebacklimit = 0
 
-    REGISTRY.register(LiquidCollector(args))
+    REGISTRY.register(LiquidCollector())
 
-    if args['--port']:
-        port = int(args['--port'])
+    if args['--server-port']:
+        port = int(args['--server-port'])
     else:
         port = 8098
 
@@ -120,6 +102,7 @@ if __name__ == '__main__':
 
     try:
         while True:
-            time.sleep(update_interval)
+            # Keep HTTP server alive in a loop
+            time.sleep(2)
     except KeyboardInterrupt:
         LOGGER.info('Canceled by user')

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -77,9 +77,23 @@ class LiquidCollector(object):
         yield g
 
 
+def _make_opts(args):
+    opts = {}
+    for arg, val in args.items():
+        if val is not None and arg in _PARSE_ARG:
+            opt = arg.replace('--', '').replace('-', '_')
+            opts[opt] = _PARSE_ARG[arg](val)
+    return opts
+
+
+_PARSE_ARG = {
+    '--legacy-690lc': bool
+}
+
 if __name__ == '__main__':
     args = docopt(__doc__, version='0.1.0')
-    devs = list(find_liquidctl_devices())
+    opts = _make_opts(args)
+    devs = list(find_liquidctl_devices(**opts))
 
     if args['--debug']:
         args['--verbose'] = True

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -59,7 +59,6 @@ class LiquidCollector(object):
         g = GaugeMetricFamily('liquidctl', self.description, labels=labels)
         i = InfoMetricFamily('liquidctl', self.description, labels=['device'])
         for d in devs:
-            d.connect()
             try:
                 get_status = d.get_status()
                 for metric in get_status:
@@ -86,7 +85,6 @@ class LiquidCollector(object):
             except usb.core.USBError as err:
                 LOGGER.warning('Failed to read from the device, possibly serving stale data')
                 LOGGER.debug(err, exc_info=True)
-            d.disconnect()
         yield g
         yield i
 
@@ -108,6 +106,9 @@ if __name__ == '__main__':
     args = docopt(__doc__, version='0.1.0')
     opts = _make_opts(args)
     devs = list(find_liquidctl_devices(**opts))
+    for d in devs:
+        LOGGER.info('Initializing %s', d.description)
+        d.connect()
 
     if args['--debug']:
         args['--verbose'] = True
@@ -134,3 +135,10 @@ if __name__ == '__main__':
             time.sleep(2)
     except KeyboardInterrupt:
         LOGGER.info('Canceled by user')
+    finally:
+        for d in devs:
+            try:
+                LOGGER.info('Disconnecting from %s', d.description)
+                d.disconnect()
+            except:
+                LOGGER.exception('Unexpected error when disconnecting')

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -12,8 +12,6 @@ liquidctl{device="NZXT Kraken X (X42, X52, X62 or X72)",sensor="liquid_temperatu
 
 Usage:
   liquidexport [options]
-  liquidexport --help
-  liquidexport --version
 
 Options:
   --legacy-690lc          Use Asetek 690LC in legacy mode (old Krakens)

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -33,7 +33,6 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import logging
-import re
 import sys
 import time
 import usb
@@ -41,7 +40,8 @@ import usb
 from docopt import docopt
 from liquidctl.driver import *
 from prometheus_client import start_http_server
-from prometheus_client.core import GaugeMetricFamily, REGISTRY
+from prometheus_client.core import GaugeMetricFamily, REGISTRY, InfoMetricFamily
+from datetime import timedelta
 
 LOGGER = logging.getLogger(__name__)
 
@@ -57,33 +57,47 @@ class LiquidCollector(object):
     def collect(self):
         labels = ['device', 'sensor', 'unit']
         g = GaugeMetricFamily('liquidctl', self.description, labels=labels)
+        i = InfoMetricFamily('liquidctl', self.description, labels=['device'])
         for d in devs:
             d.connect()
             try:
                 get_status = d.get_status()
                 for metric in get_status:
-                    # Only allow numerical stats and exclude string values like "firmware='6.3.3'"
-                    if isinstance(metric[1], (int, float, complex)) and not isinstance(metric[1], bool):
-                        sanitized_name = gauge_name_sanitize(metric[0])
-                        label_values = [d.description, sanitized_name, metric[2]]
-                        g.add_metric(label_values, value=metric[1])
+                    unit = metric[2]
+                    sanitized_name = gauge_name_sanitize(metric[0])
+                    sample_value = metric[1]
+
+                    if isinstance(sample_value, timedelta):
+                        # cast timedelta into seconds and override the supplied unit
+                        sample_value = sample_value.seconds
+                        unit = 'seconds'
+
+                    if unit != '':
+                        label_values = [d.description, sanitized_name, unit]
+                        g.add_metric(label_values, value=sample_value)
                         LOGGER.debug(
-                            '{}: {} as {} with labels {}'.format(d.description, metric, sanitized_name,
-                                                                 '/'.join(label_values)))
+                            '%s: %s as GaugeMetric %s labels %s' %
+                            (d.description, metric, sanitized_name, '/'.join(label_values)))
+                    else:
+                        i.add_metric([d.description], value={sanitized_name: sample_value})
+                        LOGGER.debug(
+                            '%s: %s InfoMetric labeled with %s => %s' %
+                            (d.description, metric, sanitized_name, sample_value))
             except usb.core.USBError as err:
                 LOGGER.warning('Failed to read from the device, possibly serving stale data')
                 LOGGER.debug(err, exc_info=True)
             d.disconnect()
         yield g
+        yield i
 
 
-def _make_opts(args):
-    opts = {}
-    for arg, val in args.items():
+def _make_opts(arguments):
+    options = {}
+    for arg, val in arguments.items():
         if val is not None and arg in _PARSE_ARG:
             opt = arg.replace('--', '').replace('-', '_')
-            opts[opt] = _PARSE_ARG[arg](val)
-    return opts
+            options[opt] = _PARSE_ARG[arg](val)
+    return options
 
 
 _PARSE_ARG = {
@@ -107,12 +121,12 @@ if __name__ == '__main__':
     REGISTRY.register(LiquidCollector())
 
     if args['--server-port']:
-        port = int(args['--server-port'])
+        server_port = int(args['--server-port'])
     else:
-        port = 8098
+        server_port = 8098
 
-    start_http_server(port)
-    LOGGER.debug('Server started on port {}'.format(port))
+    start_http_server(server_port)
+    LOGGER.debug('Server started on port %s' % server_port)
 
     try:
         while True:

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -73,13 +73,13 @@ class LiquidCollector(object):
                         label_values = [d.description, sanitized_name, unit]
                         g.add_metric(label_values, value=sample_value)
                         LOGGER.debug(
-                            '%s: %s as GaugeMetric %s labels %s' %
-                            (d.description, metric, sanitized_name, '/'.join(label_values)))
+                            '%s: %s as GaugeMetric %s labels %s',
+                            d.description, metric, sanitized_name, '/'.join(label_values))
                     else:
                         i.add_metric([d.description], value={sanitized_name: sample_value})
                         LOGGER.debug(
-                            '%s: %s InfoMetric labeled with %s => %s' %
-                            (d.description, metric, sanitized_name, sample_value))
+                            '%s: %s InfoMetric labeled with %s => %s',
+                            d.description, metric, sanitized_name, sample_value)
             except usb.core.USBError as err:
                 LOGGER.warning('Failed to read from the device, possibly serving stale data')
                 LOGGER.debug(err, exc_info=True)
@@ -125,7 +125,7 @@ if __name__ == '__main__':
         server_port = 8098
 
     start_http_server(server_port)
-    LOGGER.debug('Server started on port %s' % server_port)
+    LOGGER.debug('Server started on port %s', server_port)
 
     try:
         while True:

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -1,4 +1,48 @@
 #!/usr/bin/env python3
+"""liquidexport – host a metrics HTTP endpoint with Prometheus formatted data from liquidctl
+
+This is an experimental script that collects stats from liquidctl and exposes them as a http://localhost:8098/metrics
+endpoint in the Prometheus text format.
+See: https://prometheus.io/docs/instrumenting/exposition_formats/#text-format-example
+
+Example metric with labels:
+# HELP liquidctl liquidctl exported metrics
+# TYPE liquidctl gauge
+liquidctl{device="NZXT Kraken X (X42, X52, X62 or X72)",sensor="liquid_temperature",unit="°C"} 33.6
+
+Usage:
+  liquidexport [options]
+  liquidexport --help
+  liquidexport --version
+
+Options:
+  --interval <seconds>    Update interval in seconds [default: 2]
+  --hid <module>          Override API for USB HIDs: usb, hid or hidraw
+  --legacy-690lc          Use Asetek 690LC in legacy mode (old Krakens)
+  --match <name>          Filter devices by name
+  --vendor <id>           Filter devices by vendor id
+  --product <id>          Filter devices by product id
+  --release <number>      Filter devices by release number
+  --serial <number>       Filter devices by serial number
+  --bus <bus>             Filter devices by bus
+  --address <address>     Filter devices by address in bus
+  --usb-port <port>       Filter devices by USB port in bus
+  --pick <number>         Pick among many results for a given filter
+  --port <number>         Port for the HTTP /metrics endpoint
+  -v, --verbose           Output additional information
+  -g, --debug             Show debug information on stderr
+  --version               Display the version number
+  --help                  Show this message
+
+Examples:
+  liquidexport
+  liquidexport --product 0xb200
+  liquidexport --interval 0.5
+
+Copyright (C) 2020  Alex Berryman
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
 import logging
 import sys
 import time
@@ -36,11 +80,14 @@ class LiquidCollector(object):
             try:
                 get_status = d.get_status()
                 for metric in get_status:
-                    # Exclude string values like 'firmware'
+                    # Only allow numerical stats and exclude string values like "firmware='6.3.3'"
                     if isinstance(metric[1], (int, float, complex)) and not isinstance(metric[1], bool):
                         sanitized_name = gauge_name_sanitize(metric[0])
                         label_values = [d.description, sanitized_name, metric[2]]
                         g.add_metric(label_values, value=metric[1])
+                        LOGGER.debug(
+                            '{}: {} as {} with labels {}'.format(d.description, metric, sanitized_name,
+                                                                 '/'.join(label_values)))
             except usb.core.USBError as err:
                 LOGGER.warning('Failed to read from the device, possibly serving stale data')
                 LOGGER.debug(err, exc_info=True)
@@ -65,9 +112,13 @@ if __name__ == '__main__':
 
     REGISTRY.register(LiquidCollector(args))
 
-    port = 8098
+    if args['--port']:
+        port = int(args['--port'])
+    else:
+        port = 8098
+
     start_http_server(port)
-    LOGGER.info('Server started on port %(port)s', {'port': port})
+    LOGGER.debug('Server started on port {}'.format(port))
 
     try:
         while True:

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+import logging
+import sys
+import time
+
+import liquidctl.cli as _borrow
+import usb
+
+from docopt import docopt
+from liquidctl.driver import *
+
+from prometheus_client import start_http_server
+from prometheus_client.core import GaugeMetricFamily, REGISTRY
+
+import re
+
+LOGGER = logging.getLogger(__name__)
+
+
+def gauge_name_sanitize(name):
+    name = re.sub(r'(?<!^)(?=[A-Z])', '_', name).lower()
+    name = name.replace(" ", "_")
+    return name
+
+
+class LiquidCollector(object):
+    def __init__(self, args):
+        self.description = 'liquidctl exported metrics'
+        self.args = args
+
+    def collect(self):
+        labels = ['device', 'sensor', 'unit']
+        g = GaugeMetricFamily('liquidctl', self.description, labels=labels)
+        for d in devs:
+            d.connect()
+            try:
+                get_status = d.get_status()
+                for metric in get_status:
+                    # Exclude string values like 'firmware'
+                    if isinstance(metric[1], (int, float, complex)) and not isinstance(metric[1], bool):
+                        sanitized_name = gauge_name_sanitize(metric[0])
+                        label_values = [d.description, sanitized_name, metric[2]]
+                        g.add_metric(label_values, value=metric[1])
+            except usb.core.USBError as err:
+                LOGGER.warning('Failed to read from the device, possibly serving stale data')
+                LOGGER.debug(err, exc_info=True)
+            d.disconnect()
+        yield g
+
+
+if __name__ == '__main__':
+    args = docopt(__doc__, version='0.1.0')
+    frwd = _borrow._make_opts(args)
+    devs = list(find_liquidctl_devices(**frwd))
+    update_interval = float(args['--interval'])
+
+    if args['--debug']:
+        args['--verbose'] = True
+        logging.basicConfig(level=logging.DEBUG, format='[%(levelname)s] %(name)s: %(message)s')
+    elif args['--verbose']:
+        logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+    else:
+        logging.basicConfig(level=logging.WARNING, format='%(message)s')
+        sys.tracebacklimit = 0
+
+    REGISTRY.register(LiquidCollector(args))
+
+    port = 8098
+    start_http_server(port)
+    LOGGER.info('Server started on port %(port)s', {'port': port})
+
+    try:
+        while True:
+            time.sleep(update_interval)
+    except KeyboardInterrupt:
+        LOGGER.info('Canceled by user')

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -63,9 +63,9 @@ class LiquidCollector(object):
             try:
                 get_status = d.get_status()
                 for metric in get_status:
-                    unit = metric[2]
                     sanitized_name = gauge_name_sanitize(metric[0])
                     sample_value = metric[1]
+                    unit = metric[2]
 
                     if isinstance(sample_value, timedelta):
                         # cast timedelta into seconds and override the supplied unit

--- a/extra/liquidexport
+++ b/extra/liquidexport
@@ -62,9 +62,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def gauge_name_sanitize(name):
-    name = re.sub(r'(?<!^)(?=[A-Z])', '_', name).lower()
-    name = name.replace(" ", "_")
-    return name
+    return name.replace(" ", "_").lower()
 
 
 class LiquidCollector(object):


### PR DESCRIPTION
## Changes
I took the idea of `liquiddump` and instead of dumping the stats out as JSON, they are instead exposed as an HTTP endpoint in a format for the Prometheus metric service to collect. Once Prometheus collects this data it is then easy to visualize in tools like Grafana. Each time the metrics web page is requested the `extra.liquidexport.LiquidCollector.collect()` method is called to collect the data from `liquidctl` and create the output.

## New packages required
`pip3 install prometheus-client`

## Example Output
`liquidexport` will host an HTTP endpoint so that Prometheus can scrape the metrics. I picked port `8098` to be the default, but exposed a `--port` option. Opening http://localhost:8098/metrics in your browser will show the basic python Prometheus metrics and then below that you will find the `liquidctl` specific metrics.

`liquidctl{device="NZXT Kraken X (X42, X52, X62 or X72)",sensor="liquid_temperature",unit="°C"} 35.1`
Looking at the specific example line above you can see that it has the following properties:
- The metric name is `liquidctl` to match the name of the main library you built
- The metric then has several labels to help filter and aggregate the data once it is stored in Prometheus
  - `device` is collected from `d.description`
  - `sensor` is a normalized version of the name of each stat that is reported from `d.get_status()` 
  - `unit` is the direct result from `d.get_status()` 
- Finally, the `35.1` is the actual measurement that was created when the page was loaded

```
# HELP python_gc_objects_collected_total Objects collected during gc
# TYPE python_gc_objects_collected_total counter
python_gc_objects_collected_total{generation="0"} 167.0
python_gc_objects_collected_total{generation="1"} 176.0
python_gc_objects_collected_total{generation="2"} 0.0
# HELP python_gc_objects_uncollectable_total Uncollectable object found during GC
# TYPE python_gc_objects_uncollectable_total counter
python_gc_objects_uncollectable_total{generation="0"} 0.0
python_gc_objects_uncollectable_total{generation="1"} 0.0
python_gc_objects_uncollectable_total{generation="2"} 0.0
# HELP python_gc_collections_total Number of times this generation was collected
# TYPE python_gc_collections_total counter
python_gc_collections_total{generation="0"} 44.0
python_gc_collections_total{generation="1"} 4.0
python_gc_collections_total{generation="2"} 0.0
# HELP python_info Python platform information
# TYPE python_info gauge
python_info{implementation="CPython",major="3",minor="8",patchlevel="5",version="3.8.5"} 1.0
# HELP liquidctl liquidctl exported metrics
# TYPE liquidctl gauge
liquidctl{device="NZXT Kraken X (X42, X52, X62 or X72)",sensor="liquid_temperature",unit="°C"} 35.1
liquidctl{device="NZXT Kraken X (X42, X52, X62 or X72)",sensor="fan_speed",unit="rpm"} 1154.0
liquidctl{device="NZXT Kraken X (X42, X52, X62 or X72)",sensor="pump_speed",unit="rpm"} 2064.0
liquidctl{device="NZXT Smart Device V2",sensor="fan_1_duty",unit="%"} 100.0
liquidctl{device="NZXT Smart Device V2",sensor="fan_1_speed",unit="rpm"} 1290.0
liquidctl{device="NZXT Smart Device V2",sensor="fan_2_duty",unit="%"} 100.0
liquidctl{device="NZXT Smart Device V2",sensor="fan_2_speed",unit="rpm"} 978.0
liquidctl{device="NZXT Smart Device V2",sensor="fan_3_duty",unit="%"} 100.0
liquidctl{device="NZXT Smart Device V2",sensor="fan_3_speed",unit="rpm"} 1321.0
liquidctl{device="NZXT Smart Device V2",sensor="noise_level",unit="dB"} 58.0
```
## Example Dashboard
By graphing this data out in Grafana it makes it easy to visualize the impact and effectiveness of fan curves. In the top left panel of this [liquidexport Prometheus Example dashboard](https://snapshot.raintank.io/dashboard/snapshot/TYi10VjL63wwwOEjLqihGqGXAICsSiDc?orgId=2) I created green/yellow/red horizontal thresholds to represent the following fan profiles defined using `liquidctl`:
- ` ./liquidctl.exe set --match kraken pump speed 40 60 41 80 44 100`
- `./liquidctl.exe set --match kraken fan speed 40 60 41 80 44 100`

Now every time the blue `Liquid Temp` line crosses a threshold at 40°C/41°C/44°C you can see the impact on the `AIO Pump` and `Exhaust - Radiator` fan RPMs.
![liquidexport_example_dashboard](https://user-images.githubusercontent.com/1881846/91680442-dbed7d80-eb10-11ea-87c2-2cab90c67923.jpg)

## Question for Reviewers
1. Is this something that you want to add to your main repository or should I spin it off to a separate package that simply requires `liquidctl`?
2. Each loop through `extra.liquidexport.LiquidCollector.collect()` I am calling `d.connect()`, gathering the data I need, and then calling `d.disconnect()`. Is this pattern ideal or should I refactor my code to maintain a single long-running connection to the devices? If I keep the connection open for hours/days are there any drawbacks? 

