### PR TITLE
Migrate to pytest

### DIFF
--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -316,11 +316,14 @@ class Legacy690Lc(_CommonAsetekDriver):
         # discarded; defer instantiating the data storage until to connect()
         self._data = None
 
-    def connect(self, **kwargs):
+    def connect(self, runtime_storage=None, **kwargs):
         super().connect(**kwargs)
         ids = 'vid{:04x}_pid{:04x}'.format(self.vendor_id, self.product_id)
         loc = 'bus{}_port{}'.format(self.bus, '_'.join(map(str, self.port)))
-        self._data = RuntimeStorage(key_prefixes=[ids, loc, 'legacy'])
+        if runtime_storage:
+            self._data = runtime_storage
+        else:
+            self._data = RuntimeStorage(key_prefixes=[ids, loc, 'legacy'])
 
     def _set_all_fixed_speeds(self):
         self._begin_transaction()

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -129,7 +129,7 @@ class CommanderPro(UsbHidDriver):
         self._temp_probs = temp_probs
         self._fan_count = fan_count
 
-    def connect(self, **kwargs):
+    def connect(self, runtime_storage=None, **kwargs):
         """Connect to the device."""
         super().connect(**kwargs)
         ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
@@ -138,7 +138,10 @@ class CommanderPro(UsbHidDriver):
         # numbers, since they are likely the only parts that vary between two
         # devices of the same model
         loc = 'loc' + '_'.join(re.findall(r'\d+', self.address))
-        self._data = RuntimeStorage(key_prefixes=[ids, loc])
+        if runtime_storage:
+            self._data = runtime_storage
+        else:
+            self._data = RuntimeStorage(key_prefixes=[ids, loc])
 
     def initialize(self, **kwargs):
         """Initialize the device and get the fan modes.

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -137,20 +137,24 @@ class HydroPlatinum(UsbHidDriver):
             ('led', 'off'): 0,
         }
 
+        # the following fields are only initialized in connect()
+        self._data = None
+        self._sequence = None
+
+    def connect(self, **kwargs):
+        """Connect to the device."""
+        super().connect(**kwargs)
+
         ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
         # must use the HID path because there is no serial number; however,
         # these can be quite long on Windows and macOS, so only take the
         # numbers, since they are likely the only parts that vary between two
         # devices of the same model
         loc = 'loc' + '_'.join(re.findall(r'\d+', self.address))
-        self._data = RuntimeStorage(key_prefixes=[ids, loc])
 
-        # the following fields are only initialized in connect()
-        self._sequence = None
-
-    def connect(self, **kwargs):
-        """Connect to the device."""
-        super().connect(**kwargs)
+        if self._data is  None:
+            self._data = RuntimeStorage(key_prefixes=[ids, loc])
+        
         self._sequence = _sequence(self._data)
         return self
 

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -136,13 +136,7 @@ class HydroPlatinum(UsbHidDriver):
             ('led', 'fixed'): 1,
             ('led', 'off'): 0,
         }
-        # the following fields are only initialized in connect()
-        self._data = None
-        self._sequence = None
 
-    def connect(self, **kwargs):
-        """Connect to the device."""
-        super().connect(**kwargs)
         ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
         # must use the HID path because there is no serial number; however,
         # these can be quite long on Windows and macOS, so only take the
@@ -150,6 +144,13 @@ class HydroPlatinum(UsbHidDriver):
         # devices of the same model
         loc = 'loc' + '_'.join(re.findall(r'\d+', self.address))
         self._data = RuntimeStorage(key_prefixes=[ids, loc])
+
+        # the following fields are only initialized in connect()
+        self._sequence = None
+
+    def connect(self, **kwargs):
+        """Connect to the device."""
+        super().connect(**kwargs)
         self._sequence = _sequence(self._data)
         return self
 

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -141,7 +141,7 @@ class HydroPlatinum(UsbHidDriver):
         self._data = None
         self._sequence = None
 
-    def connect(self, **kwargs):
+    def connect(self, runtime_storage=None, **kwargs):
         """Connect to the device."""
         super().connect(**kwargs)
 
@@ -152,9 +152,11 @@ class HydroPlatinum(UsbHidDriver):
         # devices of the same model
         loc = 'loc' + '_'.join(re.findall(r'\d+', self.address))
 
-        if self._data is  None:
+        if runtime_storage:
+            self._data = runtime_storage
+        else:
             self._data = RuntimeStorage(key_prefixes=[ids, loc])
-        
+
         self._sequence = _sequence(self._data)
         return self
 

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 from collections import deque
 from liquidctl.driver.asetek import Modern690Lc, Legacy690Lc, Hydro690Lc
 from _testutils import noop
@@ -35,86 +35,87 @@ class _Mock690LcDevice():
     def _reset_sent(self):
         self._sent_xfers = deque()
 
+@pytest.fixture
+def mockModern690LcDevice():
+    device = _Mock690LcDevice()
+    dev = Modern690Lc(device, 'Mock Modern 690LC')
 
-class Modern690LcTestCase(unittest.TestCase):
-    def setUp(self):
-        self.mock_usb = _Mock690LcDevice()
-        self.device = Modern690Lc(self.mock_usb, 'Mock Modern 690LC')
-        self.device.connect()
+    dev.connect()
+    return dev
 
-    def tearDown(self):
-        self.device.disconnect()
+@pytest.fixture
+def mockLegacy690LcDevice():
+    device = _Mock690LcDevice(vendor_id=0xffff, product_id=0xb200, bus=1, port=(1,))
+    dev = Legacy690Lc(device, 'Mock Legacy 690LC')
 
-    def test_not_totally_broken(self):
-        """A few reasonable example calls do not raise exceptions."""
-        self.device.initialize()
-        status = self.device.get_status()
-        self.device.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
-                       time_per_color=3, time_off=1, alert_threshold=42,
-                       alert_color=[90, 80, 10])
-        self.device.set_color(channel='led', mode='rainbow', colors=[], speed=5)
-        self.device.set_speed_profile(channel='fan',
-                               profile=iter([(20, 20), (30, 50), (40, 100)]))
-        self.device.set_fixed_speed(channel='pump', duty=50)
+    dev.connect()
+    return dev
 
-    def test_connect(self):
-        def mock_open():
-            nonlocal opened
-            opened = True
-        self.mock_usb.open = mock_open
-        opened = False
-        with self.device.connect() as cm:
-            assert cm == self.device
-            assert opened
+def test_modern690Lc_device_not_totally_broken(mockModern690LcDevice):
+    """A few reasonable example calls do not raise exceptions."""
 
-    def test_begin_transaction(self):
-        self.mock_usb._reset_sent()
+    mockModern690LcDevice.initialize()
+    status = mockModern690LcDevice.get_status()
+    mockModern690LcDevice.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
+                   time_per_color=3, time_off=1, alert_threshold=42,
+                   alert_color=[90, 80, 10])
+    mockModern690LcDevice.set_color(channel='led', mode='rainbow', colors=[], speed=5)
+    mockModern690LcDevice.set_speed_profile(channel='fan',
+                           profile=iter([(20, 20), (30, 50), (40, 100)]))
+    mockModern690LcDevice.set_fixed_speed(channel='pump', duty=50)
 
-        self.device.get_status()
+def test_modern690Lc_device_connect(mockModern690LcDevice):
+    def mock_open():
+        nonlocal opened
+        opened = True
+    mockModern690LcDevice.device.open = mock_open
+    opened = False
+    with mockModern690LcDevice.connect() as cm:
+        assert cm == mockModern690LcDevice
+        assert opened
 
-        (begin, _) = self.mock_usb._sent_xfers
-        xfer_type, bmRequestType, bRequest, wValue, wIndex, datalen = begin
-        assert xfer_type == 'ctrl_transfer'
-        assert bRequest == 2
-        assert bmRequestType == 0x40
-        assert wValue == 1
-        assert wIndex == 0
-        assert datalen == None
+def test_modern690Lc_device_begin_transaction(mockModern690LcDevice):
+    mockModern690LcDevice.device._reset_sent()
 
+    mockModern690LcDevice.get_status()
 
-class Legacy690LcTestCase(unittest.TestCase):
-    def setUp(self):
-        self.mock_usb = _Mock690LcDevice(vendor_id=0xffff, product_id=0xb200, bus=1, port=(1,))
-        self.device = Legacy690Lc(self.mock_usb, 'Mock Legacy 690LC')
-        self.device.connect()
+    (begin, _) = mockModern690LcDevice.device._sent_xfers
+    xfer_type, bmRequestType, bRequest, wValue, wIndex, datalen = begin
+    assert xfer_type == 'ctrl_transfer'
+    assert bRequest == 2
+    assert bmRequestType == 0x40
+    assert wValue == 1
+    assert wIndex == 0
+    assert datalen == None
 
-    def tearDown(self):
-        self.device.disconnect()
+def test_legacy690Lc_device_not_totally_broken(mockLegacy690LcDevice):
+    """A few reasonable example calls do not raise exceptions."""
+    dev = mockLegacy690LcDevice
 
-    def test_not_totally_broken(self):
-        """A few reasonable example calls do not raise exceptions."""
-        self.device.initialize()
-        status = self.device.get_status()
-        self.device.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
-                       time_per_color=3, time_off=1, alert_threshold=42,
-                       alert_color=[90, 80, 10])
-        self.device.set_fixed_speed(channel='fan', duty=80)
-        self.device.set_fixed_speed(channel='pump', duty=50)
+    dev.initialize()
+    status = dev.get_status()
+    dev.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
+                   time_per_color=3, time_off=1, alert_threshold=42,
+                   alert_color=[90, 80, 10])
+    dev.set_fixed_speed(channel='fan', duty=80)
+    dev.set_fixed_speed(channel='pump', duty=50)
 
-    def test_matches_leviathan_updates(self):
-        self.device.initialize()
-        self.device.set_fixed_speed(channel='pump', duty=50)
+def test_legacy690Lc_device_matches_leviathan_updates(mockLegacy690LcDevice):
+    dev = mockLegacy690LcDevice
 
-        self.mock_usb._reset_sent()
-        self.device.set_color(channel='led', mode='fading', colors=[[0, 0, 255], [0, 255, 0]],
-                              time_per_color=1, alert_threshold=60, alert_color=[0, 0, 0])
-        _begin, (color_msgtype, color_ep, color_data) = self.mock_usb._sent_xfers
-        assert color_msgtype == 'write'
-        assert color_ep == 2
-        assert color_data[0:12] == [0x10, 0, 0, 255, 0, 255, 0, 0, 0, 0, 0x3c, 1]
+    dev.initialize()
+    dev.set_fixed_speed(channel='pump', duty=50)
 
-        self.mock_usb._reset_sent()
-        self.device.set_fixed_speed(channel='fan', duty=50)
-        _begin, pump_message, fan_message = self.mock_usb._sent_xfers
-        assert pump_message == ('write', 2, [0x13, 50])
-        assert fan_message == ('write', 2, [0x12, 50])
+    dev.device._reset_sent()
+    dev.set_color(channel='led', mode='fading', colors=[[0, 0, 255], [0, 255, 0]],
+                          time_per_color=1, alert_threshold=60, alert_color=[0, 0, 0])
+    _begin, (color_msgtype, color_ep, color_data) = dev.device._sent_xfers
+    assert color_msgtype == 'write'
+    assert color_ep == 2
+    assert color_data[0:12] == [0x10, 0, 0, 255, 0, 255, 0, 0, 0, 0, 0x3c, 1]
+
+    dev.device._reset_sent()
+    dev.set_fixed_speed(channel='fan', duty=50)
+    _begin, pump_message, fan_message = dev.device._sent_xfers
+    assert pump_message == ('write', 2, [0x13, 50])
+    assert fan_message == ('write', 2, [0x12, 50])

--- a/tests/test_backwards_compatibility_10.py
+++ b/tests/test_backwards_compatibility_10.py
@@ -5,7 +5,7 @@ cases from GKraken as that software is a substantial contribution to the
 community.
 """
 
-import unittest
+import pytest
 from liquidctl.driver.kraken_two import KrakenTwoDriver
 from liquidctl.version import __version__
 from _testutils import MockHidapiDevice
@@ -21,36 +21,32 @@ SPECTRUM = [
     (208,0,122)
 ]
 
+@pytest.fixture
+def mockDevice():
+    device = MockHidapiDevice()
+    dev = KrakenTwoDriver(device, 'Mock X62',
+                                  device_type=KrakenTwoDriver.DEVICE_KRAKENX)
 
-class Pre11CliApisUsedByGkraken(unittest.TestCase):
-    def test_find_does_not_raise(self):
-        import liquidctl.cli
-        devices = liquidctl.cli.find_all_supported_devices()
+    dev.connect()
+    return dev
 
+def test_pre11_apis_find_does_not_raise():
+    import liquidctl.cli
+    devices = liquidctl.cli.find_all_supported_devices()
 
-class Pre11KrakenApisUsedByGkraken(unittest.TestCase):
-    def setUp(self):
-        self.mock_hid = MockHidapiDevice()
-        self.device = KrakenTwoDriver(self.mock_hid, 'Mock X62',
-                                      device_type=KrakenTwoDriver.DEVICE_KRAKENX)
-        self.device.connect()
+def test_pre11_apis_connect_as_initialize(mockDevice):
+    # deprecated behavior in favor of connect()
+    mockDevice.initialize()
 
-    def tearDown(self):
-        self.device.disconnect()
+def test_pre11_apis_deprecated_super_mode(mockDevice):
+    # deprecated in favor of super-fixed, super-breathing and super-wave
+    mockDevice.set_color('sync', 'super', [(128,0,255)] + SPECTRUM, 'normal')
 
-    def test_connect_as_initialize(self):
-        # deprecated behavior in favor of connect()
-        self.device.initialize()
+def test_pre11_apis_status_order(mockDevice):
+    # GKraken unreasonably expects a particular ordering
+    pass
 
-    def test_deprecated_super_mode(self):
-        # deprecated in favor of super-fixed, super-breathing and super-wave
-        self.device.set_color('sync', 'super', [(128,0,255)] + SPECTRUM, 'normal')
-
-    def test_status_order(self):
-        # GKraken unreasonably expects a particular ordering
-        pass
-
-    def test_finalize_as_connect_or_noop(self):
-        # deprecated in favor of disconnect()
-        self.device.finalize()  # should disconnect
-        self.device.finalize()  # should be a no-op
+def test_pre11_apis_finalize_as_connect_or_noop(mockDevice):
+    # deprecated in favor of disconnect()
+    mockDevice.finalize()  # should disconnect
+    mockDevice.finalize()  # should be a no-op

--- a/tests/test_backwards_compatibility_11.py
+++ b/tests/test_backwards_compatibility_11.py
@@ -3,6 +3,7 @@
 from liquidctl.driver.kraken2 import Kraken2
 from liquidctl.driver.usb import hid, HidapiDevice
 import usb
+import pytest
 
 
 class _MockPyUsbHandle(usb.core.Device):

--- a/tests/test_backwards_compatibility_12.py
+++ b/tests/test_backwards_compatibility_12.py
@@ -1,5 +1,4 @@
-import unittest
+import pytest
 
-class Pre13NamesTestCase(unittest.TestCase):
-    def test_old_driver_names(self):
-        from liquidctl.driver.nzxt_smart_device import NzxtSmartDeviceDriver
+def test_pre13_old_driver_names():
+    from liquidctl.driver.nzxt_smart_device import NzxtSmartDeviceDriver

--- a/tests/test_backwards_compatibility_13.py
+++ b/tests/test_backwards_compatibility_13.py
@@ -1,19 +1,19 @@
-import unittest
+import pytest
 
-class Pre14NamesTestCase(unittest.TestCase):
-    def test_old_module_names(self):
-        import liquidctl.driver.asetek
-        import liquidctl.driver.corsair_hid_psu
-        import liquidctl.driver.kraken_two
-        import liquidctl.driver.nzxt_smart_device
-        import liquidctl.driver.seasonic
 
-    def test_old_driver_names(self):
-        from liquidctl.driver.asetek import AsetekDriver
-        from liquidctl.driver.asetek import LegacyAsetekDriver
-        from liquidctl.driver.asetek import CorsairAsetekDriver
-        from liquidctl.driver.corsair_hid_psu import CorsairHidPsuDriver
-        from liquidctl.driver.kraken_two import KrakenTwoDriver
-        from liquidctl.driver.nzxt_smart_device import SmartDeviceDriver
-        from liquidctl.driver.nzxt_smart_device import SmartDeviceV2Driver
-        from liquidctl.driver.seasonic import SeasonicEDriver
+def test_pre14_old_module_names():
+    import liquidctl.driver.asetek
+    import liquidctl.driver.corsair_hid_psu
+    import liquidctl.driver.kraken_two
+    import liquidctl.driver.nzxt_smart_device
+    import liquidctl.driver.seasonic
+
+def test_pre14_old_driver_names():
+    from liquidctl.driver.asetek import AsetekDriver
+    from liquidctl.driver.asetek import LegacyAsetekDriver
+    from liquidctl.driver.asetek import CorsairAsetekDriver
+    from liquidctl.driver.corsair_hid_psu import CorsairHidPsuDriver
+    from liquidctl.driver.kraken_two import KrakenTwoDriver
+    from liquidctl.driver.nzxt_smart_device import SmartDeviceDriver
+    from liquidctl.driver.nzxt_smart_device import SmartDeviceV2Driver
+    from liquidctl.driver.seasonic import SeasonicEDriver

--- a/tests/test_corsair_hid_psu.py
+++ b/tests/test_corsair_hid_psu.py
@@ -1,7 +1,5 @@
-import unittest
+import pytest
 from liquidctl.driver.corsair_hid_psu import CorsairHidPsu
-from liquidctl.driver.corsair_hid_psu import _CORSAIR_12V_OCP_MODE
-from liquidctl.driver.corsair_hid_psu import _CORSAIR_FAN_CONTROL_MODE
 from _testutils import MockHidapiDevice, Report
 
 
@@ -11,27 +9,27 @@ class _MockPsuDevice(MockHidapiDevice):
         data = data[1:]  # skip unused report ID
 
         reply = bytearray(64)
-        if data[1] in [_CORSAIR_12V_OCP_MODE, _CORSAIR_FAN_CONTROL_MODE]:
+        if data[1] in [0xd8, 0xf0]:
             reply[2] = 1  # just a valid mode
         self.preload_read(Report(0, reply))
 
 
-class CorsairHidPsuTestCase(unittest.TestCase):
-    def setUp(self):
-        self.mock_hid = _MockPsuDevice()
-        self.device = CorsairHidPsu(self.mock_hid, 'Mock Corsair HID PSU')
-        self.device.connect()
+@pytest.fixture
+def mockPsuDevice():
+    device = _MockPsuDevice(vendor_id=0x1b1c, product_id=0x1c05, address='addr')
+    return CorsairHidPsu(device, 'mock Corsair HX750i PSU')
 
-    def tearDown(self):
-        self.device.disconnect()
+def test_corsair_psu_not_totally_broken(mockPsuDevice):
 
-    def test_not_totally_broken(self):
-        """A few reasonable example calls do not raise exceptions."""
-        self.device.initialize()
-        status = self.device.get_status()
+    status = mockPsuDevice.set_fixed_speed(channel='fan', duty=50)
+    report_id, report_data = mockPsuDevice.device.sent[0]
+    assert report_id == 0
+    assert len(report_data) == 64
 
-    def test_dont_inject_report_ids(self):
-        status = self.device.set_fixed_speed(channel='fan', duty=50)
-        report_id, report_data = self.mock_hid.sent[0]
-        assert report_id == 0
-        assert len(report_data) == 64
+
+def test_corsair_psu_dont_inject_report_ids(mockPsuDevice):
+
+    status = mockPsuDevice.set_fixed_speed(channel='fan', duty=50)
+    report_id, report_data = mockPsuDevice.device.sent[0]
+    assert report_id == 0
+    assert len(report_data) == 64

--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -17,19 +17,11 @@ def h115iPlatinumDevice():
     device = _H115iPlatinumDevice()
     dev = HydroPlatinum(device, description, **kwargs)
 
-    dev._data = MockRuntimeStorage(key_prefixes='testing')
-    dev.connect()
-    dev._data.store('leds_enabled', 0)
+    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage.store('leds_enabled', 0)
 
-    return dev
+    dev.connect(runtime_storage=runtime_storage)
 
-@pytest.fixture
-def h115iPlatinumDeviceRaw():
-    description = 'Mock H115i Platinum'
-    kwargs = {'fan_count': 2, 'rgb_fans': True}
-    device = _H115iPlatinumDevice()
-    dev = HydroPlatinum(device, description, **kwargs)
-    dev.connect()
     return dev
 
 class _H115iPlatinumDevice(MockHidapiDevice):
@@ -58,6 +50,7 @@ class _H115iPlatinumDevice(MockHidapiDevice):
 
 def test_h115i_platinum_device_connect(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
+    dev.disconnect()  # the fixture had by default connected to the device
 
     def mock_open():
         nonlocal opened
@@ -244,8 +237,13 @@ def test_h115i_platinum_device_invalid_color_modes(h115iPlatinumDevice):
 
     assert len(dev.device.sent) == 0
 
-def test_h115i_platinum_device_short_enough_storage_path(h115iPlatinumDeviceRaw):
-    dev = h115iPlatinumDeviceRaw
+def test_h115i_platinum_device_short_enough_storage_path():
+    description = 'Mock H115i Platinum'
+    kwargs = {'fan_count': 2, 'rgb_fans': True}
+    device = _H115iPlatinumDevice()
+    dev = HydroPlatinum(device, description, **kwargs)
+    dev.connect()
+
     assert len(dev._data._backend._write_dir) < _WIN_MAX_PATH;
     assert dev._data._backend._write_dir.endswith('3142')
 

--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -61,8 +61,6 @@ def test_h115i_platinum_device_connect(h115iPlatinumDevice):
 
 def test_h115i_platinum_device_command_format(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
-    dev._data.store('sequence', None)
-    dev._data.store('leds_enabled', 0)
     dev.initialize()
     dev.get_status()
     dev.set_fixed_speed(channel='fan', duty=100)
@@ -81,7 +79,6 @@ def test_h115i_platinum_device_command_format_enabled(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
 
     # test that the led enable messages are not sent if they are sent again
-    dev._data.store('sequence', None)
     dev.initialize()
     dev._data.store('leds_enabled', 1)
     dev.get_status()

--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -16,9 +16,19 @@ def h115iPlatinumDevice():
     kwargs = {'fan_count': 2, 'rgb_fans': True}
     device = _H115iPlatinumDevice()
     dev = HydroPlatinum(device, description, **kwargs)
+
     dev._data = MockRuntimeStorage(key_prefixes='testing')
+    dev.connect()
     dev._data.store('leds_enabled', 0)
 
+    return dev
+
+@pytest.fixture
+def h115iPlatinumDeviceRaw():
+    description = 'Mock H115i Platinum'
+    kwargs = {'fan_count': 2, 'rgb_fans': True}
+    device = _H115iPlatinumDevice()
+    dev = HydroPlatinum(device, description, **kwargs)
     dev.connect()
     return dev
 
@@ -234,10 +244,10 @@ def test_h115i_platinum_device_invalid_color_modes(h115iPlatinumDevice):
 
     assert len(dev.device.sent) == 0
 
-def test_h115i_platinum_device_short_enough_storage_path(h115iPlatinumDevice):
-    dev = h115iPlatinumDevice
-    #this test should not be here, the storage backed is tested seperately
-    pass
+def test_h115i_platinum_device_short_enough_storage_path(h115iPlatinumDeviceRaw):
+    dev = h115iPlatinumDeviceRaw
+    assert len(dev._data._backend._write_dir) < _WIN_MAX_PATH;
+    assert dev._data._backend._write_dir.endswith('3142')
 
 def test_h115i_platinum_device_bad_stored_data(h115iPlatinumDevice):
     dev = h115iPlatinumDevice

--- a/tests/test_kraken2.py
+++ b/tests/test_kraken2.py
@@ -1,9 +1,33 @@
-import unittest
+import pytest
 from liquidctl.driver.kraken2 import Kraken2
 from _testutils import MockHidapiDevice
+from liquidctl.error import NotSupportedByDevice
 
+@pytest.fixture
+def mockKrakenXDevice():
+    device = _MockKrakenDevice(fw_version=(6, 0, 2))
+    dev = Kraken2(device, 'Mock X62', device_type=Kraken2.DEVICE_KRAKENX)
 
-class _MockKraken(MockHidapiDevice):
+    dev.connect()
+    return dev
+
+@pytest.fixture
+def mockOldKrakenXDevice():
+    device = _MockKrakenDevice(fw_version=(2, 5, 8))
+    dev = Kraken2(device, 'Mock X62', device_type=Kraken2.DEVICE_KRAKENX)
+
+    dev.connect()
+    return dev
+
+@pytest.fixture
+def mockKrakenMDevice():
+    device = _MockKrakenDevice(fw_version=(6, 0, 2))
+    dev = Kraken2(device, 'Mock M22', device_type=Kraken2.DEVICE_KRAKENM)
+
+    dev.connect()
+    return dev
+
+class _MockKrakenDevice(MockHidapiDevice):
     def __init__(self, fw_version):
         super().__init__(vendor_id=0xffff, product_id=0x1e71)
         self.fw_version = fw_version
@@ -25,88 +49,75 @@ class _MockKraken(MockHidapiDevice):
         buf[0xe] = patch
         return buf[:length]
 
+def test_kraken_connect(mockKrakenXDevice):
+    def mock_open():
+        nonlocal opened
+        opened = True
 
-class _TestCase(unittest.TestCase):
-    def _prepare(self):
-        raise NotImplementedError
+    mockKrakenXDevice.device.open = mock_open
+    opened = False
 
-    def setUp(self):
-        self._prepare()
-        self.device.connect()
+    with mockKrakenXDevice.connect() as cm:
+        assert cm == mockKrakenXDevice
+        assert opened == True
 
-    def tearDown(self):
-        self.device.disconnect()
+def test_kraken_get_status(mockKrakenXDevice):
+    fan, fw_ver, temp, pump = sorted(mockKrakenXDevice.get_status())
 
+    assert fw_ver[1] == '6.0.2'
+    assert temp[1] == pytest.approx(mockKrakenXDevice.device.temperature)
+    assert fan[1] == mockKrakenXDevice.device.fan_speed
+    assert pump[1] == mockKrakenXDevice.device.pump_speed
 
-class CurrentX2TestCase(_TestCase):
-    def _prepare(self):
-        self.mock_hid = _MockKraken(fw_version=(6, 0, 2))
-        self.device = Kraken2(self.mock_hid, 'Mock X62', device_type=Kraken2.DEVICE_KRAKENX)
+def test_kraken_not_totally_broken(mockKrakenXDevice):
+    """Reasonable example calls to untested APIs do not raise exceptions."""
 
-    def test_connect(self):
-        def mock_open():
-            nonlocal opened
-            opened = True
-        self.mock_hid.open = mock_open
-        opened = False
-        with self.device.connect() as cm:
-            self.assertEqual(cm, self.device)
-            self.assertTrue(opened)
+    mockKrakenXDevice.initialize()
+    mockKrakenXDevice.set_color(channel='ring', mode='loading', colors=iter([[90, 80, 0]]),
+                          speed='slowest')
+    mockKrakenXDevice.set_speed_profile(channel='fan',
+                                  profile=iter([(20, 20), (30, 40), (40, 100)]))
+    mockKrakenXDevice.set_fixed_speed(channel='pump', duty=50)
+    mockKrakenXDevice.set_instantaneous_speed(channel='pump', duty=50)
 
-    def test_get_status(self):
-        fan, fw_ver, temp, pump = sorted(self.device.get_status())
-        self.assertEqual(fw_ver[1], '%d.%d.%d' % self.mock_hid.fw_version)
-        self.assertAlmostEqual(temp[1], self.mock_hid.temperature, places=1)
-        self.assertEqual(fan[1], self.mock_hid.fan_speed)
-        self.assertEqual(pump[1], self.mock_hid.pump_speed)
+def test_kraken_set_fixed_speeds(mockOldKrakenXDevice):
+    mockOldKrakenXDevice.set_fixed_speed(channel='fan', duty=42)
+    mockOldKrakenXDevice.set_fixed_speed(channel='pump', duty=84)
 
-    def test_not_totally_broken(self):
-        """Reasonable example calls to untested APIs do not raise exceptions."""
-        self.device.initialize()
-        self.device.set_color(channel='ring', mode='loading', colors=iter([[90, 80, 0]]),
-                              speed='slowest')
-        self.device.set_speed_profile(channel='fan',
-                                      profile=iter([(20, 20), (30, 40), (40, 100)]))
-        self.device.set_fixed_speed(channel='pump', duty=50)
-        self.device.set_instantaneous_speed(channel='pump', duty=50)
+    fan_report, pump_report = mockOldKrakenXDevice.device.sent
 
+    assert fan_report.number == 2
+    assert fan_report.data[0:4] == [0x4d, 0, 0, 42]
+    assert pump_report.number == 2
+    assert pump_report.data[0:4] == [0x4d, 0x40, 0, 84]
 
-class OldX2WithoutProfilesTestCase(_TestCase):
-    def _prepare(self):
-        self.mock_hid = _MockKraken(fw_version=(2, 5, 8))
-        self.device = Kraken2(self.mock_hid, 'Mock X62', device_type=Kraken2.DEVICE_KRAKENX)
+def test_kraken_speed_profiles_not_supported(mockOldKrakenXDevice):
 
-    def test_set_fixed_speeds(self):
-        self.device.set_fixed_speed(channel='fan', duty=42)
-        self.device.set_fixed_speed(channel='pump', duty=84)
-        fan_report, pump_report = self.mock_hid.sent
-        self.assertEqual(fan_report.number, 2)
-        self.assertEqual(fan_report.data[0:4], [0x4d, 0, 0, 42])
-        self.assertEqual(pump_report.number, 2)
-        self.assertEqual(pump_report.data[0:4], [0x4d, 0x40, 0, 84])
+    with pytest.raises(NotSupportedByDevice):
+        mockOldKrakenXDevice.set_speed_profile('fan', [(20, 42)])
 
-    def test_speed_profiles_not_supported(self):
-        self.assertRaises(Exception, self.device.set_speed_profile, 'fan', [(20, 42)])
-        self.assertRaises(Exception, self.device.set_speed_profile, 'pump', [(20, 84)])
+    with pytest.raises(NotSupportedByDevice):
+        mockOldKrakenXDevice.set_speed_profile('pump', [(20, 84)])
 
+def test_krakenM_get_status(mockKrakenMDevice):
+    (fw_ver,) = mockKrakenMDevice.get_status()
+    assert fw_ver[1] ==  '6.0.2'
 
-class M22TestCase(_TestCase):
-    def _prepare(self):
-        self.mock_hid = _MockKraken(fw_version=(6, 0, 2))
-        self.device = Kraken2(self.mock_hid, 'Mock M22', device_type=Kraken2.DEVICE_KRAKENM)
+def test_krakenM_speed_control_not_supported(mockKrakenMDevice):
+    with pytest.raises(NotSupportedByDevice):
+        mockKrakenMDevice.set_fixed_speed('fan', 42)
 
-    def test_get_status(self):
-        (fw_ver,) = self.device.get_status()
-        self.assertEqual(fw_ver[1], '%d.%d.%d' % self.mock_hid.fw_version)
+    with pytest.raises(NotSupportedByDevice):
+        mockKrakenMDevice.set_fixed_speed('pump', 84)
 
-    def test_speed_control_not_supported(self):
-        self.assertRaises(Exception, self.device.set_fixed_speed, 'fan', 42)
-        self.assertRaises(Exception, self.device.set_fixed_speed, 'pump', 84)
-        self.assertRaises(Exception, self.device.set_speed_profile, 'fan', [(20, 42)])
-        self.assertRaises(Exception, self.device.set_speed_profile, 'pump', [(20, 84)])
+    with pytest.raises(NotSupportedByDevice):
+        mockKrakenMDevice.set_speed_profile('fan', [(20, 42)])
 
-    def test_not_totally_broken(self):
-        """Reasonable example calls to untested APIs do not raise exceptions."""
-        self.device.initialize()
-        self.device.set_color(channel='ring', mode='loading', colors=iter([[90, 80, 0]]),
-                              speed='slowest')
+    with pytest.raises(NotSupportedByDevice):
+        mockKrakenMDevice.set_speed_profile('pump', [(20, 84)])
+
+def test_krakenM_not_totally_broken(mockKrakenMDevice):
+    """Reasonable example calls to untested APIs do not raise exceptions."""
+    mockKrakenMDevice.initialize()
+    mockKrakenMDevice.set_color(channel='ring', mode='loading', colors=iter([[90, 80, 0]]),
+                          speed='slowest')

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 
 from liquidctl.driver.kraken3 import KrakenX3, KrakenZ3
 from liquidctl.driver.kraken3 import _COLOR_CHANNELS_KRAKENX
@@ -20,6 +20,27 @@ _FAULTY_STATUS = bytes.fromhex(
     '0000000000000000000000000000000000000000000000000000000000000000'
 )
 
+@pytest.fixture
+def mockKrakenXDevice():
+    device = _MockKrakenDevice(raw_led_channels=len(_COLOR_CHANNELS_KRAKENX) - 1)
+    dev = KrakenX3(device, 'Corsair Kraken X73',
+            speed_channels=_SPEED_CHANNELS_KRAKENX,
+            color_channels=_COLOR_CHANNELS_KRAKENX)
+
+    dev.connect()
+    return dev
+
+
+@pytest.fixture
+def mockKrakenZDevice():
+    device = _MockKrakenDevice(raw_led_channels=0)
+    dev = KrakenZ3(device, 'Mock Kraken Z73',
+           speed_channels=_SPEED_CHANNELS_KRAKENZ,
+           color_channels={})
+
+    dev.connect()
+    return dev
+
 class _MockKrakenDevice(MockHidapiDevice):
     def __init__(self, raw_led_channels):
         super().__init__()
@@ -37,57 +58,33 @@ class _MockKrakenDevice(MockHidapiDevice):
                 reply[15 + 2 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_LOGO.value
         self.preload_read(Report(0, reply))
 
+def test_kracken_x_device_parses_status_fields(mockKrakenXDevice):
+    mockKrakenXDevice.device.preload_read(Report(0, _SAMPLE_STATUS))
+    temperature, pump_speed, pump_duty = mockKrakenXDevice.get_status()
+    assert temperature == ('Liquid temperature', 33.1, '°C')
+    assert pump_speed == ('Pump speed', 1704, 'rpm')
+    assert pump_duty == ('Pump duty', 53, '%')
 
-class KrakenX3TestCase(unittest.TestCase):
-    def setUp(self):
-        self.mock_hid = _MockKrakenDevice(raw_led_channels=len(_COLOR_CHANNELS_KRAKENX) - 1)
-        self.device = KrakenX3(self.mock_hid, 'Mock Kraken X73',
-                               speed_channels=_SPEED_CHANNELS_KRAKENX,
-                               color_channels=_COLOR_CHANNELS_KRAKENX)
-        self.device.connect()
+def test_kracken_x_device_warns_if_faulty_temperature(mockKrakenXDevice, caplog):
+    mockKrakenXDevice.device.preload_read(Report(0, _FAULTY_STATUS))
+    mockKrakenXDevice.get_status()
 
-    def tearDown(self):
-        self.device.disconnect()
+    assert 'unexpected temperature reading' in caplog.text
 
-    def test_parses_status_fields(self):
-        self.mock_hid.preload_read(Report(0, _SAMPLE_STATUS))
-        temperature, pump_speed, pump_duty = self.device.get_status()
-        assert temperature == ('Liquid temperature', 33.1, '°C')
-        assert pump_speed == ('Pump speed', 1704, 'rpm')
-        assert pump_duty == ('Pump duty', 53, '%')
+def test_kracken_x_device_not_totally_broken(mockKrakenXDevice):
+    """Reasonable example calls to untested APIs do not raise exceptions."""
+    infos = mockKrakenXDevice.initialize()
+    mockKrakenXDevice.set_color(channel='ring', mode='fixed', colors=iter([[3, 2, 1]]),
+                          speed='fastest')
+    mockKrakenXDevice.set_speed_profile(channel='pump',
+                                  profile=iter([(20, 20), (30, 50), (40, 100)]))
+    mockKrakenXDevice.set_fixed_speed(channel='pump', duty=50)
 
-    def test_warns_if_faulty_temperature(self):
-        self.mock_hid.preload_read(Report(0, _FAULTY_STATUS))
-        with self.assertLogs(level='WARNING') as cm:
-            self.device.get_status()
-        self.assertIn('unexpected temperature reading', ''.join(cm.output))
-
-    def test_not_totally_broken(self):
-        """Reasonable example calls to untested APIs do not raise exceptions."""
-        infos = self.device.initialize()
-        self.device.set_color(channel='ring', mode='fixed', colors=iter([[3, 2, 1]]),
-                              speed='fastest')
-        self.device.set_speed_profile(channel='pump',
-                                      profile=iter([(20, 20), (30, 50), (40, 100)]))
-        self.device.set_fixed_speed(channel='pump', duty=50)
-
-
-class KrakenZ3TestCase(unittest.TestCase):
-    def setUp(self):
-        self.mock_hid = _MockKrakenDevice(raw_led_channels=0)
-        self.device = KrakenZ3(self.mock_hid, 'Mock Kraken Z73',
-                               speed_channels=_SPEED_CHANNELS_KRAKENZ,
-                               color_channels={})
-        self.device.connect()
-
-    def tearDown(self):
-        self.device.disconnect()
-
-    def test_not_totally_broken(self):
-        """Reasonable example calls to untested APIs do not raise exceptions."""
-        infos = self.device.initialize()
-        self.mock_hid.preload_read(Report(0, _SAMPLE_STATUS))
-        status = self.device.get_status()
-        self.device.set_speed_profile(channel='fan',
-                                      profile=iter([(20, 20), (30, 50), (40, 100)]))
-        self.device.set_fixed_speed(channel='pump', duty=50)
+def test_kracken_z_device_not_totally_broken(mockKrakenZDevice):
+    """Reasonable example calls to untested APIs do not raise exceptions."""
+    infos = mockKrakenZDevice.initialize()
+    mockKrakenZDevice.device.preload_read(Report(0, _SAMPLE_STATUS))
+    status = mockKrakenZDevice.get_status()
+    mockKrakenZDevice.set_speed_profile(channel='fan',
+                                  profile=iter([(20, 20), (30, 50), (40, 100)]))
+    mockKrakenZDevice.set_fixed_speed(channel='pump', duty=50)

--- a/tests/test_nzxt_epsu.py
+++ b/tests/test_nzxt_epsu.py
@@ -1,42 +1,76 @@
-import unittest
+import pytest
 from liquidctl.driver.nzxt_epsu import NzxtEPsu
-from liquidctl.driver.nzxt_epsu import _SEASONIC_READ_FIRMWARE_VERSION
-from liquidctl.pmbus import CommandCode
 from _testutils import MockHidapiDevice, Report
 
 
-class _MockPsuDevice(MockHidapiDevice):
-    def write(self, data):
-        super().write(data)
-        data = data[1:]  # skip unused report ID
-        reply = bytearray(64)
-        reply[0:2] = (0xaa, data[2])
-        if data[5] == CommandCode.PAGE_PLUS_READ:
-            reply[2] = data[2] - 2
-        elif data[5] == _SEASONIC_READ_FIRMWARE_VERSION:
-            reply[2:4] = (0x11, 0x41)
-        self.preload_read(Report(0, reply[0:]))
+@pytest.fixture
+def mockPsuDevice():
+    device = MockHidapiDevice(vendor_id=0x7793, product_id=0x5911, address='addr')
+    return NzxtEPsu(device, 'mock NZXT E500 PSU')
 
 
-class NzxtEPsuTestCase(unittest.TestCase):
-    def setUp(self):
-        self.mock_hid = _MockPsuDevice()
-        self.device = NzxtEPsu(self.mock_hid, 'Mock NZXT E PSU')
-        self.device.connect()
+def test_psu_device_initialize(mockPsuDevice):
+    mockPsuDevice.initialize()
 
-    def tearDown(self):
-        self.device.disconnect()
+    assert len(mockPsuDevice.device.sent) == 0
 
-    def test_not_totally_broken(self):
-        """A few reasonable example calls do not raise exceptions."""
-        self.device.initialize()
-        status = self.device.get_status()
 
-        fw = next(filter(lambda x: x[0] == 'Firmware version', status))
-        assert fw == ('Firmware version', 'A017/40983', '')
+def test_psu_device_status(mockPsuDevice):
 
-    def test_dont_inject_report_ids(self):
-        status = self.device.get_status()
-        get_fw = self.mock_hid.sent[0]
-        assert get_fw == Report(0, [0xad, 0, 3, 1, 0x60, 0xfc] + 58*[0])
+    replyFW = bytearray(64)
+    replyFW[0:2] = (0xaa, 0x03)
+    replyFW[2:4] = (0x11, 0x41)
 
+    replyTemp = bytearray(64)
+    replyTemp[0:2] = (0xaa, 0x03)
+
+    replySpeed = replyTemp
+
+    replyVoltA = bytearray(64)
+    replyVoltA[0:2] = (0xaa, 0x03)
+    replyVoltA[2] = 1
+
+    replyVoltB = bytearray(64)
+    replyVoltB[0:2] = (0xaa, 0x04)
+    replyVoltB[2] = 2
+
+    replyCurrent = replyVoltB
+    replyPower = replyCurrent
+
+    replies = [
+        replyFW,
+        replyTemp,
+        replySpeed,
+        replyVoltA,
+        replyVoltB,
+        replyCurrent,
+        replyPower,
+        replyVoltA,
+        replyVoltB,
+        replyCurrent,
+        replyPower,
+        replyVoltA,
+        replyVoltB,
+        replyCurrent,
+        replyPower,
+        replyVoltA,
+        replyVoltB,
+        replyCurrent,
+        replyPower,
+        replyVoltA,
+        replyVoltB,
+        replyCurrent,
+        replyPower,
+    ]
+
+    for reply in replies:
+        mockPsuDevice.device.preload_read(Report(0, reply[0:]))
+
+    mockPsuDevice.connect()
+    status = mockPsuDevice.get_status()
+
+    fw = next(filter(lambda x: x[0] == 'Firmware version', status))
+    assert fw == ('Firmware version', 'A017/40983', '')
+
+    sent = mockPsuDevice.device.sent
+    assert sent[0] == Report(0, [0xad, 0, 3, 1, 0x60, 0xfc] + 58*[0])

--- a/tests/test_rgb_fusion2.py
+++ b/tests/test_rgb_fusion2.py
@@ -1,4 +1,4 @@
-import unittest
+import pytest
 from collections import deque
 from liquidctl.driver.rgb_fusion2 import RgbFusion2
 from _testutils import MockHidapiDevice, Report
@@ -21,148 +21,151 @@ _INIT_8297_DATA = bytes.fromhex(
 _INIT_8297_SAMPLE = Report(_INIT_8297_DATA[0], _INIT_8297_DATA[1:])
 
 
-class Controller5702TestCase(unittest.TestCase):
-    def setUp(self):
-        description = 'Mock 5702 Controller'
-        self.mock_hid = MockHidapiDevice()
-        self.device = RgbFusion2(self.mock_hid, description)
-        self.device.connect()
-        self.report_id = 0xcc
+@pytest.fixture
+def mockRgbFusion2_5702Device():
+    device = MockHidapiDevice(vendor_id=0x048d, product_id=0x5702, address='addr')
+    dev =  RgbFusion2(device, 'mock 5702 Controller')
 
-    def tearDown(self):
-        self.device.disconnect()
-
-    def test_command_format(self):
-        self.mock_hid.preload_read(_INIT_5702_SAMPLE)
-        self.device.initialize()
-        self.device.set_color(channel='sync', mode='off', colors=[])
-        self.assertEqual(len(self.mock_hid.sent), 1 + 8 + 1)
-        for i, (report, data) in enumerate(self.mock_hid.sent):
-            self.assertEqual(report, self.report_id)
-            self.assertEqual(len(data), 63)  # TODO double check, more likely to be 64
-
-    def test_get_status(self):
-        self.assertEqual(self.device.get_status(), [])
-
-    def test_initialize_status(self):
-        self.mock_hid.preload_read(_INIT_5702_SAMPLE)
-        name, fw_version = self.device.initialize()
-        self.assertEqual(name[1], "IT5702-GIGABYTE V1.0.10.0")
-        self.assertEqual(fw_version[1], '1.0.10.0')
-
-    def test_off_with_some_channel(self):
-        colors = [[0xff, 0, 0x80]]  # should be ignored
-        self.device.set_color(channel='led8', mode='off', colors=iter(colors))
-        set_color, execute = self.mock_hid.sent
-        self.assertEqual(set_color.data[0:2], [0x27, 0x80], "incorrect channel")
-        self.assertEqual(set_color.data[10], 0x01, "wrong mode value")
-        self.assertEqual(max(set_color.data[13:16]), 0, "incorrect color")
-        self.assertEqual(max(set_color.data[21:27]), 0, "incorrect speed values")
-
-    def test_fixed_with_some_channel(self):
-        colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
-        self.device.set_color(channel='led7', mode='fixed', colors=iter(colors))
-        set_color, execute = self.mock_hid.sent
-        self.assertEqual(set_color.data[0:2], [0x26, 0x40], "incorrect channel")
-        self.assertEqual(set_color.data[10], 0x01, "wrong mode value")
-        self.assertEqual(set_color.data[13:16], [0x80, 0x00, 0xff], "incorrect color encoding")
-        self.assertEqual(max(set_color.data[21:27]), 0, "incorrect speed values")
-
-    def test_pulse_with_some_channel_and_speed(self):
-        colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
-        self.device.set_color(channel='led3', mode='pulse', colors=iter(colors), speed='faster')
-        set_color, execute = self.mock_hid.sent
-        self.assertEqual(set_color.data[0:2], [0x22, 0x04], "incorrect channel")
-        self.assertEqual(set_color.data[10], 0x02, "wrong mode value")
-        self.assertEqual(set_color.data[13:16], [0x80, 0x00, 0xff], "incorrect color encoding")
-        self.assertEqual(set_color.data[21:27], [0xe8, 0x03, 0xe8, 0x03, 0xf4, 0x01],
-                         "incorrect speed values")
-
-    def test_flash_with_some_channel_and_speed(self):
-        colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
-        self.device.set_color(channel='led6', mode='flash', colors=iter(colors), speed='slowest')
-        set_color, execute = self.mock_hid.sent
-        self.assertEqual(set_color.data[0:2], [0x25, 0x20], "incorrect channel")
-        self.assertEqual(set_color.data[10], 0x03, "wrong mode value")
-        self.assertEqual(set_color.data[13:16], [0x80, 0x00, 0xff], "incorrect color encoding")
-        self.assertEqual(set_color.data[21:27], [0x64, 0x00, 0x64, 0x00, 0x60, 0x09],
-                         "incorrect speed values")
-
-    def test_double_flash_with_some_channel_and_speed_and_uppercase(self):
-        colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
-        self.device.set_color(channel='LED5', mode='DOUBLE-FLASH', colors=iter(colors),
-                              speed='LUDICROUS')
-        set_color, execute = self.mock_hid.sent
-        self.assertEqual(set_color.data[0:2], [0x24, 0x10], "incorrect channel")
-        self.assertEqual(set_color.data[10], 0x03, "wrong mode value")
-        self.assertEqual(set_color.data[13:16], [0x80, 0x00, 0xff], "incorrect color encoding")
-        self.assertEqual(set_color.data[21:27], [0x64, 0x00, 0x64, 0x00, 0x40, 0x06],
-                         "incorrect speed values")
-
-    def test_color_cycle_with_some_channel_and_speed(self):
-        colors = [[0xff, 0, 0x80]]  # should be ignored
-        self.device.set_color(channel='led4', mode='color-cycle', colors=iter(colors),
-                              speed='fastest')
-        set_color, execute = self.mock_hid.sent
-        self.assertEqual(set_color.data[0:2], [0x23, 0x08], "incorrect channel")
-        self.assertEqual(set_color.data[10], 0x04, "wrong mode value")
-        self.assertEqual(max(set_color.data[13:16]), 0, "incorrect color")
-        self.assertEqual(set_color.data[21:27], [0x26, 0x02, 0xc2, 0x01, 0x00, 0x00],
-                         "incorrect speed values")
-        # TODO brightness
-
-    def test_common_behavior_in_all_set_color_writes(self):
-        colors = [[0xff, 0, 0x80]]
-        for mode in ['off', 'fixed', 'pulse', 'flash', 'double-flash', 'color-cycle']:
-            self.mock_hid.sent = deque()
-            self.device.set_color(channel='led1', mode=mode, colors=iter(colors))
-            set_color, execute = self.mock_hid.sent
-            self.assertEqual(execute.data[0:2], [0x28, 0xff], "incorrect execute payload")
-            self.assertEqual(max(execute.data[2:]), 0, "incorrect execute padding")
-
-    def test_sync_channel(self):
-        colors = [[0xff, 0, 0x80]]
-        self.device.set_color(channel='sync', mode='fixed', colors=iter(colors))
-        self.assertEqual(len(self.mock_hid.sent), 8 + 1)  # 8 × set + execute
-
-    def test_reset_all_channels(self):
-        self.device.reset_all_channels()
-        for addr, report in enumerate(self.mock_hid.sent[:-1], 0x20):
-            self.assertEqual(report.data[0:2], [addr, 0], "invalid payload")
-            self.assertEqual(max(report.data[2:]), 0, "invalid padding")
-        execute = self.mock_hid.sent[-1]
-        self.assertEqual(execute.data[0:2], [0x28, 0xff], "incorrect execute payload")
-        self.assertEqual(max(execute.data[2:]), 0, "incorrect execute padding")
-
-    def test_invalid_set_color_arguments(self):
-        self.assertRaises(Exception, self.device.set_color, channel='invalid',
-                          mode='off', colors=[])
-        self.assertRaises(Exception, self.device.set_color, channel='led1',
-                          mode='invalid', colors=[])
-        self.assertRaises(Exception, self.device.set_color, channel='led1',
-                          mode='fixed', colors=[])
-        self.assertRaises(Exception, self.device.set_color, channel='led1',
-                          mode='pulse', colors=[[0xff, 0, 0x80]], speed='invalid')
-
+    dev.connect()
+    return dev
 
 class Mock8297HidInterface(MockHidapiDevice):
     def get_feature_report(self, report_id, length):
         """Get a feature report emulating out of spec behavior of the device."""
         return super().get_feature_report(0, length)
 
+@pytest.fixture
+def mockRgbFusion2_8297Device():
+    device = Mock8297HidInterface(vendor_id=0x048d, product_id=0x8297, address='addr')
+    dev =  RgbFusion2(device, 'mock 8297 Controller')
 
-class Controller8297TestCase(unittest.TestCase):
-    def setUp(self):
-        description = 'Mock 8297 Controller'
-        self.mock_hid = Mock8297HidInterface()
-        self.device = RgbFusion2(self.mock_hid, description)
-        self.device.connect()
-        self.report_id = 0xcc
+    dev.connect()
+    return dev
 
-    def test_initialize_status(self):
-        self.mock_hid.preload_read(_INIT_8297_SAMPLE)
-        name, fw_version = self.device.initialize()
-        self.assertEqual(name[1], "IT8297BX-GBX570")
-        self.assertEqual(fw_version[1], '1.0.6.0')
+
+def test_fusion2_5702_device_command_format(mockRgbFusion2_5702Device):
+    mockRgbFusion2_5702Device.device.preload_read(_INIT_5702_SAMPLE)
+    mockRgbFusion2_5702Device.initialize()
+    mockRgbFusion2_5702Device.set_color(channel='sync', mode='off', colors=[])
+    assert len(mockRgbFusion2_5702Device.device.sent) == 1 + 8 + 1
+
+    for i, (report, data) in enumerate(mockRgbFusion2_5702Device.device.sent):
+        assert report == 0xcc
+        assert len(data) ==  63  # TODO double check, more likely to be 64
+
+def test_fusion2_5702_device_get_status(mockRgbFusion2_5702Device):
+    assert mockRgbFusion2_5702Device.get_status() == []
+
+def test_fusion2_5702_device_initialize_status(mockRgbFusion2_5702Device):
+    mockRgbFusion2_5702Device.device.preload_read(_INIT_5702_SAMPLE)
+    name, fw_version = mockRgbFusion2_5702Device.initialize()
+    assert name[1] == "IT5702-GIGABYTE V1.0.10.0"
+    assert fw_version[1] == '1.0.10.0'
+
+def test_fusion2_5702_device_off_with_some_channel(mockRgbFusion2_5702Device):
+    colors = [[0xff, 0, 0x80]]  # should be ignored
+    mockRgbFusion2_5702Device.set_color(channel='led8', mode='off', colors=iter(colors))
+    set_color, execute = mockRgbFusion2_5702Device.device.sent
+    assert set_color.data[0:2] == [0x27, 0x80]
+    assert set_color.data[10] == 0x01
+    assert max(set_color.data[13:16]) == 0
+    assert max(set_color.data[21:27]) == 0
+
+def test_fusion2_5702_device_fixed_with_some_channel(mockRgbFusion2_5702Device):
+    colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
+    mockRgbFusion2_5702Device.set_color(channel='led7', mode='fixed', colors=iter(colors))
+    set_color, execute = mockRgbFusion2_5702Device.device.sent
+    assert set_color.data[0:2] == [0x26, 0x40]
+    assert set_color.data[10] == 0x01
+    assert set_color.data[13:16] == [0x80, 0x00, 0xff]
+    assert max(set_color.data[21:27]) == 0
+
+def test_fusion2_5702_device_pulse_with_some_channel_and_speed(mockRgbFusion2_5702Device):
+    colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
+    mockRgbFusion2_5702Device.set_color(channel='led3', mode='pulse', colors=iter(colors), speed='faster')
+    set_color, execute = mockRgbFusion2_5702Device.device.sent
+
+    assert set_color.data[0:2] == [0x22, 0x04]
+    assert set_color.data[10] == 0x02
+    assert set_color.data[13:16] == [0x80, 0x00, 0xff]
+    assert set_color.data[21:27] == [0xe8, 0x03, 0xe8, 0x03, 0xf4, 0x01]
+
+def test_fusion2_5702_device_flash_with_some_channel_and_speed(mockRgbFusion2_5702Device):
+    colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
+    mockRgbFusion2_5702Device.set_color(channel='led6', mode='flash', colors=iter(colors), speed='slowest')
+    set_color, execute = mockRgbFusion2_5702Device.device.sent
+
+    assert set_color.data[0:2] == [0x25, 0x20]
+    assert set_color.data[10] == 0x03
+    assert set_color.data[13:16] == [0x80, 0x00, 0xff]
+    assert set_color.data[21:27] == [0x64, 0x00, 0x64, 0x00, 0x60, 0x09]
+
+def test_fusion2_5702_device_double_flash_with_some_channel_and_speed_and_uppercase(mockRgbFusion2_5702Device):
+    colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
+    mockRgbFusion2_5702Device.set_color(channel='LED5', mode='DOUBLE-FLASH', colors=iter(colors),
+                          speed='LUDICROUS')
+    set_color, execute = mockRgbFusion2_5702Device.device.sent
+
+    assert set_color.data[0:2] == [0x24, 0x10]
+    assert set_color.data[10] == 0x03
+    assert set_color.data[13:16] == [0x80, 0x00, 0xff]
+    assert set_color.data[21:27] == [0x64, 0x00, 0x64, 0x00, 0x40, 0x06]
+
+def test_fusion2_5702_device_color_cycle_with_some_channel_and_speed(mockRgbFusion2_5702Device):
+    colors = [[0xff, 0, 0x80]]  # should be ignored
+    mockRgbFusion2_5702Device.set_color(channel='led4', mode='color-cycle', colors=iter(colors),
+                          speed='fastest')
+    set_color, execute = mockRgbFusion2_5702Device.device.sent
+
+    assert set_color.data[0:2] == [0x23, 0x08]
+    assert set_color.data[10] == 0x04
+    assert max(set_color.data[13:16]) == 0
+    assert set_color.data[21:27] == [0x26, 0x02, 0xc2, 0x01, 0x00, 0x00]
+    # TODO brightness
+
+def test_fusion2_5702_device_common_behavior_in_all_set_color_writes(mockRgbFusion2_5702Device):
+    colors = [[0xff, 0, 0x80]]
+    for mode in ['off', 'fixed', 'pulse', 'flash', 'double-flash', 'color-cycle']:
+        mockRgbFusion2_5702Device.device.sent = deque()
+        mockRgbFusion2_5702Device.set_color(channel='led1', mode=mode, colors=iter(colors))
+        set_color, execute = mockRgbFusion2_5702Device.device.sent
+
+        assert execute.data[0:2] == [0x28, 0xff]
+        assert max(execute.data[2:]) == 0
+
+def test_fusion2_5702_device_sync_channel(mockRgbFusion2_5702Device):
+    colors = [[0xff, 0, 0x80]]
+    mockRgbFusion2_5702Device.set_color(channel='sync', mode='fixed', colors=iter(colors))
+    assert len(mockRgbFusion2_5702Device.device.sent) == 8 + 1  # 8 × set + execute
+
+def test_fusion2_5702_device_reset_all_channels(mockRgbFusion2_5702Device):
+    mockRgbFusion2_5702Device.reset_all_channels()
+    for addr, report in enumerate(mockRgbFusion2_5702Device.device.sent[:-1], 0x20):
+        assert report.data[0:2] == [addr, 0]
+        assert max(report.data[2:]) == 0
+    execute = mockRgbFusion2_5702Device.device.sent[-1]
+    assert execute.data[0:2] == [0x28, 0xff]
+    assert max(execute.data[2:]) == 0
+
+def test_fusion2_5702_device_invalid_set_color_arguments(mockRgbFusion2_5702Device):
+
+    with pytest.raises(KeyError):
+        mockRgbFusion2_5702Device.set_color('invalid', 'off', [])
+
+    with pytest.raises(KeyError):
+        mockRgbFusion2_5702Device.set_color('led1', 'invalid', [])
+
+    with pytest.raises(ValueError):
+        mockRgbFusion2_5702Device.set_color('led1', 'fixed', [])
+
+    with pytest.raises(KeyError):
+        mockRgbFusion2_5702Device.set_color('led1', 'pulse', [[0xff, 0, 0x80]], speed='invalid')
+
+def test_fusion2_8297_device_initialize_status(mockRgbFusion2_8297Device):
+    mockRgbFusion2_8297Device.device.preload_read(_INIT_8297_SAMPLE)
+    name, fw_version = mockRgbFusion2_8297Device.initialize()
+
+    assert name[1] == "IT8297BX-GBX570"
+    assert fw_version[1] == '1.0.6.0'
 
     # other tests skipped, see Controller5702TestCase

--- a/tests/test_smart_device.py
+++ b/tests/test_smart_device.py
@@ -1,25 +1,34 @@
-import unittest
+import pytest
 from liquidctl.driver.smart_device import SmartDevice
 from _testutils import MockHidapiDevice, Report
 
 
-class SmartDeviceTestCase(unittest.TestCase):
-    def setUp(self):
-        self.mock_hid = MockHidapiDevice()
-        self.device = SmartDevice(self.mock_hid, 'Mock Smart Device',
-                                  speed_channel_count=3,
-                                  color_channel_count=1)
-        self.device.connect()
+@pytest.fixture
+def mockSmartDevice():
+    device = MockHidapiDevice(vendor_id=0x1e71, product_id=0x1714, address='addr')
+    return SmartDevice(device, 'mock NZXT Smart Device V1', speed_channel_count=3, color_channel_count=1)
 
-    def tearDown(self):
-        self.device.disconnect()
 
-    def test_not_totally_broken(self):
-        """A few reasonable example calls do not raise exceptions."""
-        for i in range(3):
-            self.mock_hid.preload_read(Report(0, bytes(63)))
-        self.device.initialize()
-        status = self.device.get_status()
-        self.device.set_color(channel='led', mode='breathing', colors=iter([[142, 24, 68]]),
-                              speed='fastest')
-        self.device.set_fixed_speed(channel='fan3', duty=50)
+##### class methods
+def test_smart_device_constructor(mockSmartDevice):
+
+    assert mockSmartDevice._speed_channels == {
+            'fan1': (0, 0, 100),
+            'fan2': (1, 0, 100),
+            'fan3': (2, 0, 100),
+        }
+
+    assert mockSmartDevice._color_channels == {'led': (0), }
+
+def test_smart_device_not_totally_broken(mockSmartDevice):
+
+    for i in range(3):
+        mockSmartDevice.device.preload_read(Report(0, bytes(63)))
+
+    mockSmartDevice.initialize()
+    status = mockSmartDevice.get_status()
+
+    mockSmartDevice.set_color(channel='led', mode='breathing', colors=iter([[142, 24, 68]]),
+                          speed='fastest')
+
+    mockSmartDevice.set_fixed_speed(channel='fan3', duty=50)

--- a/tests/test_smart_device2.py
+++ b/tests/test_smart_device2.py
@@ -25,7 +25,7 @@ def test_smart_device2_constructor(mockSmartDevice2):
         }
 
 
-def test_smart_device2_ot_totally_broken(mockSmartDevice2):
+def test_smart_device2_not_totally_broken(mockSmartDevice2):
 
     frimwareData = bytearray(64)
     lightingData = bytearray(64)
@@ -47,8 +47,6 @@ def test_smart_device2_ot_totally_broken(mockSmartDevice2):
     ]
     for reply in replys:
         mockSmartDevice2.device.preload_read(Report(reply[0], reply[1:]))
-
-    mockSmartDevice2.connect()
 
     mockSmartDevice2.initialize()
     status = mockSmartDevice2.get_status()

--- a/tests/test_smart_device2.py
+++ b/tests/test_smart_device2.py
@@ -1,45 +1,59 @@
-import unittest
+import pytest
 from liquidctl.driver.smart_device import SmartDevice2
-from liquidctl.util import Hue2Accessory
-from liquidctl.util import HUE2_MAX_ACCESSORIES_IN_CHANNEL as MAX_ACCESSORIES
 from _testutils import MockHidapiDevice, Report
 
 
-class _MockSmartDevice2(MockHidapiDevice):
-    def __init__(self, raw_speed_channels, raw_led_channels):
-        super().__init__()
-        self.raw_speed_channels = raw_speed_channels
-        self.raw_led_channels = raw_led_channels
-
-    def write(self, data):
-        reply = bytearray(64)
-        if data[0:2] == [0x10, 0x01]:
-            reply[0:2] = [0x11, 0x01]
-        elif data[0:2] == [0x20, 0x03]:
-            reply[0:2] = [0x21, 0x03]
-            reply[14] = self.raw_led_channels
-            if self.raw_led_channels > 1:
-                reply[15 + 1 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_RING.value
-                reply[15 + 2 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_LOGO.value
-        self.preload_read(Report(reply[0], reply[1:]))
+@pytest.fixture
+def mockSmartDevice2():
+    device = MockHidapiDevice(vendor_id=0x1e71, product_id=0x2006, address='addr')
+    return SmartDevice2(device, 'mock NZXT Smart Device V2', speed_channel_count=3, color_channel_count=2)
 
 
-class SmartDevice2TestCase(unittest.TestCase):
-    def setUp(self):
-        self.mock_hid = _MockSmartDevice2(raw_speed_channels=3, raw_led_channels=2)
-        self.device = SmartDevice2(self.mock_hid, 'Mock Smart Device V2',
-                                   speed_channel_count=3,
-                                   color_channel_count=2)
-        self.device.connect()
+##### class methods
+def test_smart_device2_constructor(mockSmartDevice2):
 
-    def tearDown(self):
-        self.device.disconnect()
+    assert mockSmartDevice2._speed_channels == {
+            'fan1': (0, 0, 100),
+            'fan2': (1, 0, 100),
+            'fan3': (2, 0, 100),
+        }
 
-    def test_not_totally_broken(self):
-        """A few reasonable example calls do not raise exceptions."""
-        self.device.initialize()
-        self.mock_hid.preload_read(Report(0, [0x67, 0x02] + [0] * 62))
-        status = self.device.get_status()
-        self.device.set_color(channel='led1', mode='breathing', colors=iter([[142, 24, 68]]),
-                              speed='fastest')
-        self.device.set_fixed_speed(channel='fan3', duty=50)
+    assert mockSmartDevice2._color_channels == {
+            'led1': (0b001),
+            'led2': (0b010),
+            'sync': (0b011),
+        }
+
+
+def test_smart_device2_ot_totally_broken(mockSmartDevice2):
+
+    frimwareData = bytearray(64)
+    lightingData = bytearray(64)
+
+    frimwareData[0:2] = [0x11, 0x01]
+    lightingData[0:2] = [0x21, 0x03]
+    lightingData[14] = 2
+    lightingData[15 + 1 * 6] = 0x10
+    lightingData[15 + 2 * 6] = 0x11
+
+    replys = [
+        bytearray(64),
+        bytearray(64),
+        frimwareData,
+        lightingData,
+        [0] + [0x67, 0x02] + [0] * 62,
+        bytearray(64),
+        bytearray(64),
+    ]
+    for reply in replys:
+        mockSmartDevice2.device.preload_read(Report(reply[0], reply[1:]))
+
+    mockSmartDevice2.connect()
+
+    mockSmartDevice2.initialize()
+    status = mockSmartDevice2.get_status()
+
+    mockSmartDevice2.set_color(channel='led1', mode='breathing', colors=iter([[142, 24, 68]]),
+                          speed='fastest')
+
+    mockSmartDevice2.set_fixed_speed(channel='fan3', duty=50)

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -8,7 +8,12 @@ from _testutils import MockHidapiDevice
 @pytest.fixture
 def emulated_hid_device():
     hiddev = MockHidapiDevice()
-    dev = UsbHidDriver(hiddev, 'Test')
+    return UsbHidDriver(hiddev, 'Test')
+
+@pytest.fixture
+def emulated_usb_device():
+    usbdev = MockHidapiDevice()  # hack, should mock PyUsbDevice
+    dev = UsbDriver(usbdev, 'Test')
 
     return dev
 
@@ -27,14 +32,18 @@ def test_hid_connects(emulated_hid_device):
         assert cm == dev
         assert opened
 
+def test_hid_disconnect(emulated_hid_device):
+    dev = emulated_hid_device
 
-@pytest.fixture
-def emulated_usb_device():
-    usbdev = MockHidapiDevice()  # hack, should mock PyUsbDevice
-    dev = UsbDriver(usbdev, 'Test')
+    def mock_close():
+        nonlocal opened
+        opened = False
 
-    return dev
+    dev.device.close = mock_close
+    opened = True
 
+    dev.disconnect()
+    assert opened == False
 
 def test_usb_connects(emulated_usb_device):
     dev = emulated_usb_device
@@ -49,3 +58,16 @@ def test_usb_connects(emulated_usb_device):
     with dev.connect() as cm:
         assert cm == dev
         assert opened
+
+def test_usb_disconnect(emulated_usb_device):
+    dev = emulated_usb_device
+
+    def mock_close():
+        nonlocal opened
+        opened = False
+
+    dev.device.close = mock_close
+    opened = True
+
+    dev.disconnect()
+    assert opened == False


### PR DESCRIPTION
In partial completion of #231. 

This changes all of the tests to use the python pytest module instead of the UnitTest module. Aside from the `hydro platinum` moving where the `RuntimeStorage` module gets set all of the tests and the code should be the same. 

One of the `hydro platinum`  test case to ensure that the `RuntimeStorage`  is in the correct spot was removed. 