### PR TITLE
direction flag change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Changelog since 1.4.2:
 ### Fixed
  - Fix potential exception when a release number is not available
  - Enforce USB port filters on HID devices
+ - Fix backwards `rainbow-pulse` mode on Kraken X3 devices
 
 
 ## [1.4.2] – 2020-11-01

--- a/docs/kraken-x2-m2-guide.md
+++ b/docs/kraken-x2-m2-guide.md
@@ -75,6 +75,9 @@ For lighting, the user can control a total of nine LEDs: one behind the NZXT log
 
 Colors can be specified in RGB, HSV or HSL (see [Supported color specification formats](../README.md#supported-color-specification-formats)), and each animation mode supports different number of colors.  The animation speed can be customized with the `--speed <value>`, and five relative values are accepted by the device: `slowest`, `slower`, `normal`, `faster` and `fastest`.
 
+Some of the color animations can be in either the `forward` or `backward` direction.
+This can be specified by using the `--direction` flag.
+
 | `ring` | `logo` | `sync` | Mode | Colors | Notes |
 | --- | --- | --- | --- | --- | --- |
 | ✓ | ✓ | ✓ | `off` | None |
@@ -82,16 +85,11 @@ Colors can be specified in RGB, HSV or HSL (see [Supported color specification f
 | ✓ | ✓ | ✓ | `super-fixed` | Up to 9 (logo + each ring LED) |
 | ✓ | ✓ | ✓ | `fading` | Between 2 and 8, one for each step |
 | ✓ | ✓ | ✓ | `spectrum-wave` | None |
-| ✓ | ✓ | ✓ | `backwards-spectrum-wave` | None |
 | ✓ |   |   | `super-wave` | Up to 8 |
-| ✓ |   |   | `backwards-super-wave` | Up to 8 |
 | ✓ |   |   | `marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
-| ✓ |   |   | `backwards-marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
 | ✓ |   |   | `covering-marquee` | Up to 8, one for each step |
-| ✓ |   |   | `covering-backwards-marquee` | Up to 8, one for each step |
 | ✓ |   |   | `alternating` | Two |
 | ✓ |   |   | `moving-alternating` | Two |
-| ✓ |   |   | `backwards-moving-alternating` | Two |
 | ✓ | ✓ | ✓ | `breathing` | Up to 8, one for each step |
 | ✓ | ✓ | ✓ | `super-breathing` | Up to 9 (logo + each ring LED) | Only one step |
 | ✓ | ✓ | ✓ | `pulse` | Up to 8, one for each pulse |

--- a/docs/kraken-x2-m2-guide.md
+++ b/docs/kraken-x2-m2-guide.md
@@ -70,7 +70,7 @@ For lighting, the user can control a total of nine LEDs: one behind the NZXT log
 # liquidctl set sync color fixed af5a2f
 # liquidctl set ring color fading 350017 ff2608
 # liquidctl set logo color pulse ffffff
-# liquidctl set ring color backwards-marquee-5 2f6017 --speed slower
+# liquidctl set ring color marquee-5 2f6017 --direction backward --speed slower
 ```
 
 Colors can be specified in RGB, HSV or HSL (see [Supported color specification formats](../README.md#supported-color-specification-formats)), and each animation mode supports different number of colors.  The animation speed can be customized with the `--speed <value>`, and five relative values are accepted by the device: `slowest`, `slower`, `normal`, `faster` and `fastest`.
@@ -97,3 +97,17 @@ This can be specified by using the `--direction` flag.
 | ✓ |   |   | `water-cooler` | None |
 | ✓ |   |   | `loading` | One |
 | ✓ |   |   | `wings` | One |
+
+
+#### Deprecated modes
+
+The following modes are now deprecated and the use of the `--direction backward` is preferred,
+they will be removed in a future version and are kept for now for backwards compatibility.
+
+| `ring` | `logo` | `sync` | Mode | Colors | Notes |
+| --- | --- | --- | --- | --- | --- |
+| ✓ | ✓ | ✓ | `backwards-spectrum-wave` | None |
+| ✓ |   |   | `backwards-super-wave` | Up to 8 |
+| ✓ |   |   | `backwards-marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
+| ✓ |   |   | `covering-backwards-marquee` | Up to 8, one for each step |
+| ✓ |   |   | `backwards-moving-alternating` | Two |

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -113,6 +113,9 @@ Color modes can be set independently for each lighting channel, but the specifie
 
 Colors can be specified in RGB, HSV or HSL (see [Supported color specification formats](../README.md#supported-color-specification-formats)), and each animation mode supports different number of colors.  The animation speed can be customized with the `--speed <value>`, and five relative values are accepted by the device: `slowest`, `slower`, `normal`, `faster` and `fastest`.
 
+Some of the color animations can be in either the `forward` or `backward` direction.
+This can be specified by using the `--direction` flag.
+
 | Mode | Colors | Variable speed |
 | --- | --- | :---: |
 | `off` | None | |
@@ -120,14 +123,10 @@ Colors can be specified in RGB, HSV or HSL (see [Supported color specification f
 | `fading` | Between 1 and 8 | ✓ | |
 | `super-fixed` | Between 1 and 40 | |
 | `spectrum-wave` | None | ✓ |
-| `backwards-spectrum-wave` | None | ✓ |
 | `marquee-<length>`, 3 ≤ length ≤ 6 | One | ✓ |
-| `backwards-marquee-<length>`, 3 ≤ length ≤ 6 | One | ✓ |
 | `covering-marquee` | Between 1 and 8 | ✓ |
-| `covering-backwards-marquee` | Between 1 and 8 | ✓ |
 | `alternating-<length>` | Between 1 and 2 | ✓ |
 | `moving-alternating-<length>`, 3 ≤ length ≤ 6 | Between 1 and 2 | ✓ |
-| `backwards-moving-alternating-<length>`, 3 ≤ length ≤ 6 | Between 1 and 2 | ✓ |
 | `pulse` | Between 1 and 8 | ✓ |
 | `breathing` | Between 1 and 8 | ✓ |
 | `super-breathing` | Between 1 and 40 | ✓ |
@@ -136,9 +135,6 @@ Colors can be specified in RGB, HSV or HSL (see [Supported color specification f
 | `rainbow-flow` | None | ✓ |
 | `super-rainbow` | None | ✓ |
 | `rainbow-pulse` | None | ✓ |
-| `backwards-rainbow-flow` | None | ✓ |
-| `backwards-super-rainbow` | None | ✓ |
-| `backwards-rainbow-pulse` | None | ✓ |
 | `loading` | One | |
 | `tai-chi` | Between 1 and 2 | ✓ |
 | `water-cooler` | Two | ✓ |

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -108,7 +108,7 @@ Color modes can be set independently for each lighting channel, but the specifie
 # liquidctl set sync color fixed af5a2f
 # liquidctl set ring color fading 350017 ff2608
 # liquidctl set logo color pulse ffffff
-# liquidctl set external color backwards-marquee-5 2f6017 --speed slower
+# liquidctl set external color marquee-5 2f6017 --direction backward --speed slower
 ```
 
 Colors can be specified in RGB, HSV or HSL (see [Supported color specification formats](../README.md#supported-color-specification-formats)), and each animation mode supports different number of colors.  The animation speed can be customized with the `--speed <value>`, and five relative values are accepted by the device: `slowest`, `slower`, `normal`, `faster` and `fastest`.
@@ -140,6 +140,22 @@ This can be specified by using the `--direction` flag.
 | `water-cooler` | Two | ✓ |
 | `wings` | One | ✓ |
 
+
+
+#### Deprecated modes
+
+The following modes are now deprecated and the use of the `--direction backward` is preferred,
+they will be removed in a future version and are kept for now for backwards compatibility.
+
+| Mode | Colors | Variable speed |
+| --- | --- | :---: |
+| `backwards-spectrum-wave` | None | ✓ |
+| `backwards-marquee-<length>`, 3 ≤ length ≤ 6 | One | ✓ |
+| `covering-backwards-marquee` | Between 1 and 8 | ✓ |
+| `backwards-moving-alternating-<length>`, 3 ≤ length ≤ 6 | Between 1 and 2 | ✓ |
+| `backwards-rainbow-flow` | None | ✓ |
+| `backwards-super-rainbow` | None | ✓ |
+| `backwards-rainbow-pulse` | None | ✓ |
 
 ## The OLED screen (only Z models)
 

--- a/docs/nzxt-hue2-guide.md
+++ b/docs/nzxt-hue2-guide.md
@@ -120,3 +120,18 @@ This can be specified by using the `--direction` flag.
 | `super-rainbow` | None |
 | `rainbow-pulse` | None |
 | `wings` | One |
+
+#### Deprecated modes
+
+The following modes are now deprecated and the use of the `--direction backward` is preferred,
+they will be removed in a future version and are kept for now for backwards compatibility.
+
+| Mode | Colors | Notes |
+| --- | --- | --- |
+| `backwards-spectrum-wave` | None |
+| `backwards-marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
+| `covering-backwards-marquee` | Up to 8, one for each step |
+| `backwards-moving-alternating-<length>` | Two | 3 ≤ `length` ≤ 6 |
+| `backwards-rainbow-flow` | None |
+| `backwards-super-rainbow` | None |
+| `backwards-rainbow-pulse` | None |

--- a/docs/nzxt-hue2-guide.md
+++ b/docs/nzxt-hue2-guide.md
@@ -91,11 +91,14 @@ LED channels are numbered sequentially: `led1`, `led2`, (only HUE 2: `led3`, `le
 # liquidctl set led1 color fixed af5a2f
 # liquidctl set led2 color fading 350017 ff2608 --speed slower
 # liquidctl set led3 color pulse ffffff
-# liquidctl set led4 color backwards-marquee-5 2f6017 --speed slowest
-# liquidctl set sync color backwards-spectrum-wave
+# liquidctl set led4 color marquee-5 2f6017 --direction backward --speed slowest
+# liquidctl set sync color spectrum-wave
 ```
 
 Colors can be specified in RGB, HSV or HSL (see [Supported color specification formats](../README.md#supported-color-specification-formats)), and each animation mode supports different number of colors.  The animation speed can be customized with the `--speed <value>`, and five relative values are accepted by the device: `slowest`, `slower`, `normal`, `faster` and `fastest`.
+
+Some of the color animations can be in either the `forward` or `backward` direction.
+This can be specified by using the `--direction` flag.
 
 | Mode | Colors | Notes |
 | --- | --- | --- |
@@ -104,23 +107,16 @@ Colors can be specified in RGB, HSV or HSL (see [Supported color specification f
 | `super-fixed` | Up to 40, one for each LED |
 | `fading` | Between 2 and 8, one for each step |
 | `spectrum-wave` | None |
-| `backwards-spectrum-wave` | None |
 | `marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
-| `backwards-marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
 | `covering-marquee` | Up to 8, one for each step |
-| `covering-backwards-marquee` | Up to 8, one for each step |
 | `alternating-<length>` | Two | 3 ≤ `length` ≤ 6 |
 | `moving-alternating-<length>` | Two | 3 ≤ `length` ≤ 6 |
-| `backwards-moving-alternating-<length>` | Two | 3 ≤ `length` ≤ 6 |
 | `pulse` | Up to 8, one for each pulse |
 | `breathing` | Up to 8, one for each step |
 | `super-breathing` | Up to 40, one for each LED | Only one step |
 | `candle` | One |
 | `starry-night` | One |
 | `rainbow-flow` | None |
-| `backwards-rainbow-flow` | None |
 | `super-rainbow` | None |
-| `backwards-super-rainbow` | None |
 | `rainbow-pulse` | None |
-| `backwards-rainbow-pulse` | None |
 | `wings` | One |

--- a/docs/nzxt-smart-device-v1-guide.md
+++ b/docs/nzxt-smart-device-v1-guide.md
@@ -108,3 +108,16 @@ This can be specified by using the `--direction` flag.
 | `pulse` | Up to 8, one for each pulse |
 | `candle` | One |
 | `wings` | One |
+
+#### Deprecated modes
+
+The following modes are now deprecated and the use of the `--direction backward` is preferred,
+they will be removed in a future version and are kept for now for backwards compatibility.
+
+| Mode | Colors | Notes |
+| --- | --- | --- |
+| `backwards-spectrum-wave` | None |
+| `backwards-super-wave` | Up to 40 |
+| `backwards-marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
+| `covering-backwards-marquee` | Up to 8, one for each step |
+| `backwards-moving-alternating` | Two |

--- a/docs/nzxt-smart-device-v1-guide.md
+++ b/docs/nzxt-smart-device-v1-guide.md
@@ -83,10 +83,13 @@ For lighting, the user can control up to 40 LEDs, if all four strips or five fan
 # liquidctl set led color fixed af5a2f
 # liquidctl set led color fading 350017 ff2608 --speed slower
 # liquidctl set led color pulse ffffff
-# liquidctl set led color backwards-marquee-5 2f6017 --speed slowest
+# liquidctl set led color marquee-5 2f6017 --direction backward --speed slowest
 ```
 
 Colors can be specified in RGB, HSV or HSL (see [Supported color specification formats](../README.md#supported-color-specification-formats)), and each animation mode supports different number of colors.  The animation speed can be customized with the `--speed <value>`, and five relative values are accepted by the device: `slowest`, `slower`, `normal`, `faster` and `fastest`.
+
+Some of the color animations can be in either the `forward` or `backward` direction.
+This can be specified by using the `--direction` flag.
 
 | Mode | Colors | Notes |
 | --- | --- | --- |
@@ -95,16 +98,11 @@ Colors can be specified in RGB, HSV or HSL (see [Supported color specification f
 | `super-fixed` | Up to 40, one for each LED |
 | `fading` | Between 2 and 8, one for each step |
 | `spectrum-wave` | None |
-| `backwards-spectrum-wave` | None |
 | `super-wave` | Up to 40 |
-| `backwards-super-wave` | Up to 40 |
 | `marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
-| `backwards-marquee-<length>` | One | 3 ≤ `length` ≤ 6 |
 | `covering-marquee` | Up to 8, one for each step |
-| `covering-backwards-marquee` | Up to 8, one for each step |
 | `alternating` | Two |
 | `moving-alternating` | Two |
-| `backwards-moving-alternating` | Two |
 | `breathing` | Up to 8, one for each step |
 | `super-breathing` | Up to 40, one for each LED | Only one step |
 | `pulse` | Up to 8, one for each pulse |

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -333,6 +333,7 @@ When applicable the animation speed can be set with
 .BI \-\-speed= value ,
 where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
 \fIfaster\fR, \fIfastest\fR.
+The animation direction can be set with
 .BI \-\-direction= value ,
 where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .
@@ -366,6 +367,7 @@ When applicable the animation speed can be set with
 .BI \-\-speed= value ,
 where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
 \fIfaster\fR, \fIfastest\fR.
+The animation direction can be set with
 .BI \-\-direction= value ,
 where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .
@@ -418,6 +420,7 @@ When applicable the animation speed can be set with
 .BI \-\-speed= value ,
 where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
 \fIfaster\fR, \fIfastest\fR.
+The animation direction can be set with
 .BI \-\-direction= value ,
 where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .
@@ -452,6 +455,7 @@ When applicable the animation speed can be set with
 .BI \-\-speed= value ,
 where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
 \fIfaster\fR, \fIfastest\fR.
+The animation direction can be set with
 .BI \-\-direction= value ,
 where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -265,12 +265,7 @@ Mode	logo	ring	#colors
 \fIfixed\fR	yes	yes	1
 \fIsuper\-fixed\fR	yes	yes	1\(en9
 \fIfading\fR	yes	yes	2\(en8
-\fI(backwards\-)?spectrum\-wave\fR	yes	yes	0
-\fI(backwards\-)?super\-wave\fR	no	yes	1\(en8
-\fI(backwards\-)?marquee\-[3\-6]\fR	no	yes	1
-\fIcovering\-(backwards\-)?marquee\fR	no	yes	1\(en8
 \fIalternating\fR	no	yes	2
-\fI(backwards\-)?moving\-alternating\fR	no	yes	2
 \fIbreathing\fR	yes	yes	1\(en8
 \fIsuper\-breathing\fR	yes	yes	1\(en9
 \fIpulse\fR	yes	yes	1\(en8
@@ -284,6 +279,8 @@ When applicable the animation speed can be set with
 .BI \-\-speed= value ,
 where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
 \fIfaster\fR, \fIfastest\fR.
+.BI \-\-direction= value ,
+where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .
 .SS NZXT Kraken X53, X63, X73
 .SS NZXT Kraken Z63, Z73
@@ -299,19 +296,12 @@ Mode	#colors
 \fIfixed\fR	1
 \fIfading\fR	2\(en8
 \fIsuper\-fixed\fR	1\(en40
-\fI(backwards\-)?spectrum\-wave\fR	0
-\fI(backwards\-)?marquee\-[3\-6]\fR	1
-\fIcovering\-(backwards\-)?marquee\fR	1\(en8
 \fIalternating\-[3\-6]\fR	1\(en2
-\fI(backwards\-)?moving\-alternating\-[3\-6]\fR	1\(en2
 \fIpulse\fR	1\(en8
 \fIbreathing\fR	1\(en8
 \fIsuper\-breathing\fR	1\(en40
 \fIcandle\fR	1
 \fIstarry\-night\fR	1
-\fI(backwards\-)?rainbow\-flow\fR	0
-\fI(backwards\-)?super\-rainbow\fR	0
-\fI(backwards\-)?rainbow\-pulse\fR	0
 \fIloading\fR	1
 \fItai\-chi\fR	1\(en2
 \fIwater\-cooler\fR	2
@@ -322,6 +312,8 @@ When applicable the animation speed can be set with
 .BI \-\-speed= value ,
 where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
 \fIfaster\fR, \fIfastest\fR.
+.BI \-\-direction= value ,
+where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .
 .SS Corsair HX750i, HX850i, HX1000i, HX1200i
 .SS Corsair RM650i, RM750i, RM850i, RM1000i
@@ -360,12 +352,7 @@ Mode	#colors
 \fIfixed\fR	1
 \fIsuper\-fixed\fR	1\(en40
 \fIfading\fR	2\(en8
-\fI(backwards\-)?spectrum\-wave\fR	0
-\fI(backwards\-)?super\-wave\fR	1\(en40
-\fI(backwards\-)?marquee\-[3\-6]\fR	1
-\fIcovering\-(backwards\-)?marquee\fR	1\(en8
 \fIalternating\fR	2
-\fI(backwards\-)?moving\-alternating\fR	2
 \fIbreathing\fR	1\(en8
 \fIsuper\-breathing\fR	1\(en40
 \fIpulse\fR	1\(en8
@@ -377,6 +364,8 @@ When applicable the animation speed can be set with
 .BI \-\-speed= value ,
 where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
 \fIfaster\fR, \fIfastest\fR.
+.BI \-\-direction= value ,
+where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .
 .SS NZXT Smart Device V2
 .SS NZXT RGB & Fan Controller
@@ -396,19 +385,12 @@ Mode	#colors
 \fIfixed\fR	1
 \fIsuper\-fixed\fR	1\(en40
 \fIfading\fR	2\(en8
-\fI(backwards\-)?spectrum\-wave\fR	0
-\fI(backwards\-)?marquee\-[3\-6]\fR	1
-\fIcovering\-(backwards\-)?marquee\fR	1\(en8
 \fIalternating\-[3\-6]\fR	2
-\fI(backwards\-)?moving\-alternating\-[3\-6]\fR	2
 \fIpulse\fR	1\(en8
 \fIbreathing\fR	1\(en8
 \fIsuper\-breathing\fR	1\(en40
 \fIcandle\fR	1
 \fIstarry\-night\fR	1
-\fI(backwards\-)?rainbow\-flow\fR	0
-\fI(backwards\-)?super\-rainbow\fR	0
-\fI(backwards\-)?rainbow\-pulse\fR	0
 \fIwings\fR	1
 .TE
 .PP
@@ -416,6 +398,8 @@ When applicable the animation speed can be set with
 .BI \-\-speed= value ,
 where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
 \fIfaster\fR, \fIfastest\fR.
+.BI \-\-direction= value ,
+where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .
 .SS ASUS Strix RTX 2080 Ti OC
 Fan channels: none.

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -28,6 +28,8 @@ Animation options (devices/modes can support zero or more):
   --time-off <value>          Time to wait with the LED turned off (seconds)
   --alert-threshold <number>  Threshold temperature for a visual alert (°C)
   --alert-color <color>       Color used by the visual high temperature alert
+  --direction <string>        If the pattern should move forward or backwards. [default: forward]
+
 
 Other device options:
   --single-12v-ocp            Enable single rail +12V OCP

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -102,6 +102,7 @@ _PARSE_ARG = {
     '--time-off': int,
     '--alert-threshold': int,
     '--alert-color': color_from_str,
+    '--direction': str,
 
     '--single-12v-ocp': bool,
     '--pump-mode': str,

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -65,6 +65,16 @@ _COLOR_MODES = {
     'loading':                       (0x0a, 0x00, 0x00, 1, 1, True),
     'wings':                         (0x0c, 0x00, 0x00, 1, 1, True),
     'super-wave':                    (0x0d, 0x00, 0x00, 1, 8, True),  # independent ring leds
+
+    ## Deprecated modes, will be removed later
+    'backwards-spectrum-wave':       (0x02, 0x00, 0x00, 0, 0, False),
+    'backwards-marquee-3':           (0x03, 0x00, 0x00, 1, 1, True),
+    'backwards-marquee-4':           (0x03, 0x00, 0x08, 1, 1, True),
+    'backwards-marquee-5':           (0x03, 0x00, 0x10, 1, 1, True),
+    'backwards-marquee-6':           (0x03, 0x00, 0x18, 1, 1, True),
+    'covering-backwards-marquee':    (0x04, 0x00, 0x00, 1, 8, True),
+    'backwards-moving-alternating':  (0x05, 0x08, 0x00, 2, 2, True),
+    'backwards-super-wave':          (0x0d, 0x00, 0x00, 1, 8, True),
 }
 
 _ANIMATION_SPEEDS = {
@@ -151,7 +161,7 @@ class Kraken2(UsbHidDriver):
             mode = 'super-fixed'
         mval, mod2, mod4, mincolors, maxcolors, ringonly = _COLOR_MODES[mode]
 
-        if direction == 'backward':
+        if direction == 'backward' or 'backwards' in mode:
             mod2 += 0x10
 
         if ringonly and channel != 'ring':

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -50,20 +50,13 @@ _COLOR_MODES = {
     'super-fixed':                   (0x00, 0x00, 0x00, 1, 9, False),  # independent logo + ring leds
     'fading':                        (0x01, 0x00, 0x00, 2, 8, False),
     'spectrum-wave':                 (0x02, 0x00, 0x00, 0, 0, False),
-    'backwards-spectrum-wave':       (0x02, 0x10, 0x00, 0, 0, False),
     'marquee-3':                     (0x03, 0x00, 0x00, 1, 1, True),
     'marquee-4':                     (0x03, 0x00, 0x08, 1, 1, True),
     'marquee-5':                     (0x03, 0x00, 0x10, 1, 1, True),
     'marquee-6':                     (0x03, 0x00, 0x18, 1, 1, True),
-    'backwards-marquee-3':           (0x03, 0x10, 0x00, 1, 1, True),
-    'backwards-marquee-4':           (0x03, 0x10, 0x08, 1, 1, True),
-    'backwards-marquee-5':           (0x03, 0x10, 0x10, 1, 1, True),
-    'backwards-marquee-6':           (0x03, 0x10, 0x18, 1, 1, True),
     'covering-marquee':              (0x04, 0x00, 0x00, 1, 8, True),
-    'covering-backwards-marquee':    (0x04, 0x10, 0x00, 1, 8, True),
     'alternating':                   (0x05, 0x00, 0x00, 2, 2, True),
     'moving-alternating':            (0x05, 0x08, 0x00, 2, 2, True),
-    'backwards-moving-alternating':  (0x05, 0x18, 0x00, 2, 2, True),
     'breathing':                     (0x06, 0x00, 0x00, 1, 8, False),  # colors for each step
     'super-breathing':               (0x06, 0x00, 0x00, 1, 9, False),  # one step, independent logo + ring leds
     'pulse':                         (0x07, 0x00, 0x00, 1, 8, False),
@@ -72,7 +65,6 @@ _COLOR_MODES = {
     'loading':                       (0x0a, 0x00, 0x00, 1, 1, True),
     'wings':                         (0x0c, 0x00, 0x00, 1, 1, True),
     'super-wave':                    (0x0d, 0x00, 0x00, 1, 8, True),  # independent ring leds
-    'backwards-super-wave':          (0x0d, 0x10, 0x00, 1, 8, True),  # independent ring leds
 }
 
 _ANIMATION_SPEEDS = {
@@ -150,7 +142,7 @@ class Kraken2(UsbHidDriver):
                 ('Firmware version', firmware, '')
             ]
 
-    def set_color(self, channel, mode, colors, speed='normal', **kwargs):
+    def set_color(self, channel, mode, colors, speed='normal', direction='forward', **kwargs):
         """Set the color mode for a specific channel."""
         if not self.supports_lighting:
             raise NotSupportedByDevice()
@@ -158,6 +150,10 @@ class Kraken2(UsbHidDriver):
             LOGGER.warning('deprecated mode, update to super-fixed, super-breathing or super-wave')
             mode = 'super-fixed'
         mval, mod2, mod4, mincolors, maxcolors, ringonly = _COLOR_MODES[mode]
+
+        if direction == 'backward':
+            mod2 += 0x10
+
         if ringonly and channel != 'ring':
             LOGGER.warning('mode=%s unsupported with channel=%s, dropping to ring',
                            mode, channel)

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -90,6 +90,20 @@ _COLOR_MODES = {
     'tai-chi':                              (0x0e, 0x00,  7, 1, 2),
     'water-cooler':                         (0x0f, 0x00,  6, 2, 2),
     'wings':                                (None, 0x00, 11, 1, 1),
+
+    ## Deprecated modes, will be removed later
+    'backwards-spectrum-wave':              (0x02, 0x00,  2, 0, 0),
+    'backwards-marquee-3':                  (0x03, 0x03,  2, 1, 1),
+    'backwards-marquee-4':                  (0x03, 0x04,  2, 1, 1),
+    'backwards-marquee-5':                  (0x03, 0x05,  2, 1, 1),
+    'backwards-marquee-6':                  (0x03, 0x06,  2, 1, 1),
+    'backwards-moving-alternating-3':       (0x05, 0x03,  4, 1, 2),
+    'backwards-moving-alternating-4':       (0x05, 0x04,  4, 1, 2),
+    'backwards-moving-alternating-5':       (0x05, 0x05,  4, 1, 2),
+    'backwards-moving-alternating-6':       (0x05, 0x06,  4, 1, 2),
+    'backwards-rainbow-flow':               (0x0b, 0x00,  2, 0, 0),
+    'backwards-super-rainbow':              (0x0c, 0x00,  2, 0, 0),
+    'backwards-rainbow-pulse':              (0x0b, 0x00,  2, 0, 0),
 }
 
 # A static value per channel that is somehow related to animation time and
@@ -302,7 +316,7 @@ class KrakenX3(UsbHidDriver):
             else:
                 backwards_byte = 0x00
 
-            if directionStr == 'backward':
+            if directionStr == 'backward' or 'backwards' in mode:
                 backwards_byte += 0x02
 
 

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -330,7 +330,7 @@ class KrakenX3(UsbHidDriver):
             else:
                 backwards_byte = 0x00
 
-            if direction == 'backward' or 'backwards' in mode:
+            if direction == 'backward':
                 backwards_byte += 0x02
 
             if mode == 'fading' or mode == 'pulse' or mode == 'breathing':

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -216,6 +216,16 @@ class SmartDevice(_CommonSmartDeviceDriver):
         'candle':                        (0x09, 0x00, 0x00, 1, 1),
         'wings':                         (0x0c, 0x00, 0x00, 1, 1),
         'super-wave':                    (0x0d, 0x00, 0x00, 1, 40),  # independent ring leds
+
+        ## Deprecated modes, will be removed later
+        'backwards-spectrum-wave':       (0x02, 0x00, 0x00, 0, 0),
+        'backwards-marquee-3':           (0x03, 0x00, 0x00, 1, 1),
+        'backwards-marquee-4':           (0x03, 0x00, 0x08, 1, 1),
+        'backwards-marquee-5':           (0x03, 0x00, 0x10, 1, 1),
+        'backwards-marquee-6':           (0x03, 0x00, 0x18, 1, 1),
+        'covering-backwards-marquee':    (0x04, 0x00, 0x00, 1, 8),
+        'backwards-moving-alternating':  (0x05, 0x08, 0x00, 2, 2),
+        'backwards-super-wave':          (0x0d, 0x00, 0x00, 1, 40),
     }
 
     def __init__(self, device, description, speed_channel_count, color_channel_count, **kwargs):
@@ -275,7 +285,7 @@ class SmartDevice(_CommonSmartDeviceDriver):
         # one step, where it is specified to all leds and the device handles the animation;
         # but in super mode there is a single step and each color directly controls a led
 
-        if direction == 'backward':
+        if direction == 'backward' or 'backwards' in mode:
             mod3 += 0x10
 
         if 'super' in mode:
@@ -347,6 +357,21 @@ class SmartDevice2(_CommonSmartDeviceDriver):
         'super-rainbow':                    (0x0c, 0x00, 0x00, 0, 0),
         'rainbow-pulse':                    (0x0d, 0x00, 0x00, 0, 0),
         'wings':                            (None, 0x00, 0x00, 1, 1),   # wings requires special handling
+
+        ## Deprecated modes, will be removed later
+        'backwards-spectrum-wave':          (0x02, 0x00, 0x00, 0, 0),
+        'backwards-marquee-3':              (0x03, 0x00, 0x00, 1, 1),
+        'backwards-marquee-4':              (0x03, 0x01, 0x00, 1, 1),
+        'backwards-marquee-5':              (0x03, 0x02, 0x00, 1, 1),
+        'backwards-marquee-6':              (0x03, 0x03, 0x00, 1, 1),
+        'covering-backwards-marquee':       (0x04, 0x00, 0x00, 1, 8),
+        'backwards-moving-alternating-3':   (0x05, 0x00, 0x01, 2, 2),
+        'backwards-moving-alternating-4':   (0x05, 0x01, 0x01, 2, 2),
+        'backwards-moving-alternating-5':   (0x05, 0x02, 0x01, 2, 2),
+        'backwards-moving-alternating-6':   (0x05, 0x03, 0x01, 2, 2),
+        'backwards-rainbow-flow':           (0x0b, 0x00, 0x00, 0, 0),
+        'backwards-super-rainbow':          (0x0c, 0x00, 0x00, 0, 0),
+        'backwards-rainbow-pulse':          (0x0d, 0x00, 0x00, 0, 0),
     }
 
     def __init__(self, device, description, speed_channel_count, color_channel_count, **kwargs):
@@ -460,7 +485,7 @@ class SmartDevice2(_CommonSmartDeviceDriver):
                 self._write([0x22, 0x03, cid, 0x08])   # this actually enables wings mode
         else:
             byte7 = movingFlag # sets 'moving' flag for moving alternating modes
-            byte8 = direction == 'backward'  # sets 'backwards' flag
+            byte8 = direction == 'backward' or 'backwards' in mode # sets 'backwards' flag
             byte9 = mod3 if mval == 0x03 else color_count  #  specifies 'marquee' LED size
             byte10 = mod3 if mval == 0x05 else 0x00  #  specifies LED size for 'alternating' modes
             header = [0x28, 0x03, cid, 0x00, mval, sval, byte7, byte8, byte9, byte10]

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -297,7 +297,7 @@ class SmartDevice(_CommonSmartDeviceDriver):
         # one step, where it is specified to all leds and the device handles the animation;
         # but in super mode there is a single step and each color directly controls a led
 
-        if direction == 'backward' or 'backwards' in mode:
+        if direction == 'backward':
             mod3 += 0x10
 
         if 'super' in mode:
@@ -497,7 +497,7 @@ class SmartDevice2(_CommonSmartDeviceDriver):
                 self._write([0x22, 0x03, cid, 0x08])   # this actually enables wings mode
         else:
             byte7 = movingFlag # sets 'moving' flag for moving alternating modes
-            byte8 = direction == 'backward' or 'backwards' in mode # sets 'backwards' flag
+            byte8 = direction == 'backward' # sets 'backwards' flag
             byte9 = mod3 if mval == 0x03 else color_count  #  specifies 'marquee' LED size
             byte10 = mod3 if mval == 0x05 else 0x00  #  specifies LED size for 'alternating' modes
             header = [0x28, 0x03, cid, 0x00, mval, sval, byte7, byte8, byte9, byte10]

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -136,6 +136,17 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
 
         if not self._color_channels:
             raise NotSupportedByDevice()
+
+        channel = channel.lower()
+        mode = mode.lower()
+        speed = speed.lower()
+        directon = direction.lower()
+
+        if 'backwards' in mode:
+            LOGGER.warning('deprecated mode, move to direction=backwards option')
+            mode = mode.replace('backwards-', '')
+            direction = 'backward'
+
         cid = self._color_channels[channel]
         _, _, _, mincolors, maxcolors = self._COLOR_MODES[mode]
         colors = [[g, r, b] for [r, g, b] in colors]
@@ -150,6 +161,7 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
             LOGGER.warning('too many colors for mode=%s, dropping to %i',
                            mode, maxcolors)
             colors = colors[:maxcolors]
+
         sval = _ANIMATION_SPEEDS[speed]
         self._write_colors(cid, mode, colors, sval, direction)
 
@@ -217,7 +229,7 @@ class SmartDevice(_CommonSmartDeviceDriver):
         'wings':                         (0x0c, 0x00, 0x00, 1, 1),
         'super-wave':                    (0x0d, 0x00, 0x00, 1, 40),  # independent ring leds
 
-        ## Deprecated modes, will be removed later
+        # deprecated in favor of direction=backward
         'backwards-spectrum-wave':       (0x02, 0x00, 0x00, 0, 0),
         'backwards-marquee-3':           (0x03, 0x00, 0x00, 1, 1),
         'backwards-marquee-4':           (0x03, 0x00, 0x08, 1, 1),
@@ -358,7 +370,7 @@ class SmartDevice2(_CommonSmartDeviceDriver):
         'rainbow-pulse':                    (0x0d, 0x00, 0x00, 0, 0),
         'wings':                            (None, 0x00, 0x00, 1, 1),   # wings requires special handling
 
-        ## Deprecated modes, will be removed later
+        # deprecated in favor of direction=backward
         'backwards-spectrum-wave':          (0x02, 0x00, 0x00, 0, 0),
         'backwards-marquee-3':              (0x03, 0x00, 0x00, 1, 1),
         'backwards-marquee-4':              (0x03, 0x01, 0x00, 1, 1),

--- a/tests/test_backwards_compatibility_14.py
+++ b/tests/test_backwards_compatibility_14.py
@@ -1,4 +1,128 @@
 import pytest
 
+from _testutils import MockHidapiDevice
+
+RADICAL_RED = [0xff, 0x35, 0x5e]
+MOUNTAIN_MEADOW = [0x1a, 0xb3, 0x85]
+
+
 def test_find_from_driver_package_still_available():
     from liquidctl.driver import find_liquidctl_devices
+
+
+def test_kraken2_backwards_modes_are_deprecated(caplog):
+    modes = ['backwards-spectrum-wave', 'backwards-marquee-3',
+             'backwards-marquee-4', 'backwards-marquee-5',
+             'backwards-marquee-6', 'covering-backwards-marquee',
+             'backwards-moving-alternating', 'backwards-super-wave']
+
+    from liquidctl.driver.kraken2 import Kraken2
+
+    for mode in modes:
+        base_mode = mode.replace('backwards-', '')
+
+        old = Kraken2(MockHidapiDevice(), 'Mock X62',
+                      device_type=Kraken2.DEVICE_KRAKENX)
+        new = Kraken2(MockHidapiDevice(), 'Mock X62',
+                      device_type=Kraken2.DEVICE_KRAKENX)
+
+        colors = [RADICAL_RED, MOUNTAIN_MEADOW]
+
+        old.set_color('ring', mode, colors)
+        new.set_color('ring', base_mode, colors, direction='backward')
+
+        assert old.device.sent == new.device.sent, \
+               f'{mode} != {base_mode} + direction=backward'
+
+        assert 'deprecated mode' in caplog.text
+
+
+def test_kraken3_backwards_modes_are_deprecated(caplog):
+    modes = ['backwards-spectrum-wave', 'backwards-marquee-3',
+             'backwards-marquee-4', 'backwards-marquee-5',
+             'backwards-marquee-6', 'backwards-moving-alternating-3',
+             'covering-backwards-marquee', 'backwards-moving-alternating-4',
+             'backwards-moving-alternating-5', 'backwards-moving-alternating-6',
+             'backwards-rainbow-flow', 'backwards-super-rainbow',
+             'backwards-rainbow-pulse']
+
+    from liquidctl.driver.kraken3 import KrakenX3
+    from liquidctl.driver.kraken3 import _COLOR_CHANNELS_KRAKENX
+    from liquidctl.driver.kraken3 import _SPEED_CHANNELS_KRAKENX
+
+    for mode in modes:
+        base_mode = mode.replace('backwards-', '')
+
+        old = KrakenX3(MockHidapiDevice(), 'Mock X63',
+                       speed_channels=_SPEED_CHANNELS_KRAKENX,
+                       color_channels=_COLOR_CHANNELS_KRAKENX)
+        new = KrakenX3(MockHidapiDevice(), 'Mock X63',
+                       speed_channels=_SPEED_CHANNELS_KRAKENX,
+                       color_channels=_COLOR_CHANNELS_KRAKENX)
+
+        colors = [RADICAL_RED, MOUNTAIN_MEADOW]
+
+        old.set_color('ring', mode, colors)
+        new.set_color('ring', base_mode, colors, direction='backward')
+
+        assert old.device.sent == new.device.sent, \
+               f'{mode} != {base_mode} + direction=backward'
+
+        assert 'deprecated mode' in caplog.text
+
+
+def test_smart_device_v1_backwards_modes_are_deprecated(caplog):
+    modes = ['backwards-spectrum-wave', 'backwards-marquee-3',
+             'backwards-marquee-4', 'backwards-marquee-5',
+             'backwards-marquee-6', 'covering-backwards-marquee',
+             'backwards-moving-alternating', 'backwards-super-wave']
+
+    from liquidctl.driver.smart_device import SmartDevice
+
+    for mode in modes:
+        base_mode = mode.replace('backwards-', '')
+
+        old = SmartDevice(MockHidapiDevice(), 'Mock Smart Device',
+                          speed_channel_count=3, color_channel_count=1)
+        new = SmartDevice(MockHidapiDevice(), 'Mock Smart Device',
+                          speed_channel_count=3, color_channel_count=1)
+
+        colors = [RADICAL_RED, MOUNTAIN_MEADOW]
+
+        old.set_color('led', mode, colors)
+        new.set_color('led', base_mode, colors, direction='backward')
+
+        assert old.device.sent == new.device.sent, \
+               f'{mode} != {base_mode} + direction=backward'
+
+        assert 'deprecated mode' in caplog.text
+
+
+def test_hue2_backwards_modes_are_deprecated(caplog):
+    modes = ['backwards-spectrum-wave', 'backwards-marquee-3',
+             'backwards-marquee-4', 'backwards-marquee-5',
+             'backwards-marquee-6', 'backwards-moving-alternating-3',
+             'covering-backwards-marquee', 'backwards-moving-alternating-4',
+             'backwards-moving-alternating-5', 'backwards-moving-alternating-6',
+             'backwards-rainbow-flow', 'backwards-super-rainbow',
+             'backwards-rainbow-pulse']
+
+    from liquidctl.driver.smart_device import SmartDevice2
+
+    for mode in modes:
+        base_mode = mode.replace('backwards-', '')
+
+        old = SmartDevice2(MockHidapiDevice(), 'Mock Smart Device V2',
+                           speed_channel_count=3, color_channel_count=2)
+        new = SmartDevice2(MockHidapiDevice(), 'Mock Smart Device V2',
+                           speed_channel_count=3, color_channel_count=2)
+
+        colors = [RADICAL_RED, MOUNTAIN_MEADOW]
+
+        old.set_color('led1', mode, colors)
+        new.set_color('led1', base_mode, colors, direction='backward')
+
+        assert old.device.sent == new.device.sent, \
+               f'{mode} != {base_mode} + direction=backward'
+
+        assert 'deprecated mode' in caplog.text


### PR DESCRIPTION
Closes: #253

Re: https://github.com/liquidctl/liquidctl/pull/213#discussion_r549895314

Change the mode strings for these devices to use the direction flag to specify forwards or backwards

This should be merged after #213