### PR TITLE
Logger consistency

### DIFF
--- a/docs/developer/style-guide.md
+++ b/docs/developer/style-guide.md
@@ -110,8 +110,8 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 ```
 
-Prefer old-style %-formatting, since this is evaluated lazyly by `logging`, and
-the message will only be formated if the logging level is enabled.
+Prefer PEP3101 style formatting over old-style %-formatting for all strings to be
+consistent rather then using mixes of `f strings`, `% formatting`, and `string.format()`.
 
 ```py
 _LOGGER.warning('value %d, expected %d', current, expected)

--- a/docs/developer/style-guide.md
+++ b/docs/developer/style-guide.md
@@ -117,7 +117,7 @@ the message will only be formated if the logging level is enabled.
 _LOGGER.warning('value %d, expected %d', current, expected)
 ```
 
-The rest of the time using `string.format()` is preferred.
+The rest of the time using `f-strings` are preferred, to follow the `PEP 498` guideline.
 
 When writing informational or debug messages, pay attention to the cost of
 computing each value.  A classic example is hex formatting some bytes, which

--- a/docs/developer/style-guide.md
+++ b/docs/developer/style-guide.md
@@ -110,12 +110,14 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 ```
 
-Prefer PEP3101 style formatting over old-style %-formatting for all strings to be
-consistent rather then using mixes of `f strings`, `% formatting`, and `string.format()`.
+Prefer old-style %-formatting, since this is evaluated lazyly by `logging`, and
+the message will only be formated if the logging level is enabled.
 
 ```py
 _LOGGER.warning('value %d, expected %d', current, expected)
 ```
+
+The rest of the time using `string.format()` is preferred.
 
 When writing informational or debug messages, pay attention to the cost of
 computing each value.  A classic example is hex formatting some bytes, which

--- a/extra/windows/LQiNFO.py
+++ b/extra/windows/LQiNFO.py
@@ -110,7 +110,7 @@ if __name__ == '__main__':
                     winreg.SetValueEx(sensor_key, 'Unit', None, winreg.REG_SZ, u)
                     winreg.SetValueEx(sensor_key, 'Value', None, winreg.REG_SZ, str(v))
                     dev_values.append(sensor_key)
-                
+
             infos.append((dev_key, dev_values))
             # set up dev infos and registry
         status = {}

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -127,11 +127,11 @@ _FILTER_OPTIONS = [
 
 # custom number formats for values of select units
 _VALUE_FORMATS = {
-    '°C' : '.1f',
-    'rpm' : '.0f',
-    'V' : '.2f',
-    'A' : '.2f',
-    'W' : '.2f'
+    '°C': '.1f',
+    'rpm': '.0f',
+    'V': '.2f',
+    'A': '.2f',
+    'W': '.2f'
 }
 
 _LOGGER = logging.getLogger(__name__)
@@ -325,7 +325,7 @@ def main():
         except OSError as err:
             # each backend API returns a different subtype of OSError (OSError,
             # usb.core.USBError or PermissionError) for permission issues
-            if err.errno in [errno.EACCES , errno.EPERM]:
+            if err.errno in [errno.EACCES, errno.EPERM]:
                 log_error(err, f'Error: insufficient permissions to access {dev.description}')
             elif err.args == ('open failed', ):
                 log_error(err, f'Error: could not open {dev.description}, possibly due to insufficient permissions')

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -142,23 +142,23 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
         warnings = []
 
         if not using_filters:
-            print(f'Device ID {i}: {dev.description}')
+            print('Device ID {}: {}'.format(i, dev.description))
         elif device_id is not None:
-            print(f'Device ID {device_id}: {dev.description}')
+            print('Device ID {}: {}'.format(device_id, dev.description))
         else:
-            print(f'Result #{i}: {dev.description}')
+            print('Result #{}: {}'.format(i, dev.description))
         if not verbose:
             continue
 
         if dev.vendor_id:
-            print(f'├── Vendor ID: {dev.vendor_id:#06x}')
+            print('├── Vendor ID: {:#06x}'.format(dev.vendor_id))
         if dev.product_id:
-            print(f'├── Product ID: {dev.product_id:#06x}')
+            print('├── Product ID: {:#06x}'.format(dev.product_id))
         if dev.release_number:
-            print(f'├── Release number: {dev.release_number:#06x}')
+            print('├── Release number: {:#06x}'.format(dev.release_number))
         try:
             if dev.serial_number:
-                print(f'├── Serial number: {dev.serial_number}')
+                print('├── Serial number: {}'.format(dev.serial_number))
         except:
             msg = 'could not read the serial number'
             if sys.platform.startswith('linux') and os.geteuid:
@@ -170,16 +170,16 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
             else:
                 warnings.append(msg)
 
-        print(f'├── Bus: {dev.bus}')
-        print(f'├── Address: {dev.address}')
+        print('├── Bus: {}'.format(dev.bus))
+        print('├── Address: {}'.format(dev.address))
         if dev.port:
             port = '.'.join(map(str, dev.port))
-            print(f'├── Port: {port}')
+            print('├── Port: {}'.format(port))
 
-        print(f'└── Driver: {type(dev).__name__}')
+        print('└── Driver: {}'.format(type(dev).__name__))
         if debug:
             driver_hier = [i.__name__ for i in inspect.getmro(type(dev)) if i != object]
-            _LOGGER.debug('hierarchy: %s', ', '.join(driver_hier[1:]))
+            _LOGGER.debug('hierarchy: {}'.format(', '.join(driver_hier[1:])))
 
         for msg in warnings:
             _LOGGER.warning(msg)
@@ -191,7 +191,7 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
 def _print_dev_status(dev, status):
     if not status:
         return
-    print(f'{dev.description}')
+    print(dev.description)
     tmp = []
     kcols, vcols = 0, 0
     for k, v, u in status:
@@ -200,14 +200,14 @@ def _print_dev_status(dev, status):
             u = ''
         else:
             valfmt = _VALUE_FORMATS.get(u, '')
-            v = f'{v:{valfmt}}'
+            v = '{:{valfmt}}'.format(v)
         kcols = max(kcols, len(k))
         vcols = max(vcols, len(v))
         tmp.append((k, v, u))
     for k, v, u in tmp[:-1]:
-        print(f'├── {k:<{kcols}}    {v:>{vcols}}  {u}')
+        print('├── {:<{kcols}}    {:>{vcols}}  {}'.format(k, v, u))
     k, v, u = tmp[-1]
-    print(f'└── {k:<{kcols}}    {v:>{vcols}}  {u}')
+    print('└── {:<{kcols}}    {:>{vcols}}  {}'.format(k, v, u))
     print('')
 
 
@@ -226,8 +226,8 @@ def _device_set_speed(dev, args, **opts):
 
 def _make_opts(args):
     if args['--hid']:
-        _LOGGER.warning('ignoring --hid %s: deprecated option, API will be selected automatically',
-                        args['--hid'])
+        _LOGGER.warning('ignoring --hid {}: deprecated option, API will be selected automatically'
+                        .format(args['--hid']))
     opts = {}
     for arg, val in args.items():
         if val is not None and arg in _PARSE_ARG:
@@ -263,7 +263,7 @@ def main():
     if args['--debug']:
         args['--verbose'] = True
         logging.basicConfig(level=logging.DEBUG, format='[%(levelname)s] %(name)s: %(message)s')
-        _LOGGER.debug('running %s', _gen_version())
+        _LOGGER.debug('running {}'.format(_gen_version()))
     elif args['--verbose']:
         logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     else:
@@ -326,20 +326,20 @@ def main():
             # each backend API returns a different subtype of OSError (OSError,
             # usb.core.USBError or PermissionError) for permission issues
             if err.errno in [errno.EACCES, errno.EPERM]:
-                log_error(err, f'Error: insufficient permissions to access {dev.description}')
+                log_error(err, 'Error: insufficient permissions to access {}'.format(dev.description))
             elif err.args == ('open failed', ):
-                log_error(err, f'Error: could not open {dev.description}, possibly due to insufficient permissions')
+                log_error(err, 'Error: could not open {}, possibly due to insufficient permissions'.format(dev.description))
             else:
-                log_error(err, f'Unexpected OS error with {dev.description}: {err}')
+                log_error(err, 'Unexpected OS error with {}: {}'.format(dev.description, err))
         except NotSupportedByDevice as err:
-            log_error(err, f'Error: operation not supported by {dev.description}')
+            log_error(err, 'Error: operation not supported by {}'.format(dev.description))
         except NotSupportedByDriver as err:
-            log_error(err, f'Error: operation not supported by driver for {dev.description}')
+            log_error(err, 'Error: operation not supported by driver for {}'.format(dev.description))
         except UnsafeFeaturesNotEnabled as err:
             features = ','.join(err.args)
-            log_error(err, f'Error: missing --unsafe features for {dev.description}: {features!r}')
+            log_error(err, 'Error: missing --unsafe features for {}: {!r}'.format(dev.description, features))
         except Exception as err:
-            log_error(err, f'Unexpected error with {dev.description}: {err}')
+            log_error(err, 'Unexpected error with {}: {}'.format(dev.description, err))
         finally:
             dev.disconnect(**opts)
 

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -102,7 +102,7 @@ _PARSE_ARG = {
     '--direction': str,
     '--start-led': int,
     '--maximum-leds': int,
-  
+
     '--single-12v-ocp': bool,
     '--pump-mode': str,
     '--legacy-690lc': bool,
@@ -134,7 +134,7 @@ _VALUE_FORMATS = {
     'W' : '.2f'
 }
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 def _list_devices(devices, using_filters=False, device_id=None, verbose=False, debug=False, **opts):
@@ -166,7 +166,7 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
             elif sys.platform in ['win32', 'cygwin'] and 'Hid' not in type(dev.device).__name__:
                 msg += ' (device possibly requires a kernel driver)'
             if debug:
-                LOGGER.exception(msg.capitalize())
+                _LOGGER.exception(msg.capitalize())
             else:
                 warnings.append(msg)
 
@@ -179,10 +179,10 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
         print(f'└── Driver: {type(dev).__name__}')
         if debug:
             driver_hier = [i.__name__ for i in inspect.getmro(type(dev)) if i != object]
-            LOGGER.debug('hierarchy: %s', ', '.join(driver_hier[1:]))
+            _LOGGER.debug('hierarchy: %s', ', '.join(driver_hier[1:]))
 
         for msg in warnings:
-            LOGGER.warning(msg)
+            _LOGGER.warning(msg)
         print('')
 
     assert not 'device' in opts or len(devices) <= 1, 'too many results listed with --device'
@@ -226,7 +226,7 @@ def _device_set_speed(dev, args, **opts):
 
 def _make_opts(args):
     if args['--hid']:
-        LOGGER.warning('Ignoring --hid %s: deprecated option, API will be selected automatically',
+        _LOGGER.warning('Ignoring --hid %s: deprecated option, API will be selected automatically',
                        args['--hid'])
     opts = {}
     for arg, val in args.items():
@@ -263,7 +263,7 @@ def main():
     if args['--debug']:
         args['--verbose'] = True
         logging.basicConfig(level=logging.DEBUG, format='[%(levelname)s] %(name)s: %(message)s')
-        LOGGER.debug('running %s', _gen_version())
+        _LOGGER.debug('running %s', _gen_version())
     elif args['--verbose']:
         logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     else:
@@ -287,7 +287,7 @@ def main():
             matched_devs = [dev.device for dev in find_liquidctl_devices(**opts)]
             if compat[device_id].device not in matched_devs:
                 raise SystemExit('Error: device ID does not match remaining selection criteria')
-            LOGGER.warning('mixing --device <id> with other filters is not recommended; '
+            _LOGGER.warning('mixing --device <id> with other filters is not recommended; '
                            'to disambiguate between results prefer --pick <result>')
         selected = [compat[device_id]]
 
@@ -305,11 +305,11 @@ def main():
     def log_error(err, msg, *args):
         nonlocal errors
         errors += 1
-        LOGGER.info('%s', err, exc_info=True)
-        LOGGER.error(msg, *args)
+        _LOGGER.info('%s', err, exc_info=True)
+        _LOGGER.error(msg, *args)
 
     for dev in selected:
-        LOGGER.debug('device: %s', dev.description)
+        _LOGGER.debug('device: %s', dev.description)
         try:
             dev.connect(**opts)
             if args['initialize']:
@@ -349,7 +349,7 @@ def main():
 
 def find_all_supported_devices(**opts):
     """Deprecated."""
-    LOGGER.warning('deprecated: use liquidctl.driver.find_liquidctl_devices instead')
+    _LOGGER.warning('deprecated: use liquidctl.driver.find_liquidctl_devices instead')
     return find_liquidctl_devices(**opts)
 
 

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -142,23 +142,23 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
         warnings = []
 
         if not using_filters:
-            print('Device ID {}: {}'.format(i, dev.description))
+            print(f'Device ID {i}: {dev.description}')
         elif device_id is not None:
-            print('Device ID {}: {}'.format(device_id, dev.description))
+            print(f'Device ID {device_id}: {dev.description}')
         else:
-            print('Result #{}: {}'.format(i, dev.description))
+            print(f'Result #{i}: {dev.description}')
         if not verbose:
             continue
 
         if dev.vendor_id:
-            print('├── Vendor ID: {:#06x}'.format(dev.vendor_id))
+            print(f'├── Vendor ID: {dev.vendor_id:#06x}')
         if dev.product_id:
-            print('├── Product ID: {:#06x}'.format(dev.product_id))
+            print(f'├── Product ID: {dev.product_id:#06x}')
         if dev.release_number:
-            print('├── Release number: {:#06x}'.format(dev.release_number))
+            print(f'├── Release number: {dev.release_number:#06x}')
         try:
             if dev.serial_number:
-                print('├── Serial number: {}'.format(dev.serial_number))
+                print(f'├── Serial number: {dev.serial_number}')
         except:
             msg = 'could not read the serial number'
             if sys.platform.startswith('linux') and os.geteuid:
@@ -170,13 +170,13 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
             else:
                 warnings.append(msg)
 
-        print('├── Bus: {}'.format(dev.bus))
-        print('├── Address: {}'.format(dev.address))
+        print(f'├── Bus: {dev.bus}')
+        print(f'├── Address: {dev.address}')
         if dev.port:
             port = '.'.join(map(str, dev.port))
-            print('├── Port: {}'.format(port))
+            print(f'├── Port: {port}')
 
-        print('└── Driver: {}'.format(type(dev).__name__))
+        print(f'└── Driver: {type(dev).__name__}')
         if debug:
             driver_hier = [i.__name__ for i in inspect.getmro(type(dev)) if i != object]
             _LOGGER.debug('hierarchy: %s', ', '.join(driver_hier[1:]))
@@ -200,14 +200,14 @@ def _print_dev_status(dev, status):
             u = ''
         else:
             valfmt = _VALUE_FORMATS.get(u, '')
-            v = '{:{valfmt}}'.format(v)
+            v = f'{v:{valfmt}}'
         kcols = max(kcols, len(k))
         vcols = max(vcols, len(v))
         tmp.append((k, v, u))
     for k, v, u in tmp[:-1]:
-        print('├── {:<{kcols}}    {:>{vcols}}  {}'.format(k, v, u))
+        print(f'├── {k:<{kcols}}    {v:>{vcols}}  {u}')
     k, v, u = tmp[-1]
-    print('└── {:<{kcols}}    {:>{vcols}}  {}'.format(k, v, u))
+    print(f'└── {k:<{kcols}}    {v:>{vcols}}  {u}')
     print('')
 
 
@@ -249,8 +249,8 @@ def _gen_version():
             if __extraversion__['dirty']:
                 extra[0] += '-dirty'
     except:
-        return 'liquidctl v{}'.format(__version__)
-    return 'liquidctl v{} ({})'.format(__version__, '; '.join(extra))
+        return f'liquidctl v{__version__}'
+    return f'liquidctl v{__version__} ({"; ".join(extra)})'
 
 
 def main():
@@ -326,20 +326,20 @@ def main():
             # each backend API returns a different subtype of OSError (OSError,
             # usb.core.USBError or PermissionError) for permission issues
             if err.errno in [errno.EACCES, errno.EPERM]:
-                log_error(err, 'Error: insufficient permissions to access {}'.format(dev.description))
+                log_error(err, f'Error: insufficient permissions to access {dev.description}')
             elif err.args == ('open failed', ):
-                log_error(err, 'Error: could not open {}, possibly due to insufficient permissions'.format(dev.description))
+                log_error(err, f'Error: could not open {dev.description}, possibly due to insufficient permissions')
             else:
-                log_error(err, 'Unexpected OS error with {}: {}'.format(dev.description, err))
+                log_error(err, 'Unexpected OS error with {dev.description}: {err}')
         except NotSupportedByDevice as err:
-            log_error(err, 'Error: operation not supported by {}'.format(dev.description))
+            log_error(err, f'Error: operation not supported by {dev.description}')
         except NotSupportedByDriver as err:
-            log_error(err, 'Error: operation not supported by driver for {}'.format(dev.description))
+            log_error(err, f'Error: operation not supported by driver for {dev.description}')
         except UnsafeFeaturesNotEnabled as err:
             features = ','.join(err.args)
-            log_error(err, 'Error: missing --unsafe features for {}: {!r}'.format(dev.description, features))
+            log_error(err, f'Error: missing --unsafe features for {dev.description}: {features!r}')
         except Exception as err:
-            log_error(err, 'Unexpected error with {}: {}'.format(dev.description, err))
+            log_error(err, f'Unexpected error with {dev.description}: {err}')
         finally:
             dev.disconnect(**opts)
 

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -185,7 +185,7 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
             _LOGGER.warning(msg)
         print('')
 
-    assert not 'device' in opts or len(devices) <= 1, 'too many results listed with --device'
+    assert 'device' not in opts or len(devices) <= 1, 'too many results listed with --device'
 
 
 def _print_dev_status(dev, status):

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -179,7 +179,7 @@ def _list_devices(devices, using_filters=False, device_id=None, verbose=False, d
         print('└── Driver: {}'.format(type(dev).__name__))
         if debug:
             driver_hier = [i.__name__ for i in inspect.getmro(type(dev)) if i != object]
-            _LOGGER.debug('hierarchy: {}'.format(', '.join(driver_hier[1:])))
+            _LOGGER.debug('hierarchy: %s', ', '.join(driver_hier[1:]))
 
         for msg in warnings:
             _LOGGER.warning(msg)
@@ -226,8 +226,8 @@ def _device_set_speed(dev, args, **opts):
 
 def _make_opts(args):
     if args['--hid']:
-        _LOGGER.warning('ignoring --hid {}: deprecated option, API will be selected automatically'
-                        .format(args['--hid']))
+        _LOGGER.warning('ignoring --hid %s: deprecated option, API will be selected automatically',
+                        args['--hid'])
     opts = {}
     for arg, val in args.items():
         if val is not None and arg in _PARSE_ARG:
@@ -263,7 +263,7 @@ def main():
     if args['--debug']:
         args['--verbose'] = True
         logging.basicConfig(level=logging.DEBUG, format='[%(levelname)s] %(name)s: %(message)s')
-        _LOGGER.debug('running {}'.format(_gen_version()))
+        _LOGGER.debug('running %s', _gen_version())
     elif args['--verbose']:
         logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
     else:

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -227,7 +227,7 @@ def _device_set_speed(dev, args, **opts):
 def _make_opts(args):
     if args['--hid']:
         _LOGGER.warning('ignoring --hid %s: deprecated option, API will be selected automatically',
-                       args['--hid'])
+                        args['--hid'])
     opts = {}
     for arg, val in args.items():
         if val is not None and arg in _PARSE_ARG:
@@ -288,7 +288,7 @@ def main():
             if compat[device_id].device not in matched_devs:
                 raise SystemExit('Error: device ID does not match remaining selection criteria')
             _LOGGER.warning('mixing --device <id> with other filters is not recommended; '
-                           'to disambiguate between results prefer --pick <result>')
+                            'to disambiguate between results prefer --pick <result>')
         selected = [compat[device_id]]
 
     if args['list']:

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -226,7 +226,7 @@ def _device_set_speed(dev, args, **opts):
 
 def _make_opts(args):
     if args['--hid']:
-        _LOGGER.warning('Ignoring --hid %s: deprecated option, API will be selected automatically',
+        _LOGGER.warning('ignoring --hid %s: deprecated option, API will be selected automatically',
                        args['--hid'])
     opts = {}
     for arg, val in args.items():

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -54,7 +54,7 @@ def find_liquidctl_devices(pick=None, **kwargs):
                    key=lambda x: (x.__module__, x.__name__))
     num = 0
     for bus_cls in buses:
-        for dev in  bus_cls().find_devices(**kwargs):
+        for dev in bus_cls().find_devices(**kwargs):
             if pick is not None:
                 if num == pick:
                     yield dev

--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -79,7 +79,7 @@ class _CommonAsetekDriver(UsbDriver):
 
     def _configure_flow_control(self, clear_to_send):
         """Set the software clear-to-send flow control policy for device."""
-        _LOGGER.debug('set clear to send = %s', clear_to_send)
+        _LOGGER.debug('set clear to send = {}'.format(clear_to_send))
         if clear_to_send:
             self.device.ctrl_transfer(_USBXPRESS, _USBXPRESS_REQUEST, _USBXPRESS_CLEAR_TO_SEND)
         else:
@@ -132,7 +132,7 @@ class _CommonAsetekDriver(UsbDriver):
             # somewhere, and would need another call to initialize() to clear
             # that up.  Padding with (CRIT, 100%) appears to avoid all issues,
             # at least within the reasonable range of operating temperatures.
-            _LOGGER.info('filling missing %i PWM points with (60°C, 100%%)', missing)
+            _LOGGER.info('filling missing {} PWM points with (60°C, 100%)'.format(missing))
             opt = opt + [(_CRITICAL_TEMPERATURE, 100)]*missing
         return opt
 
@@ -267,8 +267,8 @@ class Modern690Lc(_CommonAsetekDriver):
         mtype, dmin, dmax = _VARIABLE_SPEED_CHANNELS[channel]
         adjusted = self._prepare_profile(profile, dmin, dmax)
         for temp, duty in adjusted:
-            _LOGGER.info('setting %s PWM point: (%i°C, %i%%), device interpolated',
-                         channel, temp, duty)
+            _LOGGER.info('setting {} PWM point: ({}°C, {}%), device interpolated'.format(
+                         channel, temp, duty))
         temps, duties = map(list, zip(*adjusted))
         self._begin_transaction()
         self._write([mtype, 0] + temps + duties)
@@ -283,7 +283,7 @@ class Modern690Lc(_CommonAsetekDriver):
             # Note for a future self: the conflict can be cleared with
             # *another* call to initialize(), i.e.  with another
             # configuration command.
-            _LOGGER.info('using a flat profile to set %s to a fixed duty', channel)
+            _LOGGER.info('using a flat profile to set {} to a fixed duty'.format(channel))
             self.set_speed_profile(channel, [(0, duty), (_CRITICAL_TEMPERATURE - 1, duty)])
             return
         mtype, dmin, dmax = _FIXED_SPEED_CHANNELS[channel]
@@ -291,7 +291,7 @@ class Modern690Lc(_CommonAsetekDriver):
         total_levels = _MAX_PUMP_SPEED_CODE - _MIN_PUMP_SPEED_CODE + 1
         level = round((duty - dmin)/(dmax - dmin)*total_levels)
         effective_duty = round(dmin + level*(dmax - dmin)/total_levels)
-        _LOGGER.info('setting %s PWM duty to %i%% (level %i)', channel, effective_duty, level)
+        _LOGGER.info('setting {} PWM duty to {}% (level {})'.format(channel, effective_duty, level))
         self._begin_transaction()
         self._write([mtype, _MIN_PUMP_SPEED_CODE + level])
         self._end_transaction_and_read()
@@ -327,7 +327,7 @@ class Legacy690Lc(_CommonAsetekDriver):
         for channel in ['pump', 'fan']:
             mtype, dmin, dmax = _LEGACY_FIXED_SPEED_CHANNELS[channel]
             duty = clamp(self._data.load_int('{}_duty'.format(channel), default=dmax), dmin, dmax)
-            _LOGGER.info('setting %s duty to %i%%', channel, duty)
+            _LOGGER.info('setting {} duty to {}%'.format(channel, duty))
             self._write([mtype, duty])
         return self._end_transaction_and_read()
 

--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -268,7 +268,7 @@ class Modern690Lc(_CommonAsetekDriver):
         adjusted = self._prepare_profile(profile, dmin, dmax)
         for temp, duty in adjusted:
             _LOGGER.info('setting %s PWM point: (%i°C, %i%%), device interpolated',
-                        channel, temp, duty)
+                         channel, temp, duty)
         temps, duties = map(list, zip(*adjusted))
         self._begin_transaction()
         self._write([mtype, 0] + temps + duties)

--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -39,7 +39,7 @@ _CMD_EXTERNAL_TEMPERATURE = 0x22
 _FIXED_SPEED_CHANNELS = {    # (message type, minimum duty, maximum duty)
     'pump':  (_CMD_PUMP_PWM, 50, 100),  # min/max must correspond to _MIN/MAX_PUMP_SPEED_CODE
 }
-_VARIABLE_SPEED_CHANNELS = { # (message type, minimum duty, maximum duty)
+_VARIABLE_SPEED_CHANNELS = {  # (message type, minimum duty, maximum duty)
     'fan':   (_CMD_PROFILE, 0, 100)
 }
 _MAX_PROFILE_POINTS = 6

--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -121,7 +121,7 @@ class _CommonAsetekDriver(UsbDriver):
         if size < 1:
             raise ValueError('At least one PWM point required')
         elif size > _MAX_PROFILE_POINTS:
-            raise ValueError('Too many PWM points ({}), only 6 supported'.format(size))
+            raise ValueError(f'Too many PWM points ({size}), only 6 supported')
         for i, (temp, duty) in enumerate(opt):
             opt[i] = (temp, clamp(duty, min_duty, max_duty))
         missing = _MAX_PROFILE_POINTS - size
@@ -259,7 +259,7 @@ class Modern690Lc(_CommonAsetekDriver):
             self._configure_device(blackout=True, alert_temp=clamp(alert_threshold, 0, 100),
                                    color3=alert_color)
         else:
-            raise KeyError('Unknown lighting mode {}'.format(mode))
+            raise KeyError(f'Unknown lighting mode {mode}')
         self._end_transaction_and_read()
 
     def set_speed_profile(self, channel, profile, **kwargs):
@@ -318,15 +318,15 @@ class Legacy690Lc(_CommonAsetekDriver):
 
     def connect(self, **kwargs):
         super().connect(**kwargs)
-        ids = 'vid{:04x}_pid{:04x}'.format(self.vendor_id, self.product_id)
-        loc = 'bus{}_port{}'.format(self.bus, '_'.join(map(str, self.port)))
+        ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
+        loc = f'bus{self.bus}_port{"_".join(map(str, self.port))}'
         self._data = RuntimeStorage(key_prefixes=[ids, loc, 'legacy'])
 
     def _set_all_fixed_speeds(self):
         self._begin_transaction()
         for channel in ['pump', 'fan']:
             mtype, dmin, dmax = _LEGACY_FIXED_SPEED_CHANNELS[channel]
-            duty = clamp(self._data.load_int('{}_duty'.format(channel), default=dmax), dmin, dmax)
+            duty = clamp(self._data.load_int(f'{channel}_duty', default=dmax), dmin, dmax)
             _LOGGER.info('setting %s duty to %i%%', channel, duty)
             self._write([mtype, duty])
         return self._end_transaction_and_read()
@@ -381,14 +381,14 @@ class Legacy690Lc(_CommonAsetekDriver):
             self._configure_device(blackout=True, alert_temp=clamp(alert_threshold, 0, 100),
                                    color3=alert_color)
         else:
-            raise KeyError('Unsupported lighting mode {}'.format(mode))
+            raise KeyError(f'Unsupported lighting mode {mode}')
         self._end_transaction_and_read()
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         """Set channel to a fixed speed duty."""
         mtype, dmin, dmax = _LEGACY_FIXED_SPEED_CHANNELS[channel]
         duty = clamp(duty, dmin, dmax)
-        self._data.store_int('{}_duty'.format(channel), duty)
+        self._data.store_int(f'{channel}_duty', duty)
         self._set_all_fixed_speeds()
 
     def set_speed_profile(self, channel, profile, **kwargs):
@@ -417,7 +417,7 @@ class Hydro690Lc(Modern690Lc):
     def set_color(self, channel, mode, colors, **kwargs):
         """Set the color mode for a specific channel."""
         if mode == 'rainbow':
-            raise KeyError('Unsupported lighting mode {}'.format(mode))
+            raise KeyError(f'Unsupported lighting mode {mode}')
         super().set_color(channel, mode, colors, **kwargs)
 
 

--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -79,7 +79,7 @@ class _CommonAsetekDriver(UsbDriver):
 
     def _configure_flow_control(self, clear_to_send):
         """Set the software clear-to-send flow control policy for device."""
-        _LOGGER.debug('set clear to send = {}'.format(clear_to_send))
+        _LOGGER.debug('set clear to send = %s', clear_to_send)
         if clear_to_send:
             self.device.ctrl_transfer(_USBXPRESS, _USBXPRESS_REQUEST, _USBXPRESS_CLEAR_TO_SEND)
         else:
@@ -132,7 +132,7 @@ class _CommonAsetekDriver(UsbDriver):
             # somewhere, and would need another call to initialize() to clear
             # that up.  Padding with (CRIT, 100%) appears to avoid all issues,
             # at least within the reasonable range of operating temperatures.
-            _LOGGER.info('filling missing {} PWM points with (60°C, 100%)'.format(missing))
+            _LOGGER.info('filling missing %i PWM points with (60°C, 100%%)', missing)
             opt = opt + [(_CRITICAL_TEMPERATURE, 100)]*missing
         return opt
 
@@ -267,8 +267,8 @@ class Modern690Lc(_CommonAsetekDriver):
         mtype, dmin, dmax = _VARIABLE_SPEED_CHANNELS[channel]
         adjusted = self._prepare_profile(profile, dmin, dmax)
         for temp, duty in adjusted:
-            _LOGGER.info('setting {} PWM point: ({}°C, {}%), device interpolated'.format(
-                         channel, temp, duty))
+            _LOGGER.info('setting %i PWM point: (%i°C, %i%%), device interpolated',
+                         channel, temp, duty)
         temps, duties = map(list, zip(*adjusted))
         self._begin_transaction()
         self._write([mtype, 0] + temps + duties)
@@ -283,7 +283,7 @@ class Modern690Lc(_CommonAsetekDriver):
             # Note for a future self: the conflict can be cleared with
             # *another* call to initialize(), i.e.  with another
             # configuration command.
-            _LOGGER.info('using a flat profile to set {} to a fixed duty'.format(channel))
+            _LOGGER.info('using a flat profile to set %s to a fixed duty', channel)
             self.set_speed_profile(channel, [(0, duty), (_CRITICAL_TEMPERATURE - 1, duty)])
             return
         mtype, dmin, dmax = _FIXED_SPEED_CHANNELS[channel]
@@ -291,7 +291,7 @@ class Modern690Lc(_CommonAsetekDriver):
         total_levels = _MAX_PUMP_SPEED_CODE - _MIN_PUMP_SPEED_CODE + 1
         level = round((duty - dmin)/(dmax - dmin)*total_levels)
         effective_duty = round(dmin + level*(dmax - dmin)/total_levels)
-        _LOGGER.info('setting {} PWM duty to {}% (level {})'.format(channel, effective_duty, level))
+        _LOGGER.info('setting %s PWM duty to %i%% (level %i)', channel, effective_duty, level)
         self._begin_transaction()
         self._write([mtype, _MIN_PUMP_SPEED_CODE + level])
         self._end_transaction_and_read()
@@ -327,7 +327,7 @@ class Legacy690Lc(_CommonAsetekDriver):
         for channel in ['pump', 'fan']:
             mtype, dmin, dmax = _LEGACY_FIXED_SPEED_CHANNELS[channel]
             duty = clamp(self._data.load_int('{}_duty'.format(channel), default=dmax), dmin, dmax)
-            _LOGGER.info('setting {} duty to {}%'.format(channel, duty))
+            _LOGGER.info('setting %s duty to %i%%', channel, duty)
             self._write([mtype, duty])
         return self._end_transaction_and_read()
 

--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -68,7 +68,7 @@ _USBXPRESS_GET_PART_NUM = 0x08
 
 # Unknown control parameters; from Craig's libSiUSBXp and OpenCorsairLink
 _UNKNOWN_OPEN_REQUEST = 0x00
-_UNKNOWN_OPEN_VALUE = 0xFFFF
+_UNKNOWN_OPEN_VALUE = 0xffff
 
 # Control request type
 _USBXPRESS = usb.util.CTRL_OUT | usb.util.CTRL_TYPE_VENDOR | usb.util.CTRL_RECIPIENT_DEVICE

--- a/liquidctl/driver/base.py
+++ b/liquidctl/driver/base.py
@@ -4,6 +4,7 @@ Copyright (C) 2018–2019  Jonas Malaco and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+
 class BaseDriver:
     """Base driver API.
 

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -478,14 +478,14 @@ class CommanderPro(UsbHidDriver):
 
         for effect in saved_effects:
             config = [effect.get('channel'),
-                       effect.get('start_led'),
-                       effect.get('num_leds'),
-                       effect.get('mode'),
-                       effect.get('speed'),
-                       effect.get('direction'),
-                       effect.get('random_colors'),
-                       0xff
-                    ] + effect.get('colors')
+                      effect.get('start_led'),
+                      effect.get('num_leds'),
+                      effect.get('mode'),
+                      effect.get('speed'),
+                      effect.get('direction'),
+                      effect.get('random_colors'),
+                      0xff
+                     ] + effect.get('colors')
             self._send_command(_CMD_LED_EFFECT, config);
 
         self._send_command(_CMD_LED_COMMIT, [0xff]);

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -83,6 +83,7 @@ _MODES = {
     'rainbow2': 0x0a,
 }
 
+
 def _prepare_profile(original, critcalTempature):
     clamped = ((temp, clamp(duty, 0, _MAX_FAN_RPM)) for temp, duty in original)
     normal = normalize_profile(clamped, critcalTempature, _MAX_FAN_RPM)
@@ -93,8 +94,10 @@ def _prepare_profile(original, critcalTempature):
         normal += missing * [(critcalTempature, _MAX_FAN_RPM)]
     return normal
 
+
 def _quoted(*names):
     return ', '.join(map(repr, names))
+
 
 def _get_fan_mode_description(mode):
     """This will convert the fan mode value to a descriptive name.
@@ -108,6 +111,7 @@ def _get_fan_mode_description(mode):
         return 'PWM'
     else:
         return 'UNKNOWN'
+
 
 class CommanderPro(UsbHidDriver):
     """Corsair Commander Pro LED and fan hub"""

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -498,7 +498,7 @@ class CommanderPro(UsbHidDriver):
 
         if data:
             data = data[:_REPORT_LENGTH-1]
-            buf[start_at : start_at + len(data)] = data
+            buf[start_at: start_at + len(data)] = data
 
         self.device.clear_enqueued_reports()
         self.device.write(buf)

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -89,7 +89,7 @@ def _prepare_profile(original, critcalTempature):
     normal = normalize_profile(clamped, critcalTempature, _MAX_FAN_RPM)
     missing = _PROFILE_LENGTH - len(normal)
     if missing < 0:
-        raise ValueError('too many points in profile (remove {})'.format(-missing))
+        raise ValueError(f'too many points in profile (remove {-missing})')
     if missing > 0:
         normal += missing * [(critcalTempature, _MAX_FAN_RPM)]
     return normal
@@ -136,7 +136,7 @@ class CommanderPro(UsbHidDriver):
     def connect(self, **kwargs):
         """Connect to the device."""
         super().connect(**kwargs)
-        ids = 'vid{:04x}_pid{:04x}'.format(self.vendor_id, self.product_id)
+        ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
         # must use the HID path because there is no serial number; however,
         # these can be quite long on Windows and macOS, so only take the
         # numbers, since they are likely the only parts that vary between two
@@ -233,10 +233,10 @@ class CommanderPro(UsbHidDriver):
         ]
 
         for temp_num in range(self._temp_probs):
-            status += [('Temp sensor {}'.format(temp_num + 1), temp[temp_num], '°C')]
+            status += [(f'Temp sensor {temp_num + 1}', temp[temp_num], '°C')]
 
         for fan_num in range(self._fan_count):
-            status += [('Fan {} speed'.format(fan_num + 1), fanspeeds[fan_num], 'rpm')]
+            status += [(f'Fan {fan_num + 1} speed', fanspeeds[fan_num], 'rpm')]
 
         return status
 
@@ -250,7 +250,7 @@ class CommanderPro(UsbHidDriver):
             raise ValueError('this device does not have a tempature sensor')
 
         if sensor_num < 0 or sensor_num > 3:
-            raise ValueError('sensor_num {} invalid, must be between 0 and 3'.format(sensor_num))
+            raise ValueError(f'sensor_num {sensor_num} invalid, must be between 0 and 3')
 
         res = self._send_command(_CMD_GET_TEMP, [sensor_num])
         temp = u16be_from(res, offset=1) / 100
@@ -267,7 +267,7 @@ class CommanderPro(UsbHidDriver):
             raise ValueError('this device does not have any fans')
 
         if fan_num < 0 or fan_num > 5:
-            raise ValueError('fan_num {} invalid, must be between 0 and 5'.format(fan_num))
+            raise ValueError(f'fan_num {fan_num} invalid, must be between 0 and 5')
 
         res = self._send_command(_CMD_GET_FAN_RPM, [fan_num])
         speed = u16be_from(res, offset=1)
@@ -284,7 +284,7 @@ class CommanderPro(UsbHidDriver):
         elif channel in self._fan_names:
             return [self._fan_names.index(channel)]
         else:
-            raise ValueError('unknown channel, should be one of: {}'.format(_quoted('sync', *self._fan_names)))
+            raise ValueError(f'unknown channel, should be one of: {_quoted("sync", *self._fan_names)}')
 
     def _get_hw_led_channels(self, channel):
         """This will get a list of all the led channels that the command should be sent to
@@ -296,7 +296,7 @@ class CommanderPro(UsbHidDriver):
         elif channel in self._led_names:
             return [self._led_names.index(channel)]
         else:
-            raise ValueError('unknown channel, should be one of: {}'.format(_quoted('led', *self._led_names)))
+            raise ValueError(f'unknown channel, should be one of: {_quoted("led", *self._led_names)}')
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         """Set fan or fans to a fixed speed duty.
@@ -447,7 +447,7 @@ class CommanderPro(UsbHidDriver):
         mode = _MODES.get(mode, -1)
 
         if mode == -1:
-            raise ValueError('mode "{}" is not valid'.format(mode_str))
+            raise ValueError(f'mode "{mode_str}" is not valid')
 
         lighting_effect = {
                 'channel': led_channel,

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -357,7 +357,7 @@ class CommanderPro(UsbHidDriver):
             raise ValueError('the specified tempature sensor is not connected')
 
         buf = bytearray(26)
-        buf[1] = temp_sensor-1 # 0  # use temp sensor 1
+        buf[1] = temp_sensor-1  # 0  # use temp sensor 1
 
         for i, entry in enumerate(profile):
             temp = entry[0]*100
@@ -444,7 +444,7 @@ class CommanderPro(UsbHidDriver):
         direction = _LED_DIRECTION_FORWARD if direction == 'forward' else _LED_DIRECTION_BACKWARD
         speed = _LED_SPEED_SLOW if speed == 'slow' else _LED_SPEED_FAST if speed == 'fast' else _LED_SPEED_MEDIUM
         start_led = clamp(start_led, 1, 96) - 1
-        num_leds = clamp(maximum_leds, 1, 96-start_led-1) # there is a current firmware limitation of 96 led's per channel
+        num_leds = clamp(maximum_leds, 1, 96-start_led-1)  # there is a current firmware limitation of 96 led's per channel
         random_colors = 0x00 if mode_str == 'off' or len(colors) != 0 else 0x01
         mode = _MODES.get(mode, -1)
 

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -89,7 +89,7 @@ def _prepare_profile(original, critcalTempature):
     normal = normalize_profile(clamped, critcalTempature, _MAX_FAN_RPM)
     missing = _PROFILE_LENGTH - len(normal)
     if missing < 0:
-        raise ValueError(f'too many points in profile (remove {-missing})')
+        raise ValueError('too many points in profile (remove {})'.format(-missing))
     if missing > 0:
         normal += missing * [(critcalTempature, _MAX_FAN_RPM)]
     return normal
@@ -136,7 +136,7 @@ class CommanderPro(UsbHidDriver):
     def connect(self, **kwargs):
         """Connect to the device."""
         super().connect(**kwargs)
-        ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
+        ids = 'vid{:04x}_pid{:04x}'.format(self.vendor_id, self.product_id)
         # must use the HID path because there is no serial number; however,
         # these can be quite long on Windows and macOS, so only take the
         # numbers, since they are likely the only parts that vary between two
@@ -160,8 +160,8 @@ class CommanderPro(UsbHidDriver):
         bootloader_version = (res[1], res[2])               # is it possible for there to be a third value?
 
         status = [
-            ('Firmware version', '%d.%d.%d' % fw_version, ''),
-            ('Bootloader version', '%d.%d' % bootloader_version, ''),
+            ('Firmware version', '{}.{}.{}'.format(*fw_version), ''),
+            ('Bootloader version', '{}.{}'.format(*bootloader_version), ''),
         ]
 
         if self._temp_probs > 0:
@@ -233,10 +233,10 @@ class CommanderPro(UsbHidDriver):
         ]
 
         for temp_num in range(self._temp_probs):
-            status += [(f'Temp sensor {temp_num + 1}', temp[temp_num], '°C')]
+            status += [('Temp sensor {}'.format(temp_num + 1), temp[temp_num], '°C')]
 
         for fan_num in range(self._fan_count):
-            status += [(f'Fan {fan_num + 1} speed', fanspeeds[fan_num], 'rpm')]
+            status += [('Fan {} speed'.format(fan_num + 1), fanspeeds[fan_num], 'rpm')]
 
         return status
 
@@ -250,7 +250,7 @@ class CommanderPro(UsbHidDriver):
             raise ValueError('this device does not have a tempature sensor')
 
         if sensor_num < 0 or sensor_num > 3:
-            raise ValueError(f'sensor_num {sensor_num} invalid, must be between 0 and 3')
+            raise ValueError('sensor_num {} invalid, must be between 0 and 3'.format(sensor_num))
 
         res = self._send_command(_CMD_GET_TEMP, [sensor_num])
         temp = u16be_from(res, offset=1) / 100
@@ -267,7 +267,7 @@ class CommanderPro(UsbHidDriver):
             raise ValueError('this device does not have any fans')
 
         if fan_num < 0 or fan_num > 5:
-            raise ValueError(f'fan_num {fan_num} invalid, must be between 0 and 5')
+            raise ValueError('fan_num {} invalid, must be between 0 and 5'.format(fan_num))
 
         res = self._send_command(_CMD_GET_FAN_RPM, [fan_num])
         speed = u16be_from(res, offset=1)
@@ -284,7 +284,7 @@ class CommanderPro(UsbHidDriver):
         elif channel in self._fan_names:
             return [self._fan_names.index(channel)]
         else:
-            raise ValueError(f'unknown channel, should be one of: {_quoted("sync", *self._fan_names)}')
+            raise ValueError('unknown channel, should be one of: {}'.format(_quoted('sync', *self._fan_names)))
 
     def _get_hw_led_channels(self, channel):
         """This will get a list of all the led channels that the command should be sent to
@@ -296,7 +296,7 @@ class CommanderPro(UsbHidDriver):
         elif channel in self._led_names:
             return [self._led_names.index(channel)]
         else:
-            raise ValueError(f'unknown channel, should be one of: {_quoted("led", *self._led_names)}')
+            raise ValueError('unknown channel, should be one of: {}'.format(_quoted('led', *self._led_names)))
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         """Set fan or fans to a fixed speed duty.
@@ -447,7 +447,7 @@ class CommanderPro(UsbHidDriver):
         mode = _MODES.get(mode, -1)
 
         if mode == -1:
-            raise ValueError(f'mode "{mode_str}" is not valid')
+            raise ValueError('mode "{}" is not valid'.format(mode_str))
 
         lighting_effect = {
                 'channel': led_channel,

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -478,13 +478,14 @@ class CommanderPro(UsbHidDriver):
 
         for effect in saved_effects:
             config = [ effect.get('channel'),
-                effect.get('start_led'),
-                effect.get('num_leds'),
-                effect.get('mode'),
-                effect.get('speed'),
-                effect.get('direction'),
-                effect.get('random_colors'),
-                0xff] + effect.get('colors')
+                       effect.get('start_led'),
+                       effect.get('num_leds'),
+                       effect.get('mode'),
+                       effect.get('speed'),
+                       effect.get('direction'),
+                       effect.get('random_colors'),
+                       0xff
+                    ] + effect.get('colors')
             self._send_command(_CMD_LED_EFFECT, config);
 
         self._send_command(_CMD_LED_COMMIT, [0xff]);

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -75,7 +75,7 @@ _MODES = {
     'color_pulse': 0x02,
     'color_wave': 0x03,
     'fixed': 0x04,
-    #'tempature': 0x05,    # ignore this
+    # 'tempature': 0x05,    # ignore this
     'visor': 0x06,
     'marquee': 0x07,
     'blink': 0x08,
@@ -159,7 +159,6 @@ class CommanderPro(UsbHidDriver):
         res = self._send_command(_CMD_GET_BOOTLOADER)
         bootloader_version = (res[1], res[2])               # is it possible for there to be a third value?
 
-
         status = [
             ('Firmware version', '%d.%d.%d' % fw_version, ''),
             ('Bootloader version', '%d.%d' % bootloader_version, ''),
@@ -221,13 +220,11 @@ class CommanderPro(UsbHidDriver):
         res = self._send_command(_CMD_GET_VOLTS, [2])
         volt_3 = u16be_from(res, offset=1) / 1000
 
-
         # get fan RPMs of connected fans
         fanspeeds = [0]*self._fan_count
         for fan_num, mode in enumerate(fan_modes):
             if mode == _FAN_MODE_DC or mode == _FAN_MODE_PWM:
                 fanspeeds[fan_num] = self._get_fan_rpm(fan_num)
-
 
         status = [
             ('12 volt rail', volt_12, 'V'),
@@ -250,11 +247,10 @@ class CommanderPro(UsbHidDriver):
         """
 
         if self._temp_probs == 0:
-            raise ValueError(f'this device does not have a tempature sensor')
+            raise ValueError('this device does not have a tempature sensor')
 
         if sensor_num < 0 or sensor_num > 3:
             raise ValueError(f'sensor_num {sensor_num} invalid, must be between 0 and 3')
-
 
         res = self._send_command(_CMD_GET_TEMP, [sensor_num])
         temp = u16be_from(res, offset=1) / 100
@@ -268,7 +264,7 @@ class CommanderPro(UsbHidDriver):
         """
 
         if self._fan_count == 0:
-            raise ValueError(f'this device does not have any fans')
+            raise ValueError('this device does not have any fans')
 
         if fan_num < 0 or fan_num > 5:
             raise ValueError(f'fan_num {fan_num} invalid, must be between 0 and 5')
@@ -365,15 +361,13 @@ class CommanderPro(UsbHidDriver):
 
         for i, entry in enumerate(profile):
             temp = entry[0]*100
-            rpm  = entry[1]
+            rpm = entry[1]
 
             # convert both values to 2 byte big endian values
             buf[2 + i*2] = temp.to_bytes(2, byteorder='big')[0]
             buf[3 + i*2] = temp.to_bytes(2, byteorder='big')[1]
             buf[14 + i*2] = rpm.to_bytes(2, byteorder='big')[0]
             buf[15 + i*2] = rpm.to_bytes(2, byteorder='big')[1]
-
-
 
         fan_channels = self._get_hw_fan_channels(channel)
         fan_modes = self._data.load('fan_modes', default=[0]*self._fan_count)
@@ -472,9 +466,9 @@ class CommanderPro(UsbHidDriver):
         self._data.store('saved_effects', None if mode_str == 'off' else saved_effects)
 
         # start sending the led commands
-        self._send_command(_CMD_RESET_LED_CHANNEL, [led_channel]);
-        self._send_command(_CMD_BEGIN_LED_EFFECT, [led_channel]);
-        self._send_command(_CMD_SET_LED_CHANNEL_STATE, [led_channel, 0x01]);
+        self._send_command(_CMD_RESET_LED_CHANNEL, [led_channel])
+        self._send_command(_CMD_BEGIN_LED_EFFECT, [led_channel])
+        self._send_command(_CMD_SET_LED_CHANNEL_STATE, [led_channel, 0x01])
 
         for effect in saved_effects:
             config = [effect.get('channel'),
@@ -485,10 +479,10 @@ class CommanderPro(UsbHidDriver):
                       effect.get('direction'),
                       effect.get('random_colors'),
                       0xff
-                     ] + effect.get('colors')
-            self._send_command(_CMD_LED_EFFECT, config);
+                      ] + effect.get('colors')
+            self._send_command(_CMD_LED_EFFECT, config)
 
-        self._send_command(_CMD_LED_COMMIT, [0xff]);
+        self._send_command(_CMD_LED_COMMIT, [0xff])
 
     def _send_command(self, command, data=None):
         # self.device.write expects buf[0] to be the report number or 0 if not used

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -321,7 +321,7 @@ class CommanderPro(UsbHidDriver):
         for fan in fan_channels:
             mode = fan_modes[fan]
             if mode == _FAN_MODE_DC or mode == _FAN_MODE_PWM:
-                self._send_command(_CMD_SET_FAN_DUTY,[fan, duty])
+                self._send_command(_CMD_SET_FAN_DUTY, [fan, duty])
 
     def set_speed_profile(self, channel, profile, temperature_sensor=1, **kwargs):
         """Set fan or fans to follow a speed duty profile.
@@ -359,7 +359,7 @@ class CommanderPro(UsbHidDriver):
         buf = bytearray(26)
         buf[1] = temp_sensor-1 # 0  # use temp sensor 1
 
-        for i,entry in enumerate(profile):
+        for i, entry in enumerate(profile):
             temp = entry[0]*100
             rpm  = entry[1]
 

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -467,7 +467,7 @@ class CommanderPro(UsbHidDriver):
             }
 
         saved_effects = [] if mode_str == 'off' else self._data.load('saved_effects', default=[])
-        saved_effects += [ lighting_effect ]
+        saved_effects += [lighting_effect]
 
         self._data.store('saved_effects', None if mode_str == 'off' else saved_effects)
 
@@ -477,7 +477,7 @@ class CommanderPro(UsbHidDriver):
         self._send_command(_CMD_SET_LED_CHANNEL_STATE, [led_channel, 0x01]);
 
         for effect in saved_effects:
-            config = [ effect.get('channel'),
+            config = [effect.get('channel'),
                        effect.get('start_led'),
                        effect.get('num_leds'),
                        effect.get('mode'),

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -27,7 +27,7 @@ from liquidctl.pmbus import compute_pec
 from liquidctl.util import clamp, fraction_of_byte, u16be_from, u16le_from, normalize_profile, check_unsafe
 from liquidctl.error import NotSupportedByDevice
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 _REPORT_LENGTH = 64
 _RESPONSE_LENGTH = 16
@@ -195,7 +195,7 @@ class CommanderPro(UsbHidDriver):
         """
 
         if self.device.product_id != 0x0c10:
-            LOGGER.debug('only the commander pro supports this')
+            _LOGGER.debug('only the commander pro supports this')
             return []
 
         connected_temp_sensors = self._data.load('temp_sensors_connected', default=[0]*self._temp_probs)

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -80,7 +80,7 @@ _MODES = {
     'marquee': 0x07,
     'blink': 0x08,
     'sequential': 0x09,
-    'rainbow2': 0x0A,
+    'rainbow2': 0x0a,
 }
 
 def _prepare_profile(original, critcalTempature):
@@ -113,9 +113,9 @@ class CommanderPro(UsbHidDriver):
     """Corsair Commander Pro LED and fan hub"""
 
     SUPPORTED_DEVICES = [
-        (0x1B1C, 0x0C10, None, 'Corsair Commander Pro (experimental)',
+        (0x1b1c, 0x0c10, None, 'Corsair Commander Pro (experimental)',
             {'fan_count': 6, 'temp_probs': 4, 'led_channels': 2}),
-        (0x1B1C, 0x0C0B, None, 'Corsair Lighting Node Pro (experimental)',
+        (0x1b1c, 0x0c0b, None, 'Corsair Lighting Node Pro (experimental)',
             {'fan_count': 0, 'temp_probs': 0, 'led_channels': 2}),
     ]
 

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -92,7 +92,7 @@ class CorsairHidPsu(UsbHidDriver):
         mode = OCPMode.SINGLE_RAIL if single_12v_ocp else OCPMode.MULTI_RAIL
         if mode != self._get_12v_ocp_mode():
             # TODO replace log level with info once this has been confimed to work
-            _LOGGER.warning('(experimental feature) changing +12V OCP mode to {}'.format(mode))
+            _LOGGER.warning('(experimental feature) changing +12V OCP mode to %s', mode)
             self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, [mode.value])
         if self._get_fan_control_mode() != FanControlMode.HARDWARE:
             _LOGGER.info('resetting fan control to hardware mode')
@@ -134,7 +134,7 @@ class CorsairHidPsu(UsbHidDriver):
         duty = clamp(duty, _MIN_FAN_DUTY, 100)
         _LOGGER.info('ensuring fan control is in software mode')
         self._set_fan_control_mode(FanControlMode.SOFTWARE)
-        _LOGGER.info('setting fan PWM duty to {}%'.format(duty))
+        _LOGGER.info('setting fan PWM duty to %i%%', duty)
         self._exec(WriteBit.WRITE, CMD.FAN_COMMAND_1, [duty])
 
     def set_color(self, channel, mode, colors, **kwargs):

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -122,9 +122,9 @@ class CorsairHidPsu(UsbHidDriver):
         for rail in [_RAIL_12V, _RAIL_5V, _RAIL_3P3V]:
             name = _RAIL_NAMES[rail]
             self._exec(WriteBit.WRITE, CMD.PAGE, [rail])
-            status.append(('{} output voltage'.format(name), self._get_float(CMD.READ_VOUT), 'V'))
-            status.append(('{} output current'.format(name), self._get_float(CMD.READ_IOUT), 'A'))
-            status.append(('{} output power'.format(name), self._get_float(CMD.READ_POUT), 'W'))
+            status.append((f'{name} output voltage', self._get_float(CMD.READ_VOUT), 'V'))
+            status.append((f'{name} output current', self._get_float(CMD.READ_IOUT), 'A'))
+            status.append((f'{name} output power', self._get_float(CMD.READ_POUT), 'W'))
         self._exec(WriteBit.WRITE, CMD.PAGE, [0])
         _LOGGER.warning('reading the +12V OCP mode is an experimental feature')
         return status

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -92,7 +92,7 @@ class CorsairHidPsu(UsbHidDriver):
         mode = OCPMode.SINGLE_RAIL if single_12v_ocp else OCPMode.MULTI_RAIL
         if mode != self._get_12v_ocp_mode():
             # TODO replace log level with info once this has been confimed to work
-            _LOGGER.warning('(experimental feature) changing +12V OCP mode to %s', mode)
+            _LOGGER.warning('(experimental feature) changing +12V OCP mode to {}'.format(mode))
             self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, [mode.value])
         if self._get_fan_control_mode() != FanControlMode.HARDWARE:
             _LOGGER.info('resetting fan control to hardware mode')
@@ -122,9 +122,9 @@ class CorsairHidPsu(UsbHidDriver):
         for rail in [_RAIL_12V, _RAIL_5V, _RAIL_3P3V]:
             name = _RAIL_NAMES[rail]
             self._exec(WriteBit.WRITE, CMD.PAGE, [rail])
-            status.append((f'{name} output voltage', self._get_float(CMD.READ_VOUT), 'V'))
-            status.append((f'{name} output current', self._get_float(CMD.READ_IOUT), 'A'))
-            status.append((f'{name} output power', self._get_float(CMD.READ_POUT), 'W'))
+            status.append(('{} output voltage'.format(name), self._get_float(CMD.READ_VOUT), 'V'))
+            status.append(('{} output current'.format(name), self._get_float(CMD.READ_IOUT), 'A'))
+            status.append(('{} output power'.format(name), self._get_float(CMD.READ_POUT), 'W'))
         self._exec(WriteBit.WRITE, CMD.PAGE, [0])
         _LOGGER.warning('reading the +12V OCP mode is an experimental feature')
         return status
@@ -134,7 +134,7 @@ class CorsairHidPsu(UsbHidDriver):
         duty = clamp(duty, _MIN_FAN_DUTY, 100)
         _LOGGER.info('ensuring fan control is in software mode')
         self._set_fan_control_mode(FanControlMode.SOFTWARE)
-        _LOGGER.info('setting fan PWM duty to %i%%', duty)
+        _LOGGER.info('setting fan PWM duty to {}%'.format(duty))
         self._exec(WriteBit.WRITE, CMD.FAN_COMMAND_1, [duty])
 
     def set_color(self, channel, mode, colors, **kwargs):

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -26,7 +26,7 @@ from liquidctl.pmbus import CommandCode as CMD
 from liquidctl.pmbus import WriteBit, linear_to_float
 from liquidctl.util import clamp
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 _REPORT_LENGTH = 64
 _SLAVE_ADDRESS = 0x02
@@ -92,10 +92,10 @@ class CorsairHidPsu(UsbHidDriver):
         mode = OCPMode.SINGLE_RAIL if single_12v_ocp else OCPMode.MULTI_RAIL
         if mode != self._get_12v_ocp_mode():
             # TODO replace log level with info once this has been confimed to work
-            LOGGER.warning('(experimental feature) changing +12V OCP mode to %s', mode)
+            _LOGGER.warning('(experimental feature) changing +12V OCP mode to %s', mode)
             self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, [mode.value])
         if self._get_fan_control_mode() != FanControlMode.HARDWARE:
-            LOGGER.info('resetting fan control to hardware mode')
+            _LOGGER.info('resetting fan control to hardware mode')
             self._set_fan_control_mode(FanControlMode.HARDWARE)
 
     def get_status(self, **kwargs):
@@ -107,7 +107,7 @@ class CorsairHidPsu(UsbHidDriver):
         self.device.clear_enqueued_reports()
         ret = self._exec(WriteBit.WRITE, CMD.PAGE, [0])
         if ret[1] == 0xfe:
-            LOGGER.warning('possibly uninitialized device')
+            _LOGGER.warning('possibly uninitialized device')
         status = [
             ('Current uptime', self._get_timedelta(_CORSAIR_READ_UPTIME), ''),
             ('Total uptime', self._get_timedelta(_CORSAIR_READ_TOTAL_UPTIME), ''),
@@ -126,15 +126,15 @@ class CorsairHidPsu(UsbHidDriver):
             status.append((f'{name} output current', self._get_float(CMD.READ_IOUT), 'A'))
             status.append((f'{name} output power', self._get_float(CMD.READ_POUT), 'W'))
         self._exec(WriteBit.WRITE, CMD.PAGE, [0])
-        LOGGER.warning('reading the +12V OCP mode is an experimental feature')
+        _LOGGER.warning('reading the +12V OCP mode is an experimental feature')
         return status
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         """Set channel to a fixed speed duty."""
         duty = clamp(duty, _MIN_FAN_DUTY, 100)
-        LOGGER.info('ensuring fan control is in software mode')
+        _LOGGER.info('ensuring fan control is in software mode')
         self._set_fan_control_mode(FanControlMode.SOFTWARE)
-        LOGGER.info('setting fan PWM duty to %i%%', duty)
+        _LOGGER.info('setting fan PWM duty to %i%%', duty)
         self._exec(WriteBit.WRITE, CMD.FAN_COMMAND_1, [duty])
 
     def set_color(self, channel, mode, colors, **kwargs):

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -39,7 +39,7 @@ _CORSAIR_FAN_CONTROL_MODE = CMD.MFR_SPECIFIC_F0
 _RAIL_12V = 0x0
 _RAIL_5V = 0x1
 _RAIL_3P3V = 0x2
-_RAIL_NAMES = {_RAIL_12V : '+12V', _RAIL_5V : '+5V', _RAIL_3P3V : '+3.3V'}
+_RAIL_NAMES = {_RAIL_12V: '+12V', _RAIL_5V: '+5V', _RAIL_3P3V: '+3.3V'}
 _MIN_FAN_DUTY = 0
 
 
@@ -148,7 +148,7 @@ class CorsairHidPsu(UsbHidDriver):
     def _write(self, data):
         assert len(data) <= _REPORT_LENGTH
         packet = bytearray(1 + _REPORT_LENGTH)
-        packet[1 : 1 + len(data)] = data  # device doesn't use numbered reports
+        packet[1: 1 + len(data)] = data  # device doesn't use numbered reports
         self.device.write(packet)
 
     def _read(self):

--- a/liquidctl/driver/ddr4.py
+++ b/liquidctl/driver/ddr4.py
@@ -53,8 +53,8 @@ class Ddr4Spd:
             0xad: 'SK Hynix',
             0xce: 'Samsung',
         },
-        2: { 0x98: 'Kingston' },
-        3: { 0x9e: 'Corsair' },
+        2: {0x98: 'Kingston'},
+        3: {0x9e: 'Corsair'},
         5: {
             0xcd: 'G.SKILL',
             0xef: 'Team Group',
@@ -99,7 +99,7 @@ class Ddr4Spd:
     def module_type(self):
         base = self._eeprom[0x03] & 0x0f
         hybrid = self._eeprom[0x03] >> 4
-        assert not hybrid 
+        assert not hybrid
         return (self.BaseModuleType(base), None)
 
     @property

--- a/liquidctl/driver/ddr4.py
+++ b/liquidctl/driver/ddr4.py
@@ -177,7 +177,7 @@ class Ddr4Temperature(SmbusDriver):
             # accidental attempts of writes to the SPD EEPROM (DDR4 SPD writes
             # are also disabled by default in many motherboards)
             dev = cls(smbus, desc, address=(None, None, spd_addr))
-            _LOGGER.debug('instanced driver for {}'.format(desc))
+            _LOGGER.debug('instanced driver for %s', desc)
             yield dev
 
     @classmethod
@@ -210,8 +210,8 @@ class Ddr4Temperature(SmbusDriver):
         """
 
         if not check_unsafe(*self._UNSAFE, **kwargs):
-            _LOGGER.warning("{}: nothing to return, requires unsafe features '{}'"
-                            .format(self.description, ','.join(self._UNSAFE)))
+            _LOGGER.warning("%s: nothing to return, requires unsafe features '%s'",
+                            self.description, ','.join(self._UNSAFE))
             return []
 
         treg = self._read_temperature_register()
@@ -358,7 +358,7 @@ class VengeanceRgb(Ddr4Temperature):
             raise ValueError('{} mode requires {} colors'.format(mode, mode.min_colors))
 
         if len(colors) > mode.max_colors:
-            _LOGGER.debug('too many colors, dropping to {}'.format(mode.max_colors))
+            _LOGGER.debug('too many colors, dropping to %d', mode.max_colors)
             colors = colors[:mode.max_colors]
 
         self._compute_rgb_address()

--- a/liquidctl/driver/ddr4.py
+++ b/liquidctl/driver/ddr4.py
@@ -167,7 +167,7 @@ class Ddr4Temperature(SmbusDriver):
             if not desc:
                 continue
 
-            desc += ' DIMM{} (experimental)'.format(dimm + 1)
+            desc += f' DIMM{dimm + 1} (experimental)'
 
             if (address and int(address, base=16) != spd_addr) \
                     or (match and match.lower() not in desc.lower()):
@@ -191,7 +191,7 @@ class Ddr4Temperature(SmbusDriver):
             return 'DDR4'
 
         if spd.module_part_number:
-            return '{} {}'.format(manufacturer, spd.module_part_number)
+            return f'{manufacturer} {spd.module_part_number}'
         else:
             return manufacturer
 
@@ -201,7 +201,7 @@ class Ddr4Temperature(SmbusDriver):
 
     @property
     def address(self):
-        return '{:#04x}'.format(self._address[2])
+        return f'{self._address[2]:#04x}'
 
     def get_status(self, **kwargs):
         """Get a status report.
@@ -340,7 +340,7 @@ class VengeanceRgb(Ddr4Temperature):
             common = self.SpeedTimings[speed.upper()].value
             tp1 = tp2 = common
         except KeyError:
-            raise ValueError('invalid speed preset: {!r}'.format(speed)) from None
+            raise ValueError(f'invalid speed preset: {speed!r}') from None
 
         if transition_ticks is not None:
             tp1 = clamp(transition_ticks, 0, 63)
@@ -352,10 +352,10 @@ class VengeanceRgb(Ddr4Temperature):
         try:
             mode = self.Mode[mode.upper()]
         except KeyError:
-            raise ValueError('invalid mode: {!r}'.format(mode)) from None
+            raise ValueError(f'invalid mode: {mode!r}') from None
 
         if len(colors) < mode.min_colors:
-            raise ValueError('{} mode requires {} colors'.format(mode, mode.min_colors))
+            raise ValueError(f'{mode} mode requires {mode.min_colors} colors')
 
         if len(colors) > mode.max_colors:
             _LOGGER.debug('too many colors, dropping to %d', mode.max_colors)

--- a/liquidctl/driver/ddr4.py
+++ b/liquidctl/driver/ddr4.py
@@ -11,11 +11,9 @@ import logging
 from liquidctl.driver.smbus import SmbusDriver
 from liquidctl.error import ExpectationNotMet, NotSupportedByDevice, NotSupportedByDriver
 from liquidctl.util import check_unsafe, clamp
+from collections import namedtuple
 
 _LOGGER = logging.getLogger(__name__)
-
-
-from collections import namedtuple
 
 
 class Ddr4Spd:
@@ -190,7 +188,7 @@ class Ddr4Temperature(SmbusDriver):
         try:
             manufacturer = spd.module_manufacturer
         except:
-            return f'DDR4'
+            return 'DDR4'
 
         if spd.module_part_number:
             return f'{manufacturer} {spd.module_part_number}'

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -59,7 +59,7 @@ class _FanMode(Enum):
 
     @classmethod
     def _missing_(cls, value):
-        _LOGGER.debug('falling back to FIXED_DUTY for _FanMode({})'.format(value))
+        _LOGGER.debug('falling back to FIXED_DUTY for _FanMode(%s)', value)
         return _FanMode.FIXED_DUTY
 
 
@@ -71,7 +71,7 @@ class _PumpMode(Enum):
 
     @classmethod
     def _missing_(cls, value):
-        _LOGGER.debug('falling back to BALANCED for _PumpMode({})'.format(value))
+        _LOGGER.debug('falling back to BALANCED for _PumpMode(%s)', value)
         return _PumpMode.BALANCED
 
 
@@ -300,7 +300,7 @@ class HydroPlatinum(UsbHidDriver):
         if len(colors) < mincolors:
             raise ValueError('At least {} required for {}'.format(mincolors, _quoted((channel, mode))))
         if len(colors) > maxcolors:
-            _LOGGER.warning('too many colors, dropping to {}'.format(maxcolors))
+            _LOGGER.warning('too many colors, dropping to %d', maxcolors)
             return maxcolors
         return len(colors)
 
@@ -345,17 +345,17 @@ class HydroPlatinum(UsbHidDriver):
                 stored = self._data.load('{}_duty'.format(fan), of_type=int, default=100)
                 duty = clamp(stored, 0, 100)
                 data[iduty] = fraction_of_byte(percentage=duty)
-                _LOGGER.info('setting {} to {}% duty cycle'.format(fan, duty))
+                _LOGGER.info('setting %s to %i%% duty cycle', fan, duty)
             elif mode is _FanMode.CUSTOM_PROFILE:
                 stored = self._data.load('{}_profile'.format(fan), of_type=list, default=[])
                 profile = _prepare_profile(stored)  # ensures correct len(profile)
                 pairs = ((temp, fraction_of_byte(percentage=duty)) for temp, duty in profile)
                 data[iprofile: iprofile + _PROFILE_LENGTH * 2] = itertools.chain(*pairs)
-                _LOGGER.info('setting {} to follow profile {}'.format(fan, profile))
+                _LOGGER.info('setting %s to follow profile %r', fan, profile)
             else:
                 raise ValueError('Unsupported fan {}'.format(mode))
             data[imode] = mode.value
         pump_mode = _PumpMode(self._data.load('pump_mode', of_type=int))
         data[_PUMP_MODE_OFFSET] = pump_mode.value
-        _LOGGER.info('setting pump mode to {}'.format(pump_mode.name.lower()))
+        _LOGGER.info('setting pump mode to %s', pump_mode.name.lower())
         return self._send_command(_FEATURE_COOLING, _CMD_SET_COOLING, data=data)

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -59,7 +59,7 @@ class _FanMode(Enum):
 
     @classmethod
     def _missing_(cls, value):
-        _LOGGER.debug("falling back to FIXED_DUTY for _FanMode(%s)", value)
+        _LOGGER.debug('falling back to FIXED_DUTY for _FanMode({})'.format(value))
         return _FanMode.FIXED_DUTY
 
 
@@ -71,7 +71,7 @@ class _PumpMode(Enum):
 
     @classmethod
     def _missing_(cls, value):
-        _LOGGER.debug("falling back to BALANCED for _PumpMode(%s)", value)
+        _LOGGER.debug('falling back to BALANCED for _PumpMode({})'.format(value))
         return _PumpMode.BALANCED
 
 
@@ -96,7 +96,7 @@ def _prepare_profile(original):
     normal = normalize_profile(clamped, _CRITICAL_TEMPERATURE)
     missing = _PROFILE_LENGTH - len(normal)
     if missing < 0:
-        raise ValueError(f'Too many points in profile (remove {-missing})')
+        raise ValueError('Too many points in profile (remove {})'.format(-missing))
     if missing > 0:
         normal += missing * [(_CRITICAL_TEMPERATURE, 100)]
     return normal
@@ -125,7 +125,7 @@ class HydroPlatinum(UsbHidDriver):
     def __init__(self, device, description, fan_count, rgb_fans, **kwargs):
         super().__init__(device, description, **kwargs)
         self._led_count = 16 + 4 * fan_count * rgb_fans
-        self._fan_names = [f'fan{i + 1}' for i in range(fan_count)]
+        self._fan_names = ['fan{}'.format(i + 1) for i in range(fan_count)]
         self._mincolors = {
             ('led', 'super-fixed'): 1,
             ('led', 'fixed'): 1,
@@ -143,7 +143,7 @@ class HydroPlatinum(UsbHidDriver):
     def connect(self, **kwargs):
         """Connect to the device."""
         super().connect(**kwargs)
-        ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
+        ids = 'vid{:04x}_pid{:04x}'.format(self.vendor_id, self.product_id)
         # must use the HID path because there is no serial number; however,
         # these can be quite long on Windows and macOS, so only take the
         # numbers, since they are likely the only parts that vary between two
@@ -175,7 +175,7 @@ class HydroPlatinum(UsbHidDriver):
         if fw_version < (1, 1, 0):
             # see: #201 ("Fan settings affects Fan 1 only and disables fan2")
             _LOGGER.warning('outdated and possibly unsupported firmware version')
-        return [('Firmware version', '%d.%d.%d' % fw_version, '')]
+        return [('Firmware version', '{}.{}.{}'.format(*fw_version), '')]
 
     def get_status(self, **kwargs):
         """Get a status report.
@@ -184,7 +184,7 @@ class HydroPlatinum(UsbHidDriver):
         """
 
         res = self._send_command(_FEATURE_COOLING, _CMD_GET_STATUS)
-        assert len(self._fan_names) == 2, f'cannot yet parse with {len(self._fan_names)} fans'
+        assert len(self._fan_names) == 2, 'cannot yet parse with {} fans'.format(len(self._fan_names))
         return [
             ('Liquid temperature', res[8] + res[7] / 255, '°C'),
             ('Fan 1 speed', u16le_from(res, offset=15), 'rpm'),
@@ -201,8 +201,8 @@ class HydroPlatinum(UsbHidDriver):
         """
 
         for hw_channel in self._get_hw_fan_channels(channel):
-            self._data.store(f'{hw_channel}_mode', _FanMode.FIXED_DUTY.value)
-            self._data.store(f'{hw_channel}_duty', duty)
+            self._data.store('{}_mode'.format(hw_channel), _FanMode.FIXED_DUTY.value)
+            self._data.store('{}_duty'.format(hw_channel), duty)
         self._send_set_cooling()
 
     def set_speed_profile(self, channel, profile, **kwargs):
@@ -220,8 +220,8 @@ class HydroPlatinum(UsbHidDriver):
 
         profile = list(profile)
         for hw_channel in self._get_hw_fan_channels(channel):
-            self._data.store(f'{hw_channel}_mode', _FanMode.CUSTOM_PROFILE.value)
-            self._data.store(f'{hw_channel}_profile', profile)
+            self._data.store('{}_mode'.format(hw_channel), _FanMode.CUSTOM_PROFILE.value)
+            self._data.store('{}_profile'.format(hw_channel), profile)
         self._send_set_cooling()
 
     def set_color(self, channel, mode, colors, **kwargs):
@@ -296,11 +296,11 @@ class HydroPlatinum(UsbHidDriver):
             mincolors = self._mincolors[(channel, mode)]
             maxcolors = self._maxcolors[(channel, mode)]
         except KeyError:
-            raise ValueError(f'Unsupported (channel, mode) pair, should be one of: {_quoted(*self._mincolors)}')
+            raise ValueError('Unsupported (channel, mode) pair, should be one of: {}'.format(_quoted(*self._mincolors)))
         if len(colors) < mincolors:
-            raise ValueError(f'At least {mincolors} required for {_quoted((channel, mode))}')
+            raise ValueError('At least {} required for {}'.format(mincolors, _quoted((channel, mode))))
         if len(colors) > maxcolors:
-            _LOGGER.warning('too many colors, dropping to %d', maxcolors)
+            _LOGGER.warning('too many colors, dropping to {}'.format(maxcolors))
             return maxcolors
         return len(colors)
 
@@ -310,7 +310,7 @@ class HydroPlatinum(UsbHidDriver):
             return self._fan_names
         if channel in self._fan_names:
             return [channel]
-        raise ValueError(f'Unknown channel, should be one of: {_quoted("fan", *self._fan_names)}')
+        raise ValueError('Unknown channel, should be one of: {}'.format(_quoted('fan', *self._fan_names)))
 
     def _send_command(self, feature, command, data=None):
         # self.device.write expects buf[0] to be the report number or 0 if not used
@@ -340,22 +340,22 @@ class HydroPlatinum(UsbHidDriver):
         data[0: len(_SET_COOLING_DATA_PREFIX)] = _SET_COOLING_DATA_PREFIX
         data[_PROFILE_LENGTH_OFFSET] = _PROFILE_LENGTH
         for fan, (imode, iduty, iprofile) in zip(self._fan_names, _FAN_OFFSETS):
-            mode = _FanMode(self._data.load(f'{fan}_mode', of_type=int))
+            mode = _FanMode(self._data.load('{}_mode'.format(fan), of_type=int))
             if mode is _FanMode.FIXED_DUTY:
-                stored = self._data.load(f'{fan}_duty', of_type=int, default=100)
+                stored = self._data.load('{}_duty'.format(fan), of_type=int, default=100)
                 duty = clamp(stored, 0, 100)
                 data[iduty] = fraction_of_byte(percentage=duty)
-                _LOGGER.info('setting %s to %d%% duty cycle', fan, duty)
+                _LOGGER.info('setting {} to {}% duty cycle'.format(fan, duty))
             elif mode is _FanMode.CUSTOM_PROFILE:
-                stored = self._data.load(f'{fan}_profile', of_type=list, default=[])
+                stored = self._data.load('{}_profile'.format(fan), of_type=list, default=[])
                 profile = _prepare_profile(stored)  # ensures correct len(profile)
                 pairs = ((temp, fraction_of_byte(percentage=duty)) for temp, duty in profile)
                 data[iprofile: iprofile + _PROFILE_LENGTH * 2] = itertools.chain(*pairs)
-                _LOGGER.info('setting %s to follow profile %r', fan, profile)
+                _LOGGER.info('setting {} to follow profile {}'.format(fan, profile))
             else:
-                raise ValueError(f'Unsupported fan {mode}')
+                raise ValueError('Unsupported fan {}'.format(mode))
             data[imode] = mode.value
         pump_mode = _PumpMode(self._data.load('pump_mode', of_type=int))
         data[_PUMP_MODE_OFFSET] = pump_mode.value
-        _LOGGER.info('setting pump mode to %s', pump_mode.name.lower())
+        _LOGGER.info('setting pump mode to {}'.format(pump_mode.name.lower()))
         return self._send_command(_FEATURE_COOLING, _CMD_SET_COOLING, data=data)

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -325,7 +325,7 @@ class HydroPlatinum(UsbHidDriver):
             buf[2] |= command
             start_at = 3
         if data:
-            buf[start_at : start_at + len(data)] = data
+            buf[start_at: start_at + len(data)] = data
         buf[-1] = compute_pec(buf[2:-1])
         self.device.clear_enqueued_reports()
         self.device.write(buf)
@@ -337,7 +337,7 @@ class HydroPlatinum(UsbHidDriver):
     def _send_set_cooling(self):
         assert len(self._fan_names) <= 2, 'cannot yet fit all fan data'
         data = bytearray(_SET_COOLING_DATA_LENGTH)
-        data[0 : len(_SET_COOLING_DATA_PREFIX)] = _SET_COOLING_DATA_PREFIX
+        data[0: len(_SET_COOLING_DATA_PREFIX)] = _SET_COOLING_DATA_PREFIX
         data[_PROFILE_LENGTH_OFFSET] = _PROFILE_LENGTH
         for fan, (imode, iduty, iprofile) in zip(self._fan_names, _FAN_OFFSETS):
             mode = _FanMode(self._data.load(f'{fan}_mode', of_type=int))
@@ -350,7 +350,7 @@ class HydroPlatinum(UsbHidDriver):
                 stored = self._data.load(f'{fan}_profile', of_type=list, default=[])
                 profile = _prepare_profile(stored)  # ensures correct len(profile)
                 pairs = ((temp, fraction_of_byte(percentage=duty)) for temp, duty in profile)
-                data[iprofile : iprofile + _PROFILE_LENGTH * 2] = itertools.chain(*pairs)
+                data[iprofile: iprofile + _PROFILE_LENGTH * 2] = itertools.chain(*pairs)
                 _LOGGER.info('setting %s to follow profile %r', fan, profile)
             else:
                 raise ValueError(f'Unsupported fan {mode}')

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -27,10 +27,10 @@ from liquidctl.util import clamp, fraction_of_byte, u16le_from, \
 _LOGGER = logging.getLogger(__name__)
 
 _REPORT_LENGTH = 64
-_WRITE_PREFIX = 0x3F
+_WRITE_PREFIX = 0x3f
 
 _FEATURE_COOLING = 0b000
-_CMD_GET_STATUS = 0xFF
+_CMD_GET_STATUS = 0xff
 _CMD_SET_COOLING = 0x14
 
 _FEATURE_LIGHTING = None
@@ -39,13 +39,13 @@ _CMD_SET_LIGHTING2 = 0b101
 
 # cooling data starts at offset 3 and ends just before the PEC byte
 _SET_COOLING_DATA_LENGTH = _REPORT_LENGTH - 4
-_SET_COOLING_DATA_PREFIX = [0x0, 0xFF, 0x5, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF]
-_FAN_MODE_OFFSETS = [0x0B - 3, 0x11 - 3]
+_SET_COOLING_DATA_PREFIX = [0x0, 0xff, 0x5, 0xff, 0xff, 0xff, 0xff, 0xff]
+_FAN_MODE_OFFSETS = [0x0b - 3, 0x11 - 3]
 _FAN_DUTY_OFFSETS = [offset + 5 for offset in _FAN_MODE_OFFSETS]
-_FAN_PROFILE_OFFSETS = [0x1E - 3, 0x2C - 3]
+_FAN_PROFILE_OFFSETS = [0x1e - 3, 0x2c - 3]
 _FAN_OFFSETS = list(zip(_FAN_MODE_OFFSETS, _FAN_DUTY_OFFSETS, _FAN_PROFILE_OFFSETS))
 _PUMP_MODE_OFFSET = 0x17 - 3
-_PROFILE_LENGTH_OFFSET = 0x1D - 3
+_PROFILE_LENGTH_OFFSET = 0x1d - 3
 _PROFILE_LENGTH = 7
 _CRITICAL_TEMPERATURE = 60
 
@@ -110,15 +110,15 @@ class HydroPlatinum(UsbHidDriver):
     """Corsair Hydro Platinum or Pro XT liquid cooler."""
 
     SUPPORTED_DEVICES = [
-        (0x1B1C, 0x0C18, None, 'Corsair H100i Platinum (experimental)',
+        (0x1b1c, 0x0c18, None, 'Corsair H100i Platinum (experimental)',
             {'fan_count': 2, 'rgb_fans': True}),
-        (0x1B1C, 0x0C19, None, 'Corsair H100i Platinum SE (experimental)',
+        (0x1b1c, 0x0c19, None, 'Corsair H100i Platinum SE (experimental)',
             {'fan_count': 2, 'rgb_fans': True}),
-        (0x1B1C, 0x0C17, None, 'Corsair H115i Platinum (experimental)',
+        (0x1b1c, 0x0c17, None, 'Corsair H115i Platinum (experimental)',
             {'fan_count': 2, 'rgb_fans': True}),
-        (0x1B1C, 0x0C20, None, 'Corsair H100i Pro XT (experimental)',
+        (0x1b1c, 0x0c20, None, 'Corsair H100i Pro XT (experimental)',
             {'fan_count': 2, 'rgb_fans': False}),
-        (0x1B1C, 0x0C21, None, 'Corsair H115i Pro XT (experimental)',
+        (0x1b1c, 0x0c21, None, 'Corsair H115i Pro XT (experimental)',
             {'fan_count': 2, 'rgb_fans': False}),
     ]
 

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -199,7 +199,7 @@ class Kraken2(UsbHidDriver):
         if not 'super' in mode:
             steps = [(color,)*9 for color in colors]
         elif ringonly:
-            steps = [[(0,0,0)] + colors]
+            steps = [[(0, 0, 0)] + colors]
         else:
             steps = [colors]
         return steps

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -166,8 +166,8 @@ class Kraken2(UsbHidDriver):
             mod2 += 0x10
 
         if ringonly and channel != 'ring':
-            _LOGGER.warning('mode={} unsupported with channel={}, dropping to ring'
-                            .format(mode, channel))
+            _LOGGER.warning('mode=%s unsupported with channel=%s, dropping to ring',
+                            mode, channel)
             channel = 'ring'
 
         steps = self._generate_steps(colors, mincolors, maxcolors, mode, ringonly)
@@ -187,11 +187,11 @@ class Kraken2(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if len(colors) > 0:
-                _LOGGER.warning('too many colors for mode={}, none needed'.format(mode))
+                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
             colors = [(0, 0, 0)]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            _LOGGER.warning('too many colors for mode={}, dropping to {}'
-                            .format(mode, maxcolors))
+            _LOGGER.warning('too many colors for mode=%s, dropping to %d',
+                            mode, maxcolors)
             colors = colors[:maxcolors]
         # generate steps from mode and colors: usually each color set by the user generates
         # one step, where it is specified to all leds and the device handles the animation;
@@ -217,8 +217,8 @@ class Kraken2(UsbHidDriver):
         cbase, dmin, dmax = _SPEED_CHANNELS[channel]
         for i, (temp, duty) in enumerate(interp):
             duty = clamp(duty, dmin, dmax)
-            _LOGGER.info('setting {} PWM duty to {}% for liquid temperature >= {}°C'
-                         .format(channel, duty, temp))
+            _LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C',
+                         channel, duty, temp)
             self._write([0x2, 0x4d, cbase + i, temp, duty])
 
     def set_fixed_speed(self, channel, duty, **kwargs):
@@ -236,7 +236,7 @@ class Kraken2(UsbHidDriver):
             raise NotSupportedByDevice()
         cbase, dmin, dmax = _SPEED_CHANNELS[channel]
         duty = clamp(duty, dmin, dmax)
-        _LOGGER.info('setting {} PWM duty to {}%'.format(channel, duty))
+        _LOGGER.info('setting %d PWM duty to %i%%', channel, duty)
         self._write([0x2, 0x4d, cbase & 0x70, 0, duty])
 
     @property

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -166,8 +166,8 @@ class Kraken2(UsbHidDriver):
             mod2 += 0x10
 
         if ringonly and channel != 'ring':
-            _LOGGER.warning('mode=%s unsupported with channel=%s, dropping to ring',
-                            mode, channel)
+            _LOGGER.warning('mode={} unsupported with channel={}, dropping to ring'
+                            .format(mode, channel))
             channel = 'ring'
 
         steps = self._generate_steps(colors, mincolors, maxcolors, mode, ringonly)
@@ -187,11 +187,11 @@ class Kraken2(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if len(colors) > 0:
-                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
+                _LOGGER.warning('too many colors for mode={}, none needed'.format(mode))
             colors = [(0, 0, 0)]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            _LOGGER.warning('too many colors for mode=%s, dropping to %i',
-                            mode, maxcolors)
+            _LOGGER.warning('too many colors for mode={}, dropping to {}'
+                            .format(mode, maxcolors))
             colors = colors[:maxcolors]
         # generate steps from mode and colors: usually each color set by the user generates
         # one step, where it is specified to all leds and the device handles the animation;
@@ -217,8 +217,8 @@ class Kraken2(UsbHidDriver):
         cbase, dmin, dmax = _SPEED_CHANNELS[channel]
         for i, (temp, duty) in enumerate(interp):
             duty = clamp(duty, dmin, dmax)
-            _LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C',
-                         channel, duty, temp)
+            _LOGGER.info('setting {} PWM duty to {}% for liquid temperature >= {}°C'
+                         .format(channel, duty, temp))
             self._write([0x2, 0x4d, cbase + i, temp, duty])
 
     def set_fixed_speed(self, channel, duty, **kwargs):
@@ -236,7 +236,7 @@ class Kraken2(UsbHidDriver):
             raise NotSupportedByDevice()
         cbase, dmin, dmax = _SPEED_CHANNELS[channel]
         duty = clamp(duty, dmin, dmax)
-        _LOGGER.info('setting %s PWM duty to %i%%', channel, duty)
+        _LOGGER.info('setting {} PWM duty to {}%'.format(channel, duty))
         self._write([0x2, 0x4d, cbase & 0x70, 0, duty])
 
     @property

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -150,7 +150,7 @@ class Kraken2(UsbHidDriver):
         channel = channel.lower()
         mode = mode.lower()
         speed = speed.lower()
-        directon = direction.lower()
+        direction = direction.lower()
 
         if mode == 'super':
             _LOGGER.warning('deprecated mode, move to super-fixed, super-breathing or super-wave')
@@ -196,7 +196,7 @@ class Kraken2(UsbHidDriver):
         # generate steps from mode and colors: usually each color set by the user generates
         # one step, where it is specified to all leds and the device handles the animation;
         # but in super mode there is a single step and each color directly controls a led
-        if not 'super' in mode:
+        if 'super' not in mode:
             steps = [(color,)*9 for color in colors]
         elif ringonly:
             steps = [[(0, 0, 0)] + colors]

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -183,8 +183,7 @@ class Kraken2(UsbHidDriver):
     def _generate_steps(self, colors, mincolors, maxcolors, mode, ringonly):
         colors = list(colors)
         if len(colors) < mincolors:
-            raise ValueError('Not enough colors for mode={}, at least {} required'
-                             .format(mode, mincolors))
+            raise ValueError(f'Not enough colors for mode={mode}, at least {mincolors} required')
         elif maxcolors == 0:
             if len(colors) > 0:
                 _LOGGER.warning('too many colors for mode=%s, none needed', mode)

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -167,7 +167,7 @@ class Kraken2(UsbHidDriver):
 
         if ringonly and channel != 'ring':
             _LOGGER.warning('mode=%s unsupported with channel=%s, dropping to ring',
-                           mode, channel)
+                            mode, channel)
             channel = 'ring'
 
         steps = self._generate_steps(colors, mincolors, maxcolors, mode, ringonly)
@@ -191,7 +191,7 @@ class Kraken2(UsbHidDriver):
             colors = [(0, 0, 0)]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
             _LOGGER.warning('too many colors for mode=%s, dropping to %i',
-                           mode, maxcolors)
+                            mode, maxcolors)
             colors = colors[:maxcolors]
         # generate steps from mode and colors: usually each color set by the user generates
         # one step, where it is specified to all leds and the device handles the animation;

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -28,7 +28,7 @@ from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.error import NotSupportedByDevice
 from liquidctl.util import clamp, normalize_profile, interpolate_profile
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 _SPEED_CHANNELS = {  # (base, minimum duty, maximum duty)
     'fan':   (0x80, 25, 100),
@@ -120,7 +120,7 @@ class Kraken2(UsbHidDriver):
 
     def finalize(self):
         """Deprecated."""
-        LOGGER.warning('deprecated: use disconnect() instead')
+        _LOGGER.warning('deprecated: use disconnect() instead')
         if self._connected:
             self.disconnect()
 
@@ -153,10 +153,10 @@ class Kraken2(UsbHidDriver):
         directon = direction.lower()
 
         if mode == 'super':
-            LOGGER.warning('deprecated mode, move to super-fixed, super-breathing or super-wave')
+            _LOGGER.warning('deprecated mode, move to super-fixed, super-breathing or super-wave')
             mode = 'super-fixed'
         if 'backwards' in mode:
-            LOGGER.warning('deprecated mode, move to direction=backwards option')
+            _LOGGER.warning('deprecated mode, move to direction=backwards option')
             mode = mode.replace('backwards-', '')
             direction = 'backward'
 
@@ -166,7 +166,7 @@ class Kraken2(UsbHidDriver):
             mod2 += 0x10
 
         if ringonly and channel != 'ring':
-            LOGGER.warning('mode=%s unsupported with channel=%s, dropping to ring',
+            _LOGGER.warning('mode=%s unsupported with channel=%s, dropping to ring',
                            mode, channel)
             channel = 'ring'
 
@@ -187,10 +187,10 @@ class Kraken2(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if len(colors) > 0:
-                LOGGER.warning('too many colors for mode=%s, none needed', mode)
+                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
             colors = [(0, 0, 0)]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            LOGGER.warning('too many colors for mode=%s, dropping to %i',
+            _LOGGER.warning('too many colors for mode=%s, dropping to %i',
                            mode, maxcolors)
             colors = colors[:maxcolors]
         # generate steps from mode and colors: usually each color set by the user generates
@@ -217,7 +217,7 @@ class Kraken2(UsbHidDriver):
         cbase, dmin, dmax = _SPEED_CHANNELS[channel]
         for i, (temp, duty) in enumerate(interp):
             duty = clamp(duty, dmin, dmax)
-            LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C',
+            _LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C',
                          channel, duty, temp)
             self._write([0x2, 0x4d, cbase + i, temp, duty])
 
@@ -236,7 +236,7 @@ class Kraken2(UsbHidDriver):
             raise NotSupportedByDevice()
         cbase, dmin, dmax = _SPEED_CHANNELS[channel]
         duty = clamp(duty, dmin, dmax)
-        LOGGER.info('setting %s PWM duty to %i%%', channel, duty)
+        _LOGGER.info('setting %s PWM duty to %i%%', channel, duty)
         self._write([0x2, 0x4d, cbase & 0x70, 0, duty])
 
     @property

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -224,7 +224,7 @@ class Kraken2(UsbHidDriver):
     def set_fixed_speed(self, channel, duty, **kwargs):
         """Set channel to a fixed speed."""
         if not self.supports_cooling:
-             raise NotSupportedByDevice()
+            raise NotSupportedByDevice()
         elif self.supports_cooling_profiles:
             self.set_speed_profile(channel, [(0, duty), (59, duty), (60, 100), (100, 100)])
         else:

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -181,7 +181,7 @@ class KrakenX3(UsbHidDriver):
         def parse_led_info(msg):
             channel_count = msg[14]
             assert channel_count == len(self._color_channels) - ('sync' in self._color_channels), \
-                   f'Unexpected number of color channels received: {channel_count}'
+                   'Unexpected number of color channels received: {}'.format(channel_count)
 
             def find(channel, accessory):
                 offset = 15  # offset of first channel/first accessory
@@ -192,7 +192,7 @@ class KrakenX3(UsbHidDriver):
                 accessory = find(0, i)
                 if not accessory:
                     break
-                status.append((f'LED accessory {i + 1}', accessory, ''))
+                status.append(('LED accessory {}'.format(i + 1), accessory, ''))
 
             if len(self._color_channels) > 1:
                 found_ring = find(1, 0) == Hue2Accessory.KRAKENX_GEN4_RING
@@ -243,10 +243,10 @@ class KrakenX3(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if colors:
-                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
+                _LOGGER.warning('too many colors for mode={}, none needed'.format(mode))
             colors = [[0, 0, 0]]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            _LOGGER.warning('too many colors for mode=%s, dropping to %i', mode, maxcolors)
+            _LOGGER.warning('too many colors for mode={}, dropping to {}'.format(mode, maxcolors))
             colors = colors[:maxcolors]
 
         sval = _ANIMATION_SPEEDS[speed]
@@ -260,8 +260,8 @@ class KrakenX3(UsbHidDriver):
         stdtemps = list(range(20, _CRITICAL_TEMPERATURE + 1))
         interp = [clamp(interpolate_profile(norm, t), dmin, dmax) for t in stdtemps]
         for temp, duty in zip(stdtemps, interp):
-            _LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C', channel,
-                         duty, temp)
+            _LOGGER.info('setting {} PWM duty to {}% for liquid temperature >= {}°C'
+                         .format(channel, duty, temp))
         self._write(header + interp)
 
     def set_fixed_speed(self, channel, duty, **kwargs):
@@ -281,7 +281,7 @@ class KrakenX3(UsbHidDriver):
                 func(msg)
             if not parsers:
                 return
-        assert False, f'missing messages (attempts={_MAX_READ_ATTEMPTS}, missing={len(parsers)})'
+        assert False, 'missing messages (attempts={}, missing={})'.format(_MAX_READ_ATTEMPTS, len(parsers))
 
     def _write(self, data):
         padding = [0x0] * (_WRITE_LENGTH - len(data))

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -261,7 +261,7 @@ class KrakenX3(UsbHidDriver):
         interp = [clamp(interpolate_profile(norm, t), dmin, dmax) for t in stdtemps]
         for temp, duty in zip(stdtemps, interp):
             _LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C', channel,
-                        duty, temp)
+                         duty, temp)
         self._write(header + interp)
 
     def set_fixed_speed(self, channel, duty, **kwargs):

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -228,7 +228,7 @@ class KrakenX3(UsbHidDriver):
         channel = channel.lower()
         mode = mode.lower()
         speed = speed.lower()
-        directon = direction.lower()
+        direction = direction.lower()
 
         if 'backwards' in mode:
             _LOGGER.warning('deprecated mode, move to direction=backwards option')

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -181,7 +181,7 @@ class KrakenX3(UsbHidDriver):
         def parse_led_info(msg):
             channel_count = msg[14]
             assert channel_count == len(self._color_channels) - ('sync' in self._color_channels), \
-                   'Unexpected number of color channels received: {}'.format(channel_count)
+                   f'Unexpected number of color channels received: {channel_count}'
 
             def find(channel, accessory):
                 offset = 15  # offset of first channel/first accessory
@@ -192,7 +192,7 @@ class KrakenX3(UsbHidDriver):
                 accessory = find(0, i)
                 if not accessory:
                     break
-                status.append(('LED accessory {}'.format(i + 1), accessory, ''))
+                status.append((f'LED accessory {i + 1}', accessory, ''))
 
             if len(self._color_channels) > 1:
                 found_ring = find(1, 0) == Hue2Accessory.KRAKENX_GEN4_RING
@@ -239,8 +239,7 @@ class KrakenX3(UsbHidDriver):
         _, _, _, mincolors, maxcolors = _COLOR_MODES[mode]
         colors = [[g, r, b] for [r, g, b] in colors]
         if len(colors) < mincolors:
-            raise ValueError('Not enough colors for mode={}, at least {} required'
-                             .format(mode, mincolors))
+            raise ValueError(f'Not enough colors for mode={mode}, at least {mincolors} required')
         elif maxcolors == 0:
             if colors:
                 _LOGGER.warning('too many colors for mode=%s, none needed', mode)
@@ -281,7 +280,7 @@ class KrakenX3(UsbHidDriver):
                 func(msg)
             if not parsers:
                 return
-        assert False, 'missing messages (attempts={}, missing={})'.format(_MAX_READ_ATTEMPTS, len(parsers))
+        assert False, f'missing messages (attempts={_MAX_READ_ATTEMPTS}, missing={len(parsers)})'
 
     def _write(self, data):
         padding = [0x0] * (_WRITE_LENGTH - len(data))

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -243,10 +243,10 @@ class KrakenX3(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if colors:
-                _LOGGER.warning('too many colors for mode={}, none needed'.format(mode))
+                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
             colors = [[0, 0, 0]]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            _LOGGER.warning('too many colors for mode={}, dropping to {}'.format(mode, maxcolors))
+            _LOGGER.warning('too many colors for mode=%s, dropping to %d', mode, maxcolors)
             colors = colors[:maxcolors]
 
         sval = _ANIMATION_SPEEDS[speed]
@@ -260,8 +260,8 @@ class KrakenX3(UsbHidDriver):
         stdtemps = list(range(20, _CRITICAL_TEMPERATURE + 1))
         interp = [clamp(interpolate_profile(norm, t), dmin, dmax) for t in stdtemps]
         for temp, duty in zip(stdtemps, interp):
-            _LOGGER.info('setting {} PWM duty to {}% for liquid temperature >= {}°C'
-                         .format(channel, duty, temp))
+            _LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C',
+                         channel, duty, temp)
         self._write(header + interp)
 
     def set_fixed_speed(self, channel, duty, **kwargs):

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -16,7 +16,7 @@ from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.util import normalize_profile, interpolate_profile, clamp, \
                            Hue2Accessory, HUE2_MAX_ACCESSORIES_IN_CHANNEL
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 _READ_LENGTH = 64
 _WRITE_LENGTH = 64
@@ -213,9 +213,9 @@ class KrakenX3(UsbHidDriver):
         self.device.clear_enqueued_reports()
         msg = self._read()
         if msg[15:17] == [0xff, 0xff]:
-            LOGGER.warning('unexpected temperature reading, possible firmware fault;')
-            LOGGER.warning('try resetting the device or updating the firmware')
-            LOGGER.warning('(see https://github.com/liquidctl/liquidctl/issues/172)')
+            _LOGGER.warning('unexpected temperature reading, possible firmware fault;')
+            _LOGGER.warning('try resetting the device or updating the firmware')
+            _LOGGER.warning('(see https://github.com/liquidctl/liquidctl/issues/172)')
         return [
             ('Liquid temperature', msg[15] + msg[16] / 10, '°C'),
             ('Pump speed', msg[18] << 8 | msg[17], 'rpm'),
@@ -231,7 +231,7 @@ class KrakenX3(UsbHidDriver):
         directon = direction.lower()
 
         if 'backwards' in mode:
-            LOGGER.warning('deprecated mode, move to direction=backwards option')
+            _LOGGER.warning('deprecated mode, move to direction=backwards option')
             mode = mode.replace('backwards-', '')
             direction = 'backward'
 
@@ -243,10 +243,10 @@ class KrakenX3(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if colors:
-                LOGGER.warning('too many colors for mode=%s, none needed', mode)
+                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
             colors = [[0, 0, 0]]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            LOGGER.warning('too many colors for mode=%s, dropping to %i', mode, maxcolors)
+            _LOGGER.warning('too many colors for mode=%s, dropping to %i', mode, maxcolors)
             colors = colors[:maxcolors]
 
         sval = _ANIMATION_SPEEDS[speed]
@@ -260,7 +260,7 @@ class KrakenX3(UsbHidDriver):
         stdtemps = list(range(20, _CRITICAL_TEMPERATURE + 1))
         interp = [clamp(interpolate_profile(norm, t), dmin, dmax) for t in stdtemps]
         for temp, duty in zip(stdtemps, interp):
-            LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C', channel,
+            _LOGGER.info('setting %s PWM duty to %i%% for liquid temperature >= %i°C', channel,
                         duty, temp)
         self._write(header + interp)
 

--- a/liquidctl/driver/nvidia.py
+++ b/liquidctl/driver/nvidia.py
@@ -28,6 +28,7 @@ ASUS_STRIX_RTX_2080_TI_OC = 0x866a
 EVGA = 0x3842
 EVGA_GTX_1080_FTW = 0x6286
 
+
 @unique
 class _ModeEnum(bytes, Enum):
     def __new__(cls, value, required_colors):

--- a/liquidctl/driver/nvidia.py
+++ b/liquidctl/driver/nvidia.py
@@ -147,10 +147,10 @@ class EvgaPascal(SmbusDriver):
         try:
             mode = self.Mode[mode.upper()]
         except KeyError:
-            raise ValueError('invalid mode: {!r}'.format(mode)) from None
+            raise ValueError(f'invalid mode: {mode!r}') from None
 
         if len(colors) < mode.required_colors:
-            raise ValueError('{} mode requires {} colors'.format(mode, mode.required_colors))
+            raise ValueError(f'{mode} mode requires {mode.required_colors} colors')
 
         if len(colors) > mode.required_colors:
             _LOGGER.debug('too many colors, dropping to %d', mode.required_colors)
@@ -294,7 +294,7 @@ class RogTuring(SmbusDriver):
         status = [('Mode', mode, '')]
 
         if mode.required_colors > 0:
-            status.append(('Color', '{:02x}{:02x}{:02x}'.format(red, green, blue), ''))
+            status.append(('Color', f'{red:02x}{green:02x}{blue:02x}', ''))
 
         return status
 
@@ -333,10 +333,10 @@ class RogTuring(SmbusDriver):
         try:
             mode = self.Mode[mode.upper()]
         except KeyError:
-            raise ValueError('invalid mode: {!r}'.format(mode)) from None
+            raise ValueError(f'invalid mode: {mode!r}') from None
 
         if len(colors) < mode.required_colors:
-            raise ValueError('{} mode requires {} colors'.format(mode, mode.required_colors))
+            raise ValueError(f'{mode} mode requires {mode.required_colors} colors')
 
         if len(colors) > mode.required_colors:
             _LOGGER.debug('too many colors, dropping to %d', mode.required_colors)

--- a/liquidctl/driver/nvidia.py
+++ b/liquidctl/driver/nvidia.py
@@ -86,7 +86,7 @@ class EvgaPascal(SmbusDriver):
 
             dev = cls(smbus, desc, vendor_id=EVGA, product_id=EVGA_GTX_1080_FTW,
                       address=ADDRESS)
-            _LOGGER.debug('instanced driver for %s', desc)
+            _LOGGER.debug('instanced driver for {}'.format(desc))
             yield dev
 
     def get_status(self, verbose=False, **kwargs):
@@ -102,8 +102,8 @@ class EvgaPascal(SmbusDriver):
             return []
 
         if not check_unsafe('smbus', **kwargs):
-            _LOGGER.warning("%s: nothing to return, requires unsafe features "
-                            "'smbus'",  self.description)
+            _LOGGER.warning("{}: nothing to return, requires unsafe features 'smbus'"
+                            .format(self.description))
             return []
 
         mode = self.Mode(self._smbus.read_byte_data(self._address, self._REG_MODE))
@@ -147,13 +147,13 @@ class EvgaPascal(SmbusDriver):
         try:
             mode = self.Mode[mode.upper()]
         except KeyError:
-            raise ValueError(f'invalid mode: {mode!r}') from None
+            raise ValueError('invalid mode: {!r}'.format(mode)) from None
 
         if len(colors) < mode.required_colors:
-            raise ValueError(f'{mode} mode requires {mode.required_colors} colors')
+            raise ValueError('{} mode requires {} colors'.format(mode, mode.required_colors))
 
         if len(colors) > mode.required_colors:
-            _LOGGER.debug('too many colors, dropping to %d', mode.required_colors)
+            _LOGGER.debug('too many colors, dropping to {}'.format(mode.required_colors))
             colors = colors[:mode.required_colors]
 
         self._smbus.write_byte_data(self._address, self._REG_MODE, mode.value)
@@ -168,7 +168,7 @@ class EvgaPascal(SmbusDriver):
             try:
                 self._smbus.write_byte_data(self._address, self._REG_PERSIST, self._PERSIST)
             except OSError as err:
-                _LOGGER.debug('expected OSError when writing to _REG_PERSIST: %s', err)
+                _LOGGER.debug('expected OSError when writing to _REG_PERSIST: {}'.format(err))
 
     def initialize(self, **kwargs):
         """Initialize the device."""
@@ -257,8 +257,8 @@ class RogTuring(SmbusDriver):
             if selected_address is not None:
                 dev = cls(smbus, desc, vendor_id=ASUS, product_id=dev_id,
                           address=selected_address)
-                _LOGGER.debug('instanced driver for %s at address %02x',
-                              desc, selected_address)
+                _LOGGER.debug('instanced driver for {} at address {:02x}'
+                              .format(desc, selected_address))
                 yield dev
 
     def get_status(self, verbose=False, **kwargs):
@@ -274,8 +274,8 @@ class RogTuring(SmbusDriver):
             return []
 
         if not check_unsafe('smbus', 'rog_turing', **kwargs):
-            _LOGGER.warning("%s: nothing to return, requires unsafe features "
-                            "'smbus,rog_turing'",  self.description)
+            _LOGGER.warning("{}: nothing to return, requires unsafe features "
+                            "'smbus,rog_turing'".format(self.description))
             return []
 
         assert self._address != self._SENTINEL_ADDRESS, \
@@ -294,7 +294,7 @@ class RogTuring(SmbusDriver):
         status = [('Mode', mode, '')]
 
         if mode.required_colors > 0:
-            status.append(('Color', f'{red:02x}{green:02x}{blue:02x}', ''))
+            status.append(('Color', '{:02x}{:02x}{:02x}'.format(red, green, blue), ''))
 
         return status
 
@@ -333,13 +333,13 @@ class RogTuring(SmbusDriver):
         try:
             mode = self.Mode[mode.upper()]
         except KeyError:
-            raise ValueError(f'invalid mode: {mode!r}') from None
+            raise ValueError('invalid mode: {!r}'.format(mode)) from None
 
         if len(colors) < mode.required_colors:
-            raise ValueError(f'{mode} mode requires {mode.required_colors} colors')
+            raise ValueError('{} mode requires {} colors'.format(mode, mode.required_colors))
 
         if len(colors) > mode.required_colors:
-            _LOGGER.debug('too many colors, dropping to %d', mode.required_colors)
+            _LOGGER.debug('too many colors, dropping to {}'.format(mode.required_colors))
             colors = colors[:mode.required_colors]
 
         if mode == self.Mode.OFF:

--- a/liquidctl/driver/nvidia.py
+++ b/liquidctl/driver/nvidia.py
@@ -86,7 +86,7 @@ class EvgaPascal(SmbusDriver):
 
             dev = cls(smbus, desc, vendor_id=EVGA, product_id=EVGA_GTX_1080_FTW,
                       address=ADDRESS)
-            _LOGGER.debug('instanced driver for {}'.format(desc))
+            _LOGGER.debug('instanced driver for %s', desc)
             yield dev
 
     def get_status(self, verbose=False, **kwargs):
@@ -102,8 +102,8 @@ class EvgaPascal(SmbusDriver):
             return []
 
         if not check_unsafe('smbus', **kwargs):
-            _LOGGER.warning("{}: nothing to return, requires unsafe features 'smbus'"
-                            .format(self.description))
+            _LOGGER.warning("%s: nothing to return, requires unsafe features 'smbus'",
+                            self.description)
             return []
 
         mode = self.Mode(self._smbus.read_byte_data(self._address, self._REG_MODE))
@@ -153,7 +153,7 @@ class EvgaPascal(SmbusDriver):
             raise ValueError('{} mode requires {} colors'.format(mode, mode.required_colors))
 
         if len(colors) > mode.required_colors:
-            _LOGGER.debug('too many colors, dropping to {}'.format(mode.required_colors))
+            _LOGGER.debug('too many colors, dropping to %d', mode.required_colors)
             colors = colors[:mode.required_colors]
 
         self._smbus.write_byte_data(self._address, self._REG_MODE, mode.value)
@@ -168,7 +168,7 @@ class EvgaPascal(SmbusDriver):
             try:
                 self._smbus.write_byte_data(self._address, self._REG_PERSIST, self._PERSIST)
             except OSError as err:
-                _LOGGER.debug('expected OSError when writing to _REG_PERSIST: {}'.format(err))
+                _LOGGER.debug('expected OSError when writing to _REG_PERSIST: %s', err)
 
     def initialize(self, **kwargs):
         """Initialize the device."""
@@ -257,8 +257,8 @@ class RogTuring(SmbusDriver):
             if selected_address is not None:
                 dev = cls(smbus, desc, vendor_id=ASUS, product_id=dev_id,
                           address=selected_address)
-                _LOGGER.debug('instanced driver for {} at address {:02x}'
-                              .format(desc, selected_address))
+                _LOGGER.debug('instanced driver for %s at address %02x',
+                              desc, selected_address)
                 yield dev
 
     def get_status(self, verbose=False, **kwargs):
@@ -274,8 +274,8 @@ class RogTuring(SmbusDriver):
             return []
 
         if not check_unsafe('smbus', 'rog_turing', **kwargs):
-            _LOGGER.warning("{}: nothing to return, requires unsafe features "
-                            "'smbus,rog_turing'".format(self.description))
+            _LOGGER.warning("%s: nothing to return, requires unsafe features "
+                            "'smbus,rog_turing'", self.description)
             return []
 
         assert self._address != self._SENTINEL_ADDRESS, \
@@ -339,7 +339,7 @@ class RogTuring(SmbusDriver):
             raise ValueError('{} mode requires {} colors'.format(mode, mode.required_colors))
 
         if len(colors) > mode.required_colors:
-            _LOGGER.debug('too many colors, dropping to {}'.format(mode.required_colors))
+            _LOGGER.debug('too many colors, dropping to %d', mode.required_colors)
             colors = colors[:mode.required_colors]
 
         if mode == self.Mode.OFF:

--- a/liquidctl/driver/nzxt_epsu.py
+++ b/liquidctl/driver/nzxt_epsu.py
@@ -13,15 +13,12 @@ Copyright (C) 2019–2020  Jonas Malaco and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
-import logging
 import time
 
 from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.error import NotSupportedByDevice
 from liquidctl.pmbus import CommandCode as CMD
 from liquidctl.pmbus import linear_to_float
-
-LOGGER = logging.getLogger(__name__)
 
 _REPORT_LENGTH = 64
 _MIN_DELAY = 0.0025

--- a/liquidctl/driver/nzxt_epsu.py
+++ b/liquidctl/driver/nzxt_epsu.py
@@ -56,7 +56,7 @@ class NzxtEPsu(UsbHidDriver):
         status = [
             ('Temperature', self._get_float(CMD.READ_TEMPERATURE_2), '°C'),
             ('Fan speed', self._get_float(CMD.READ_FAN_SPEED_1), 'rpm'),
-            ('Firmware version', '{}/{}'.format(fw_human, fw_cam), ''),
+            ('Firmware version', f'{fw_human}/{fw_cam}', ''),
         ]
         for i, name in enumerate(_RAILS):
             status.append((f'{name} output voltage', self._get_vout(i), 'V'))
@@ -108,7 +108,7 @@ class NzxtEPsu(UsbHidDriver):
             if res[0] == 0xaa and res[1] == data_len + 1:
                 data = res
                 break
-        assert data, 'invalid response (attempts={})'.format(_ATTEMPTS)
+        assert data, f'invalid response (attempts={_ATTEMPTS})'
         return data[2:(2 + data_len)]
 
     def _exec_page_plus_read(self, page, cmd, data_len):
@@ -124,7 +124,7 @@ class NzxtEPsu(UsbHidDriver):
             if res[0] == 0xaa and res[1] == data_len + 2 and res[2] == data_len:
                 data = res
                 break
-        assert data, 'invalid response (attempts={})'.format(_ATTEMPTS)
+        assert data, f'invalid response (attempts={_ATTEMPTS})'
         return data[3:(3 + data_len)]
 
     def _get_float(self, cmd, page=None):
@@ -141,7 +141,7 @@ class NzxtEPsu(UsbHidDriver):
 
     def _get_fw_versions(self):
         minor, major = self._exec_read(_SEASONIC_READ_FIRMWARE_VERSION, 2)
-        human_ver = '{}{:03}'.format(bytes([major]).decode(), minor)
+        human_ver = f'{bytes([major]).decode()}{minor:03}'
         ascam_ver = int.from_bytes(bytes.fromhex(human_ver), byteorder='big')
         return (human_ver, ascam_ver)
 

--- a/liquidctl/driver/nzxt_epsu.py
+++ b/liquidctl/driver/nzxt_epsu.py
@@ -79,7 +79,7 @@ class NzxtEPsu(UsbHidDriver):
     def _write(self, data):
         assert len(data) <= _REPORT_LENGTH
         packet = bytearray(1 + _REPORT_LENGTH)
-        packet[1 : 1 + len(data)] = data  # device doesn't use numbered reports
+        packet[1: 1 + len(data)] = data  # device doesn't use numbered reports
         self.device.write(packet)
 
     def _read(self):

--- a/liquidctl/driver/nzxt_epsu.py
+++ b/liquidctl/driver/nzxt_epsu.py
@@ -56,7 +56,7 @@ class NzxtEPsu(UsbHidDriver):
         status = [
             ('Temperature', self._get_float(CMD.READ_TEMPERATURE_2), '°C'),
             ('Fan speed', self._get_float(CMD.READ_FAN_SPEED_1), 'rpm'),
-            ('Firmware version', f'{fw_human}/{fw_cam}', ''),
+            ('Firmware version', '{}/{}'.format(fw_human, fw_cam), ''),
         ]
         for i, name in enumerate(_RAILS):
             status.append((f'{name} output voltage', self._get_vout(i), 'V'))
@@ -108,7 +108,7 @@ class NzxtEPsu(UsbHidDriver):
             if res[0] == 0xaa and res[1] == data_len + 1:
                 data = res
                 break
-        assert data, f'invalid response (attempts={_ATTEMPTS})'
+        assert data, 'invalid response (attempts={})'.format(_ATTEMPTS)
         return data[2:(2 + data_len)]
 
     def _exec_page_plus_read(self, page, cmd, data_len):
@@ -124,7 +124,7 @@ class NzxtEPsu(UsbHidDriver):
             if res[0] == 0xaa and res[1] == data_len + 2 and res[2] == data_len:
                 data = res
                 break
-        assert data, f'invalid response (attempts={_ATTEMPTS})'
+        assert data, 'invalid response (attempts={})'.format(_ATTEMPTS)
         return data[3:(3 + data_len)]
 
     def _get_float(self, cmd, page=None):
@@ -141,7 +141,7 @@ class NzxtEPsu(UsbHidDriver):
 
     def _get_fw_versions(self):
         minor, major = self._exec_read(_SEASONIC_READ_FIRMWARE_VERSION, 2)
-        human_ver = f'{bytes([major]).decode()}{minor:03}'
+        human_ver = '{}{:03}'.format(bytes([major]).decode(), minor)
         ascam_ver = int.from_bytes(bytes.fromhex(human_ver), byteorder='big')
         return (human_ver, ascam_ver)
 

--- a/liquidctl/driver/nzxt_epsu.py
+++ b/liquidctl/driver/nzxt_epsu.py
@@ -135,7 +135,7 @@ class NzxtEPsu(UsbHidDriver):
 
     def _get_vout(self, rail):
         mode = self._exec_page_plus_read(rail, CMD.VOUT_MODE, 1)[0]
-        assert mode >> 5 == 0 # assume vout_mode is always ulinear16
+        assert mode >> 5 == 0  # assume vout_mode is always ulinear16
         vout = self._exec_page_plus_read(rail, CMD.READ_VOUT, 2)
         return linear_to_float(vout, mode & 0x1f)
 

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -173,10 +173,6 @@ class RgbFusion2(UsbHidDriver):
         `slower`, `normal` (default), `faster`, `fastest` or `ludicrous`.
         """
 
-        if mode.lower() == 'static':
-            # TODO if today > 30 August 2020: remove this custom error
-            raise ValueError("This mode was renamed to 'fixed' before the 1.4.0 release, to be consistent with other devices")
-
         mode = _COLOR_MODES[mode.lower()]
         colors = iter(colors)
         channel = channel.lower()

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -196,7 +196,7 @@ class RgbFusion2(UsbHidDriver):
 
         brightness = clamp(100, 0, mode.max_brightness)  # hardcode this for now
         data = [_REPORT_ID, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-                  0x00, 0x00, 0x00, mode.value, brightness, 0x00]
+                0x00, 0x00, 0x00, mode.value, brightness, 0x00]
         data += single_color
         data += [0x00, 0x00, 0x00, 0x00, 0x00]
         if mode.speed_values:

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -92,6 +92,7 @@ _COLOR_MODES = {
     ]
 }
 
+
 class RgbFusion2(UsbHidDriver):
     """liquidctl driver for Gigabyte RGB Fusion 2.0 USB controllers."""
 

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -183,7 +183,7 @@ class RgbFusion2(UsbHidDriver):
                 r, g, b = next(colors)
                 single_color = (b, g, r)
             except StopIteration:
-                raise ValueError('One color required for mode={}'.format(mode.name))
+                raise ValueError(f'One color required for mode={mode.name}')
         else:
             single_color = (0, 0, 0)
         remaining = sum(1 for _ in colors)

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -133,7 +133,7 @@ class RgbFusion2(UsbHidDriver):
         fw_version = tuple(data[4:8])
         return [
             ('Hardware name', dev_name, ''),
-            ('Firmware version', '%d.%d.%d.%d' % fw_version, ''),
+            ('Firmware version', '{}.{}.{}.{}'.format(*fw_version), ''),
         ]
 
     def get_status(self, **kwargs):
@@ -144,7 +144,7 @@ class RgbFusion2(UsbHidDriver):
         non-empty list would contain `(property, value, unit)` tuples.
         """
 
-        _LOGGER.info('status reports not available from %s', self.description)
+        _LOGGER.info('status reports not available from {}'.format(self.description))
         return []
 
     def set_color(self, channel, mode, colors, speed='normal', **kwargs):
@@ -183,12 +183,12 @@ class RgbFusion2(UsbHidDriver):
                 r, g, b = next(colors)
                 single_color = (b, g, r)
             except StopIteration:
-                raise ValueError(f'One color required for mode={mode.name}')
+                raise ValueError('One color required for mode={}'.format(mode.name))
         else:
             single_color = (0, 0, 0)
         remaining = sum(1 for _ in colors)
         if remaining:
-            _LOGGER.warning('too many colors for mode=%s, dropping %d', mode.name, remaining)
+            _LOGGER.warning('too many colors for mode={}, dropping {}'.format(mode.name, remaining))
 
         brightness = clamp(100, 0, mode.max_brightness)  # hardcode this for now
         data = [_REPORT_ID, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -143,7 +143,7 @@ class RgbFusion2(UsbHidDriver):
         non-empty list would contain `(property, value, unit)` tuples.
         """
 
-        _LOGGER.info(f'Status reports not available from {self.description}')
+        _LOGGER.info('status reports not available from %s', self.description)
         return []
 
     def set_color(self, channel, mode, colors, speed='normal', **kwargs):

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -144,7 +144,7 @@ class RgbFusion2(UsbHidDriver):
         non-empty list would contain `(property, value, unit)` tuples.
         """
 
-        _LOGGER.info('status reports not available from {}'.format(self.description))
+        _LOGGER.info('status reports not available from %s', self.description)
         return []
 
     def set_color(self, channel, mode, colors, speed='normal', **kwargs):
@@ -188,7 +188,7 @@ class RgbFusion2(UsbHidDriver):
             single_color = (0, 0, 0)
         remaining = sum(1 for _ in colors)
         if remaining:
-            _LOGGER.warning('too many colors for mode={}, dropping {}'.format(mode.name, remaining))
+            _LOGGER.warning('too many colors for mode=%s, dropping %d', mode.name, remaining)
 
         brightness = clamp(100, 0, mode.max_brightness)  # hardcode this for now
         data = [_REPORT_ID, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -120,7 +120,7 @@ class RgbFusion2(UsbHidDriver):
         # single handle is returned for that device interface (see: 259)
 
         if (handle.hidinfo['usage_page'] == _USAGE_PAGE and
-            handle.hidinfo['usage'] == _OTHER_USAGE):
+                handle.hidinfo['usage'] == _OTHER_USAGE):
             return
 
         yield from super().probe(handle, **kwargs)

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -17,7 +17,7 @@ from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.error import NotSupportedByDevice
 from liquidctl.util import clamp
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 _REPORT_ID = 0xcc
 _REPORT_BYTE_LENGTH = 63
@@ -143,7 +143,7 @@ class RgbFusion2(UsbHidDriver):
         non-empty list would contain `(property, value, unit)` tuples.
         """
 
-        LOGGER.info(f'Status reports not available from {self.description}')
+        _LOGGER.info(f'Status reports not available from {self.description}')
         return []
 
     def set_color(self, channel, mode, colors, speed='normal', **kwargs):
@@ -191,7 +191,7 @@ class RgbFusion2(UsbHidDriver):
             single_color = (0, 0, 0)
         remaining = sum(1 for _ in colors)
         if remaining:
-            LOGGER.warning('too many colors for mode=%s, dropping %d', mode.name, remaining)
+            _LOGGER.warning('too many colors for mode=%s, dropping %d', mode.name, remaining)
 
         brightness = clamp(100, 0, mode.max_brightness)  # hardcode this for now
         data = [_REPORT_ID, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -106,7 +106,7 @@ from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.error import NotSupportedByDevice
 from liquidctl.util import clamp, Hue2Accessory, HUE2_MAX_ACCESSORIES_IN_CHANNEL
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 _ANIMATION_SPEEDS = {
     'slowest':  0x0,
@@ -143,7 +143,7 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
         directon = direction.lower()
 
         if 'backwards' in mode:
-            LOGGER.warning('deprecated mode, move to direction=backwards option')
+            _LOGGER.warning('deprecated mode, move to direction=backwards option')
             mode = mode.replace('backwards-', '')
             direction = 'backward'
 
@@ -155,10 +155,10 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if colors:
-                LOGGER.warning('too many colors for mode=%s, none needed', mode)
+                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
             colors = [[0, 0, 0]]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            LOGGER.warning('too many colors for mode=%s, dropping to %i',
+            _LOGGER.warning('too many colors for mode=%s, dropping to %i',
                            mode, maxcolors)
             colors = colors[:maxcolors]
 
@@ -173,7 +173,7 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
             selected_channels = {channel: self._speed_channels[channel]}
         for cname, (cid, dmin, dmax) in selected_channels.items():
             duty = clamp(duty, dmin, dmax)
-            LOGGER.info('setting %s duty to %i%%', cname, duty)
+            _LOGGER.info('setting %s duty to %i%%', cname, duty)
             self._write_fixed_duty(cid, duty)
 
     def set_speed_profile(self, channel, profile, **kwargs):

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -152,8 +152,7 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
         _, _, _, mincolors, maxcolors = self._COLOR_MODES[mode]
         colors = [[g, r, b] for [r, g, b] in colors]
         if len(colors) < mincolors:
-            raise ValueError('Not enough colors for mode={}, at least {} required'
-                             .format(mode, mincolors))
+            raise ValueError(f'Not enough colors for mode={mode}, at least {mincolors} required')
         elif maxcolors == 0:
             if colors:
                 _LOGGER.warning('too many colors for mode=%s, none needed', mode)
@@ -243,7 +242,7 @@ class SmartDevice(_CommonSmartDeviceDriver):
 
     def __init__(self, device, description, speed_channel_count, color_channel_count, **kwargs):
         """Instantiate a driver with a device handle."""
-        speed_channels = {'fan{}'.format(i + 1): (i, _MIN_DUTY, _MAX_DUTY)
+        speed_channels = {f'fan{i + 1}': (i, _MIN_DUTY, _MAX_DUTY)
                           for i in range(speed_channel_count)}
         color_channels = {'led': (i)
                           for i in range(color_channel_count)}
@@ -272,12 +271,12 @@ class SmartDevice(_CommonSmartDeviceDriver):
             msg = self.device.read(self._READ_LENGTH)
             num = (msg[15] >> 4) + 1
             state = msg[15] & 0x3
-            status.append(('Fan {}'.format(num), ['—', 'DC', 'PWM'][state], ''))
+            status.append((f'Fan {num}', ['—', 'DC', 'PWM'][state], ''))
             noise.append(msg[1])
             if state:
-                status.append(('Fan {} speed'.format(num), msg[3] << 8 | msg[4], 'rpm'))
-                status.append(('Fan {} voltage'.format(num), msg[7] + msg[8]/100, 'V'))
-                status.append(('Fan {} current'.format(num), msg[10]/100, 'A'))
+                status.append((f'Fan {num} speed', msg[3] << 8 | msg[4], 'rpm'))
+                status.append((f'Fan {num} voltage', msg[7] + msg[8]/100, 'V'))
+                status.append((f'Fan {num} current', msg[10]/100, 'A'))
             if i != 0:
                 continue
             fw = '{}.{}.{}'.format(msg[0xb], msg[0xc] << 8 | msg[0xd], msg[0xe])
@@ -389,9 +388,9 @@ class SmartDevice2(_CommonSmartDeviceDriver):
 
     def __init__(self, device, description, speed_channel_count, color_channel_count, **kwargs):
         """Instantiate a driver with a device handle."""
-        speed_channels = {'fan{}'.format(i + 1): (i, _MIN_DUTY, _MAX_DUTY)
+        speed_channels = {f'fan{i + 1}': (i, _MIN_DUTY, _MAX_DUTY)
                           for i in range(speed_channel_count)}
-        color_channels = {'led{}'.format(i + 1): (1 << i)
+        color_channels = {f'led{i + 1}': (1 << i)
                           for i in range(color_channel_count)}
         color_channels['sync'] = (1 << color_channel_count) - 1
         super().__init__(device, description, speed_channels, color_channels, **kwargs)
@@ -449,8 +448,8 @@ class SmartDevice2(_CommonSmartDeviceDriver):
             noise_offset = 56
             for i, _ in enumerate(self._speed_channels):
                 if ((msg[rpm_offset] != 0x0) and (msg[rpm_offset + 1] != 0x0)):
-                    status.append(('Fan {} speed'.format(i + 1), msg[rpm_offset + 1] << 8 | msg[rpm_offset], 'rpm'))
-                    status.append(('Fan {} duty'.format(i + 1), msg[duty_offset + i], '%'))
+                    status.append((f'Fan {i + 1} speed', msg[rpm_offset + 1] << 8 | msg[rpm_offset], 'rpm'))
+                    status.append((f'Fan {i + 1} duty', msg[duty_offset + i], '%'))
                 rpm_offset += 2
             status.append(('Noise level', msg[noise_offset], 'dB'))
 
@@ -467,7 +466,7 @@ class SmartDevice2(_CommonSmartDeviceDriver):
                 func(msg)
             if not parsers:
                 return
-        assert False, 'missing messages (attempts={}, missing={})'.format(self._MAX_READ_ATTEMPTS, len(parsers))
+        assert False, f'missing messages (attempts={self._MAX_READ_ATTEMPTS}, missing={len(parsers)})'
 
     def _write_colors(self, cid, mode, colors, sval, direction='forward',):
         mval, mod3, movingFlag, mincolors, maxcolors = self._COLOR_MODES[mode]

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -141,7 +141,7 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
         channel = channel.lower()
         mode = mode.lower()
         speed = speed.lower()
-        directon = direction.lower()
+        direction = direction.lower()
 
         if 'backwards' in mode:
             _LOGGER.warning('deprecated mode, move to direction=backwards option')
@@ -488,7 +488,7 @@ class SmartDevice2(_CommonSmartDeviceDriver):
                 color_lists[0] = [g, r, b] * 8
                 color_lists[1] = [int(x // 2.5) for x in color_lists[0]]
                 color_lists[2] = [int(x // 4) for x in color_lists[1]]
-                for i in range(8):   #  send color scheme first, before enabling wings mode
+                for i in range(8):   # send color scheme first, before enabling wings mode
                     mod = 0x05 if i in [3, 7] else 0x01
                     msg = ([0x22, 0x20, cid, i, 0x04, 0x39, 0x00, mod,
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06,
@@ -499,8 +499,8 @@ class SmartDevice2(_CommonSmartDeviceDriver):
         else:
             byte7 = movingFlag  # sets 'moving' flag for moving alternating modes
             byte8 = direction == 'backward'  # sets 'backwards' flag
-            byte9 = mod3 if mval == 0x03 else color_count  #  specifies 'marquee' LED size
-            byte10 = mod3 if mval == 0x05 else 0x00  #  specifies LED size for 'alternating' modes
+            byte9 = mod3 if mval == 0x03 else color_count  # specifies 'marquee' LED size
+            byte10 = mod3 if mval == 0x05 else 0x00  # specifies LED size for 'alternating' modes
             header = [0x28, 0x03, cid, 0x00, mval, sval, byte7, byte8, byte9, byte10]
             self._write(header + list(itertools.chain(*colors)))
 

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -119,6 +119,7 @@ _ANIMATION_SPEEDS = {
 _MIN_DUTY = 0
 _MAX_DUTY = 100
 
+
 class _CommonSmartDeviceDriver(UsbHidDriver):
     """Common functions of Smart Device and Grid drivers."""
 

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -156,11 +156,11 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if colors:
-                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
+                _LOGGER.warning('too many colors for mode={}, none needed'.format(mode))
             colors = [[0, 0, 0]]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            _LOGGER.warning('too many colors for mode=%s, dropping to %i',
-                            mode, maxcolors)
+            _LOGGER.warning('too many colors for mode={}, dropping to {}'
+                            .format(mode, maxcolors))
             colors = colors[:maxcolors]
 
         sval = _ANIMATION_SPEEDS[speed]
@@ -174,7 +174,7 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
             selected_channels = {channel: self._speed_channels[channel]}
         for cname, (cid, dmin, dmax) in selected_channels.items():
             duty = clamp(duty, dmin, dmax)
-            _LOGGER.info('setting %s duty to %i%%', cname, duty)
+            _LOGGER.info('setting {} duty to {}%'.format(cname, duty))
             self._write_fixed_duty(cid, duty)
 
     def set_speed_profile(self, channel, profile, **kwargs):
@@ -467,7 +467,7 @@ class SmartDevice2(_CommonSmartDeviceDriver):
                 func(msg)
             if not parsers:
                 return
-        assert False, f'missing messages (attempts={self._MAX_READ_ATTEMPTS}, missing={len(parsers)})'
+        assert False, 'missing messages (attempts={}, missing={})'.format(self._MAX_READ_ATTEMPTS, len(parsers))
 
     def _write_colors(self, cid, mode, colors, sval, direction='forward',):
         mval, mod3, movingFlag, mincolors, maxcolors = self._COLOR_MODES[mode]

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -160,7 +160,7 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
             colors = [[0, 0, 0]]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
             _LOGGER.warning('too many colors for mode=%s, dropping to %i',
-                           mode, maxcolors)
+                            mode, maxcolors)
             colors = colors[:maxcolors]
 
         sval = _ANIMATION_SPEEDS[speed]

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -477,7 +477,7 @@ class SmartDevice2(_CommonSmartDeviceDriver):
             leds = list(itertools.chain(*colors)) + led_padding
             self._write([0x22, 0x10, cid, 0x00] + leds[0:60]) # send first 20 colors to device (3 bytes per color)
             self._write([0x22, 0x11, cid, 0x00] + leds[60:])  # send remaining colors to device
-            self._write([0x22, 0xA0, cid, 0x00, mval, mod3, 0x00, 0x00, 0x00,
+            self._write([0x22, 0xa0, cid, 0x00, mval, mod3, 0x00, 0x00, 0x00,
                          0x00, 0x64, 0x00, 0x32, 0x00, 0x00, 0x01])
         elif mode == 'wings':  # wings requires special handling
             for [g, r, b] in colors:

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -475,7 +475,7 @@ class SmartDevice2(_CommonSmartDeviceDriver):
         if maxcolors == 40:
             led_padding = [0x00, 0x00, 0x00]*(maxcolors - color_count)  # turn off remaining LEDs
             leds = list(itertools.chain(*colors)) + led_padding
-            self._write([0x22, 0x10, cid, 0x00] + leds[0:60]) # send first 20 colors to device (3 bytes per color)
+            self._write([0x22, 0x10, cid, 0x00] + leds[0:60])  # send first 20 colors to device (3 bytes per color)
             self._write([0x22, 0x11, cid, 0x00] + leds[60:])  # send remaining colors to device
             self._write([0x22, 0xa0, cid, 0x00, mval, mod3, 0x00, 0x00, 0x00,
                          0x00, 0x64, 0x00, 0x32, 0x00, 0x00, 0x01])
@@ -496,16 +496,16 @@ class SmartDevice2(_CommonSmartDeviceDriver):
                     self._write(msg + color_lists[i % 4])
                 self._write([0x22, 0x03, cid, 0x08])   # this actually enables wings mode
         else:
-            byte7 = movingFlag # sets 'moving' flag for moving alternating modes
-            byte8 = direction == 'backward' # sets 'backwards' flag
+            byte7 = movingFlag  # sets 'moving' flag for moving alternating modes
+            byte8 = direction == 'backward'  # sets 'backwards' flag
             byte9 = mod3 if mval == 0x03 else color_count  #  specifies 'marquee' LED size
             byte10 = mod3 if mval == 0x05 else 0x00  #  specifies LED size for 'alternating' modes
             header = [0x28, 0x03, cid, 0x00, mval, sval, byte7, byte8, byte9, byte10]
             self._write(header + list(itertools.chain(*colors)))
 
     def _write_fixed_duty(self, cid, duty):
-        msg = [0x62, 0x01, 0x01 << cid, 0x00, 0x00, 0x00] # fan channel passed as bitflag in last 3 bits of 3rd byte
-        msg[cid + 3] = duty # duty percent in 4th, 5th, and 6th bytes for, respectively, fan1, fan2 and fan3
+        msg = [0x62, 0x01, 0x01 << cid, 0x00, 0x00, 0x00]  # fan channel passed as bitflag in last 3 bits of 3rd byte
+        msg[cid + 3] = duty  # duty percent in 4th, 5th, and 6th bytes for, respectively, fan1, fan2 and fan3
         self._write(msg)
 
 

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -156,11 +156,11 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
                              .format(mode, mincolors))
         elif maxcolors == 0:
             if colors:
-                _LOGGER.warning('too many colors for mode={}, none needed'.format(mode))
+                _LOGGER.warning('too many colors for mode=%s, none needed', mode)
             colors = [[0, 0, 0]]  # discard the input but ensure at least one step
         elif len(colors) > maxcolors:
-            _LOGGER.warning('too many colors for mode={}, dropping to {}'
-                            .format(mode, maxcolors))
+            _LOGGER.warning('too many colors for mode=%s, dropping to %d',
+                            mode, maxcolors)
             colors = colors[:maxcolors]
 
         sval = _ANIMATION_SPEEDS[speed]
@@ -174,7 +174,7 @@ class _CommonSmartDeviceDriver(UsbHidDriver):
             selected_channels = {channel: self._speed_channels[channel]}
         for cname, (cid, dmin, dmax) in selected_channels.items():
             duty = clamp(duty, dmin, dmax)
-            _LOGGER.info('setting {} duty to {}%'.format(cname, duty))
+            _LOGGER.info('setting %s duty to %i%%', cname, duty)
             self._write_fixed_duty(cid, duty)
 
     def set_speed_profile(self, channel, profile, **kwargs):

--- a/liquidctl/driver/smbus.py
+++ b/liquidctl/driver/smbus.py
@@ -26,9 +26,7 @@ if sys.platform == 'linux':
     # initialization
     from smbus import SMBus
 
-
     LinuxEeprom = namedtuple('LinuxEeprom', 'name data')
-
 
     class LinuxI2c(BaseBus):
         """The Linux I²C (`/sys/bus/i2c`) bus."""
@@ -68,7 +66,6 @@ if sys.platform == 'linux':
                 _LOGGER.debug('found I²C bus %s', i2c_bus.name)
                 yield from i2c_bus.find_devices(drivers, **kwargs)
 
-
     class LinuxI2cBus:
         """A Linux I²C device, which is itself an I²C bus.
 
@@ -90,7 +87,7 @@ if sys.platform == 'linux':
                 assert i2c_dev.name.startswith('i2c-')
                 self._number = int(i2c_dev.name[4:])
             except:
-                raise ValueError(f'cannot infer bus number')
+                raise ValueError('cannot infer bus number')
 
         def find_devices(self, drivers, **kwargs):
             """Probe drivers and find compatible devices in this bus."""
@@ -174,7 +171,7 @@ if sys.platform == 'linux':
                 name = self._i2c_dev.joinpath(dev, 'name').read_text().strip()
                 eeprom = self._i2c_dev.joinpath(dev, 'eeprom').read_bytes()
                 return LinuxEeprom(name, eeprom)
-            except Exception as err:
+            except Exception:
                 return None
 
         @property

--- a/liquidctl/driver/smbus.py
+++ b/liquidctl/driver/smbus.py
@@ -166,7 +166,7 @@ if sys.platform == 'linux':
             # uses kernel facilities to avoid directly reading from the EEPROM
             # or managing its pages, also avoiding the need for unsafe=smbus
 
-            dev = '{}-{:04x}'.format(self._number, address)
+            dev = f'{self._number}-{address:04x}'
             try:
                 name = self._i2c_dev.joinpath(dev, 'name').read_text().strip()
                 eeprom = self._i2c_dev.joinpath(dev, 'eeprom').read_bytes()
@@ -207,26 +207,21 @@ if sys.platform == 'linux':
 
         def __str__(self):
             if self.description:
-                return '{}: {}'.format(self.name, self.description)
+                return f'{self.name}: {self.description}'
             return self.name
 
         def __repr__(self):
             def hexid(maybe):
                 if maybe is not None:
-                    return '{:#06x}'.format(maybe)
+                    return f'{maybe:#06x}'
                 return 'None'
 
-            return '{}: name: {!r}, description: {!r}, parent_vendor: {}, ' \
-                   'parent_device: {}, parent_subsystem_vendor: {}, ' \
-                   'parent_subsystem_device: {}, parent_driver: {!r}'.format(
-                    self.__class__.__name__,
-                    self.name,
-                    self.description,
-                    hexid(self.parent_vendor),
-                    hexid(self.parent_device),
-                    hexid(self.parent_subsystem_vendor),
-                    hexid(self.parent_subsystem_device),
-                    self.parent_driver)
+            return f'{self.__class__.__name__}: name: {self.name!r}, description:' \
+                   f' {self.description!r}, parent_vendor: {hexid(self.parent_vendor)},' \
+                   f' parent_device: {hexid(self.parent_device)}, parent_subsystem_vendor:' \
+                   f' {hexid(self.parent_subsystem_vendor)},' \
+                   f' parent_subsystem_device: {hexid(self.parent_subsystem_device)},' \
+                   f' parent_driver: {self.parent_driver!r}'
 
         def _try_sysfs_read(self, *sub, default=None):
             try:
@@ -332,7 +327,7 @@ class SmbusDriver(BaseDriver):
     @property
     def address(self):
         """Address of the device on the corresponding bus, or None if N/A."""
-        return '{:#04x}'.format(self._address)
+        return f'{self._address:#04x}'
 
     @property
     def port(self):

--- a/liquidctl/driver/smbus.py
+++ b/liquidctl/driver/smbus.py
@@ -43,27 +43,27 @@ if sys.platform == 'linux':
 
             devices = self._i2c_root.joinpath('devices')
             if not devices.exists():
-                _LOGGER.debug('skipping {}, {} not available'
-                              .format(self.__class__.__name__, devices))
+                _LOGGER.debug('skipping %s, %s not available',
+                              self.__class__.__name__, devices)
                 return
 
             drivers = sorted(find_all_subclasses(SmbusDriver),
                              key=lambda x: (x.__module__, x.__name__))
 
-            _LOGGER.debug('searching {} ({})'.format(self.__class__.__name__,
-                          ', '.join(map(lambda x: x.__name__, drivers))))
+            _LOGGER.debug('searching %s (%s)', self.__class__.__name__,
+                          ', '.join(map(lambda x: x.__name__, drivers)))
 
             for i2c_dev in devices.iterdir():
                 try:
                     i2c_bus = LinuxI2cBus(i2c_dev)
                 except ValueError as err:
-                    _LOGGER.debug('ignoring {}, {}'.format(i2c_dev.name, err))
+                    _LOGGER.debug('ignoring %s, %s', i2c_dev.name, err)
                     continue
 
                 if bus and bus != i2c_bus.name:
                     continue
 
-                _LOGGER.debug('found I²C bus {}'.format(i2c_bus.name))
+                _LOGGER.debug('found I²C bus %s', i2c_bus.name)
                 yield from i2c_bus.find_devices(drivers, **kwargs)
 
     class LinuxI2cBus:
@@ -107,28 +107,28 @@ if sys.platform == 'linux':
         def read_byte(self, address):
             """Read a single byte from a device."""
             value = self._smbus.read_byte(address)
-            _LOGGER.debug('read byte @ {:#04x}:{:#04x}'.format(address, value))
+            _LOGGER.debug('read byte @ 0x%02x:0x%02x', address, value)
             return value
 
         def read_byte_data(self, address, register):
             """Read a single byte from a designated register."""
             value = self._smbus.read_byte_data(address, register)
-            _LOGGER.debug('read byte data @ {:#04x}:{:#04x} {:#04x}'
-                          .format(address, register, value))
+            _LOGGER.debug('read byte data @ 0x%02x:0x%02x 0x%02x',
+                          address, register, value)
             return value
 
         def read_word_data(self, address, register):
             """Read a single 2-byte word from a given register."""
             value = self._smbus.read_word_data(address, register)
-            _LOGGER.debug('read word data @ {:#04x}:{:#04x} {:#04x}'
-                          .format(address, register, value))
+            _LOGGER.debug('read word data @ 0x%02x:0x%02x 0x%02x',
+                          address, register, value)
             return value
 
         def read_block_data(self, address, register):
             """Read a block of up to  32 bytes from a given register."""
             data = self._smbus.read_block_data(address, register)
-            _LOGGER.debug('read block data @ {:#04x}:{:#04x} {}'
-                          .format(address, register, LazyHexRepr(data)))
+            _LOGGER.debug('read block data @ 0x%02x:0x%02x: %r',
+                          address, register, LazyHexRepr(data))
             return data
 
         def write_byte(self, address, value):
@@ -138,20 +138,20 @@ if sys.platform == 'linux':
 
         def write_byte_data(self, address, register, value):
             """Write a single byte to a designated register."""
-            _LOGGER.debug('writing byte data @ {:#04x}:{:#04x} {:#04x}'
-                          .format(address, register, value))
+            _LOGGER.debug('writing byte data @ 0x%02x:0x%02x 0x%02x',
+                          address, register, value)
             return self._smbus.write_byte_data(address, register, value)
 
         def write_word_data(self, address, register, value):
             """Write a single 2-byte word to a designated register."""
-            _LOGGER.debug('writing word data @ {:#04x}:{:#04x} {:#04x}'
-                          .format(address, register, value))
+            _LOGGER.debug('writing word data @ 0x%02x:0x%02x 0x%02x',
+                          address, register, value)
             return self._smbus.write_word_data(address, register, value)
 
         def write_block_data(self, address, register, data):
             """Write a block of byte data to a given register."""
-            _LOGGER.debug('writing block data @ {:#04x}:{:#04x} {}'
-                          .format(address, register, LazyHexRepr(data)))
+            _LOGGER.debug('writing block data @ 0x%02x:0x%02x %r',
+                          address, register, LazyHexRepr(data))
             return self._smbus.write_block_data(address, register, data)
 
         def close(self):

--- a/liquidctl/driver/smbus.py
+++ b/liquidctl/driver/smbus.py
@@ -43,27 +43,27 @@ if sys.platform == 'linux':
 
             devices = self._i2c_root.joinpath('devices')
             if not devices.exists():
-                _LOGGER.debug('skipping %s, %s not available',
-                              self.__class__.__name__, devices)
+                _LOGGER.debug('skipping {}, {} not available'
+                              .format(self.__class__.__name__, devices))
                 return
 
             drivers = sorted(find_all_subclasses(SmbusDriver),
                              key=lambda x: (x.__module__, x.__name__))
 
-            _LOGGER.debug('searching %s (%s)', self.__class__.__name__,
-                          ', '.join(map(lambda x: x.__name__, drivers)))
+            _LOGGER.debug('searching {} ({})'.format(self.__class__.__name__,
+                          ', '.join(map(lambda x: x.__name__, drivers))))
 
             for i2c_dev in devices.iterdir():
                 try:
                     i2c_bus = LinuxI2cBus(i2c_dev)
                 except ValueError as err:
-                    _LOGGER.debug('ignoring %s, %s', i2c_dev.name, err)
+                    _LOGGER.debug('ignoring {}, {}'.format(i2c_dev.name, err))
                     continue
 
                 if bus and bus != i2c_bus.name:
                     continue
 
-                _LOGGER.debug('found I²C bus %s', i2c_bus.name)
+                _LOGGER.debug('found I²C bus {}'.format(i2c_bus.name))
                 yield from i2c_bus.find_devices(drivers, **kwargs)
 
     class LinuxI2cBus:
@@ -107,28 +107,28 @@ if sys.platform == 'linux':
         def read_byte(self, address):
             """Read a single byte from a device."""
             value = self._smbus.read_byte(address)
-            _LOGGER.debug('read byte @ 0x%02x: 0x%02x', address, value)
+            _LOGGER.debug('read byte @ {:#04x}:{:#04x}'.format(address, value))
             return value
 
         def read_byte_data(self, address, register):
             """Read a single byte from a designated register."""
             value = self._smbus.read_byte_data(address, register)
-            _LOGGER.debug('read byte data @ 0x%02x:0x%02x: 0x%02x', address,
-                          register, value)
+            _LOGGER.debug('read byte data @ {:#04x}:{:#04x} {:#04x}'
+                          .format(address, register, value))
             return value
 
         def read_word_data(self, address, register):
             """Read a single 2-byte word from a given register."""
             value = self._smbus.read_word_data(address, register)
-            _LOGGER.debug('read word data @ 0x%02x:0x%02x: 0x%04x', address,
-                          register, value)
+            _LOGGER.debug('read word data @ {:#04x}:{:#04x} {:#04x}'
+                          .format(address, register, value))
             return value
 
         def read_block_data(self, address, register):
             """Read a block of up to  32 bytes from a given register."""
             data = self._smbus.read_block_data(address, register)
-            _LOGGER.debug('read block data @ 0x%02x:0x%02x: %r', address,
-                          register, LazyHexRepr(data))
+            _LOGGER.debug('read block data @ {:#04x}:{:#04x} {}'
+                          .format(address, register, LazyHexRepr(data)))
             return data
 
         def write_byte(self, address, value):
@@ -138,20 +138,20 @@ if sys.platform == 'linux':
 
         def write_byte_data(self, address, register, value):
             """Write a single byte to a designated register."""
-            _LOGGER.debug('writing byte data @ 0x%02x:0x%02x: 0x%02x', address,
-                          register, value)
+            _LOGGER.debug('writing byte data @ {:#04x}:{:#04x} {:#04x}'
+                          .format(address, register, value))
             return self._smbus.write_byte_data(address, register, value)
 
         def write_word_data(self, address, register, value):
             """Write a single 2-byte word to a designated register."""
-            _LOGGER.debug('writing word data @ 0x%02x:0x%02x: 0x%04x', address,
-                          register, value)
+            _LOGGER.debug('writing word data @ {:#04x}:{:#04x} {:#04x}'
+                          .format(address, register, value))
             return self._smbus.write_word_data(address, register, value)
 
         def write_block_data(self, address, register, data):
             """Write a block of byte data to a given register."""
-            _LOGGER.debug('writing block data @ 0x%02x:0x%02x: %r', address,
-                          register, LazyHexRepr(data))
+            _LOGGER.debug('writing block data @ {:#04x}:{:#04x} {}'
+                          .format(address, register, LazyHexRepr(data)))
             return self._smbus.write_block_data(address, register, data)
 
         def close(self):
@@ -166,7 +166,7 @@ if sys.platform == 'linux':
             # uses kernel facilities to avoid directly reading from the EEPROM
             # or managing its pages, also avoiding the need for unsafe=smbus
 
-            dev = f'{self._number}-{address:04x}'
+            dev = '{}-{:04x}'.format(self._number, address)
             try:
                 name = self._i2c_dev.joinpath(dev, 'name').read_text().strip()
                 eeprom = self._i2c_dev.joinpath(dev, 'eeprom').read_bytes()
@@ -207,22 +207,26 @@ if sys.platform == 'linux':
 
         def __str__(self):
             if self.description:
-                return f'{self.name}: {self.description}'
+                return '{}: {}'.format(self.name, self.description)
             return self.name
 
         def __repr__(self):
             def hexid(maybe):
                 if maybe is not None:
-                    return f'{maybe:#06x}'
+                    return '{:#06x}'.format(maybe)
                 return 'None'
 
-            return f'{self.__class__.__name__}: name: {self.name!r}, ' \
-                   f'description: {self.description!r}, ' \
-                   f'parent_vendor: {hexid(self.parent_vendor)}, ' \
-                   f'parent_device: {hexid(self.parent_device)}, ' \
-                   f'parent_subsystem_vendor: {hexid(self.parent_subsystem_vendor)}, ' \
-                   f'parent_subsystem_device: {hexid(self.parent_subsystem_device)}, ' \
-                   f'parent_driver: {self.parent_driver!r}'
+            return '{}: name: {!r}, description: {!r}, parent_vendor: {}, ' \
+                   'parent_device: {}, parent_subsystem_vendor: {}, ' \
+                   'parent_subsystem_device: {}, parent_driver: {!r}'.format(
+                    self.__class__.__name__,
+                    self.name,
+                    self.description,
+                    hexid(self.parent_vendor),
+                    hexid(self.parent_device),
+                    hexid(self.parent_subsystem_vendor),
+                    hexid(self.parent_subsystem_device),
+                    self.parent_driver)
 
         def _try_sysfs_read(self, *sub, default=None):
             try:
@@ -328,7 +332,7 @@ class SmbusDriver(BaseDriver):
     @property
     def address(self):
         """Address of the device on the corresponding bus, or None if N/A."""
-        return f'{self._address:#04x}'
+        return '{:#04x}'.format(self._address)
 
     @property
     def port(self):

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -415,7 +415,7 @@ class HidapiDevice:
                       len(data) - 1, LazyHexRepr(data, start=1))
         res = self.hiddev.write(data)
         if res < 0:
-                raise OSError('Could not write to device')
+            raise OSError('Could not write to device')
         if res != len(data):
             _LOGGER.debug('wrote %d total bytes, expected %d', res, len(data))
         return res
@@ -449,7 +449,7 @@ class HidapiDevice:
                       data[0], len(data) - 1, LazyHexRepr(data, start=1))
         res = self.hiddev.send_feature_report(data)
         if res < 0:
-                raise OSError('Could not send feature report to device')
+            raise OSError('Could not send feature report to device')
         if res != len(data):
             _LOGGER.debug('sent %d total bytes, expected %d', res, len(data))
         return res

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -318,7 +318,7 @@ class PyUsbDevice:
 
     @property
     def bus(self):
-        return 'usb{}'.format(self.usbdev.bus)  # follow Linux model
+        return f'usb{self.usbdev.bus}'  # follow Linux model
 
     @property
     def address(self):

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -103,7 +103,7 @@ class BaseUsbDriver(BaseDriver):
             consargs = devargs.copy()
             consargs.update(kwargs)
             dev = cls(handle, description, **consargs)
-            _LOGGER.debug('instanced driver for %s', description)
+            _LOGGER.debug('instanced driver for {}'.format(description))
             yield dev
 
     def __init__(self, device, description, **kwargs):
@@ -185,8 +185,8 @@ class UsbHidDriver(BaseUsbDriver):
         # instantiated with a usb.core.Device
         if isinstance(device, usb.core.Device):
             clname = self.__class__.__name__
-            _LOGGER.warning('constructing a %s instance from a usb.core.Device has been deprecated, '
-                            'use %s.find_supported_devices() or pass a HidapiDevice handle', clname, clname)
+            _LOGGER.warning('constructing a {} instance from a usb.core.Device has been deprecated, '
+                            'use {}.find_supported_devices() or pass a HidapiDevice handle'.format(clname, clname))
             usbdev = device
             hidinfo = next(info for info in hid.enumerate(usbdev.idVendor, usbdev.idProduct)
                            if info['serial_number'] == usbdev.serial_number)
@@ -246,7 +246,7 @@ class PyUsbDevice:
             # FIXME device or handle might not be ready for use after set_configuration()
             cfg = self.usbdev.get_active_configuration()
         self.bInterfaceNumber = self._select_interface(cfg)
-        _LOGGER.debug('selected interface: %d', self.bInterfaceNumber)
+        _LOGGER.debug('selected interface: {}'.format(self.bInterfaceNumber))
         if (sys.platform.startswith('linux') and
                 self.usbdev.is_kernel_driver_active(self.bInterfaceNumber)):
             _LOGGER.debug('replacing stock kernel driver with libusb')
@@ -277,17 +277,17 @@ class PyUsbDevice:
     def read(self, endpoint, length, timeout=None):
         """Read from endpoint."""
         data = self.usbdev.read(endpoint, length, timeout=timeout)
-        _LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
+        _LOGGER.debug('read {} bytes: {}'.format(len(data), LazyHexRepr(data)))
         return data
 
     def write(self, endpoint, data, timeout=None):
         """Write to endpoint."""
-        _LOGGER.debug('writting %d bytes: %r', len(data), LazyHexRepr(data))
+        _LOGGER.debug('writting {} bytes: {}'.format(len(data), LazyHexRepr(data)))
         return self.usbdev.write(endpoint, data, timeout=timeout)
 
     def ctrl_transfer(self, *args, **kwargs):
         """Submit a contrl transfer."""
-        _LOGGER.debug('sending control transfer with %r, %r', args, kwargs)
+        _LOGGER.debug('sending control transfer with {}, {}'.format(args, kwargs))
         return self.usbdev.ctrl_transfer(*args, **kwargs)
 
     @classmethod
@@ -384,7 +384,7 @@ class HidapiDevice:
         discarded = 0
         while self.hiddev.read(max_length=1, timeout_ms=timeout_ms):
             discarded += 1
-        _LOGGER.debug('discarded %d previously enqueued reports', discarded)
+        _LOGGER.debug('discarded {} previously enqueued reports'.format(discarded))
 
     def read(self, length):
         """Read raw report from HID.
@@ -398,7 +398,7 @@ class HidapiDevice:
         """
         self.hiddev.set_nonblocking(False)
         data = self.hiddev.read(length)
-        _LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
+        _LOGGER.debug('read {} bytes: {}'.format(len(data), LazyHexRepr(data)))
         return data
 
     def write(self, data):
@@ -411,13 +411,13 @@ class HidapiDevice:
         > first byte should be set to 0. The report data itself should begin
         > at the second byte.
         """
-        _LOGGER.debug('writting report 0x%02x with %d bytes: %r', data[0],
-                      len(data) - 1, LazyHexRepr(data, start=1))
+        _LOGGER.debug('writting report {:#04x} with {} bytes: {}'.format(data[0],
+                      len(data) - 1, LazyHexRepr(data, start=1)))
         res = self.hiddev.write(data)
         if res < 0:
             raise OSError('Could not write to device')
         if res != len(data):
-            _LOGGER.debug('wrote %d total bytes, expected %d', res, len(data))
+            _LOGGER.debug('wrote {} total bytes, expected {}'.format(res, len(data)))
         return res
 
     def get_feature_report(self, report_id, length):
@@ -431,8 +431,8 @@ class HidapiDevice:
         byte.
         """
         data = self.hiddev.get_feature_report(report_id, length)
-        _LOGGER.debug('got feature report 0x%02x with %d bytes: %r', data[0],
-                      len(data) - 1, LazyHexRepr(data, start=1))
+        _LOGGER.debug('got feature report {:#04x} with {} bytes: {}'.format(data[0],
+                      len(data) - 1, LazyHexRepr(data, start=1)))
         return data
 
     def send_feature_report(self, data):
@@ -445,13 +445,13 @@ class HidapiDevice:
         > first byte should be set to 0. The report data itself should begin
         > at the second byte.
         """
-        _LOGGER.debug('sending feature report 0x%02x with %d bytes: %r',
-                      data[0], len(data) - 1, LazyHexRepr(data, start=1))
+        _LOGGER.debug('sending feature report {:#04x} with {} bytes: {}'.format(
+                      data[0], len(data) - 1, LazyHexRepr(data, start=1)))
         res = self.hiddev.send_feature_report(data)
         if res < 0:
             raise OSError('Could not send feature report to device')
         if res != len(data):
-            _LOGGER.debug('sent %d total bytes, expected %d', res, len(data))
+            _LOGGER.debug('sent {} total bytes, expected {}'.format(res, len(data)))
         return res
 
     @classmethod
@@ -501,8 +501,8 @@ class HidapiBus(BaseBus):
         handles = HidapiDevice.enumerate(hid, vendor, product)
         drivers = sorted(find_all_subclasses(UsbHidDriver),
                          key=lambda x: (x.__module__, x.__name__))
-        _LOGGER.debug('searching %s (%s)', self.__class__.__name__,
-                      ', '.join(map(lambda x: x.__name__, drivers)))
+        _LOGGER.debug('searching {} ({})'.format(self.__class__.__name__,
+                      ', '.join(map(lambda x: x.__name__, drivers))))
         for handle in handles:
             if bus and handle.bus != bus:
                 continue
@@ -510,8 +510,8 @@ class HidapiBus(BaseBus):
                 continue
             if usb_port and handle.port != usb_port:
                 continue
-            _LOGGER.debug('found HID device %04x:%04x', handle.vendor_id,
-                          handle.product_id)
+            _LOGGER.debug('found HID device {:04x}:{:04x}'.format(handle.vendor_id,
+                          handle.product_id))
             for drv in drivers:
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)
 
@@ -531,7 +531,7 @@ class PyUsbBus(BaseBus):
                 continue
             if usb_port and handle.port != usb_port:
                 continue
-            _LOGGER.debug('found USB device %04x:%04x', handle.vendor_id,
-                          handle.product_id)
+            _LOGGER.debug('found USB device {:04x}:{:04x}'.format(handle.vendor_id,
+                          handle.product_id))
             for drv in drivers:
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -186,7 +186,7 @@ class UsbHidDriver(BaseUsbDriver):
         if isinstance(device, usb.core.Device):
             clname = self.__class__.__name__
             _LOGGER.warning('constructing a %s instance from a usb.core.Device has been deprecated, '
-                           'use %s.find_supported_devices() or pass a HidapiDevice handle', clname, clname)
+                            'use %s.find_supported_devices() or pass a HidapiDevice handle', clname, clname)
             usbdev = device
             hidinfo = next(info for info in hid.enumerate(usbdev.idVendor, usbdev.idProduct)
                            if info['serial_number'] == usbdev.serial_number)
@@ -412,7 +412,7 @@ class HidapiDevice:
         > at the second byte.
         """
         _LOGGER.debug('writting report 0x%02x with %d bytes: %r', data[0],
-                     len(data) - 1, LazyHexRepr(data, start=1))
+                      len(data) - 1, LazyHexRepr(data, start=1))
         res = self.hiddev.write(data)
         if res < 0:
                 raise OSError('Could not write to device')
@@ -432,7 +432,7 @@ class HidapiDevice:
         """
         data = self.hiddev.get_feature_report(report_id, length)
         _LOGGER.debug('got feature report 0x%02x with %d bytes: %r', data[0],
-                     len(data) - 1, LazyHexRepr(data, start=1))
+                      len(data) - 1, LazyHexRepr(data, start=1))
         return data
 
     def send_feature_report(self, data):
@@ -446,7 +446,7 @@ class HidapiDevice:
         > at the second byte.
         """
         _LOGGER.debug('sending feature report 0x%02x with %d bytes: %r',
-                     data[0], len(data) - 1, LazyHexRepr(data, start=1))
+                      data[0], len(data) - 1, LazyHexRepr(data, start=1))
         res = self.hiddev.send_feature_report(data)
         if res < 0:
                 raise OSError('Could not send feature report to device')
@@ -502,7 +502,7 @@ class HidapiBus(BaseBus):
         drivers = sorted(find_all_subclasses(UsbHidDriver),
                          key=lambda x: (x.__module__, x.__name__))
         _LOGGER.debug('searching %s (%s)', self.__class__.__name__,
-                     ', '.join(map(lambda x: x.__name__, drivers)))
+                      ', '.join(map(lambda x: x.__name__, drivers)))
         for handle in handles:
             if bus and handle.bus != bus:
                 continue
@@ -511,7 +511,7 @@ class HidapiBus(BaseBus):
             if usb_port and handle.port != usb_port:
                 continue
             _LOGGER.debug('found HID device %04x:%04x', handle.vendor_id,
-                         handle.product_id)
+                          handle.product_id)
             for drv in drivers:
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)
 
@@ -523,7 +523,7 @@ class PyUsbBus(BaseBus):
         drivers = sorted(find_all_subclasses(UsbDriver),
                          key=lambda x: (x.__module__, x.__name__))
         _LOGGER.debug('searching %s (%s)', self.__class__.__name__,
-                     ', '.join(map(lambda x: x.__name__, drivers)))
+                      ', '.join(map(lambda x: x.__name__, drivers)))
         for handle in PyUsbDevice.enumerate(vendor, product):
             if bus and handle.bus != bus:
                 continue
@@ -532,6 +532,6 @@ class PyUsbBus(BaseBus):
             if usb_port and handle.port != usb_port:
                 continue
             _LOGGER.debug('found USB device %04x:%04x', handle.vendor_id,
-                         handle.product_id)
+                          handle.product_id)
             for drv in drivers:
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -67,7 +67,7 @@ except ModuleNotFoundError:
 from liquidctl.driver.base import BaseDriver, BaseBus, find_all_subclasses
 from liquidctl.util import LazyHexRepr
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 
 class BaseUsbDriver(BaseDriver):
@@ -103,7 +103,7 @@ class BaseUsbDriver(BaseDriver):
             consargs = devargs.copy()
             consargs.update(kwargs)
             dev = cls(handle, description, **consargs)
-            LOGGER.debug('instanced driver for %s', description)
+            _LOGGER.debug('instanced driver for %s', description)
             yield dev
 
     def __init__(self, device, description, **kwargs):
@@ -185,7 +185,7 @@ class UsbHidDriver(BaseUsbDriver):
         # instantiated with a usb.core.Device
         if isinstance(device, usb.core.Device):
             clname = self.__class__.__name__
-            LOGGER.warning('constructing a %s instance from a usb.core.Device has been deprecated, '
+            _LOGGER.warning('constructing a %s instance from a usb.core.Device has been deprecated, '
                            'use %s.find_supported_devices() or pass a HidapiDevice handle', clname, clname)
             usbdev = device
             hidinfo = next(info for info in hid.enumerate(usbdev.idVendor, usbdev.idProduct)
@@ -241,26 +241,26 @@ class PyUsbDevice:
         try:
             cfg = self.usbdev.get_active_configuration()
         except usb.core.USBError:
-            LOGGER.debug('setting the (first) configuration')
+            _LOGGER.debug('setting the (first) configuration')
             self.usbdev.set_configuration()  # assume the first configuration
             # FIXME device or handle might not be ready for use after set_configuration()
             cfg = self.usbdev.get_active_configuration()
         self.bInterfaceNumber = self._select_interface(cfg)
-        LOGGER.debug('selected interface: %d', self.bInterfaceNumber)
+        _LOGGER.debug('selected interface: %d', self.bInterfaceNumber)
         if (sys.platform.startswith('linux') and
                 self.usbdev.is_kernel_driver_active(self.bInterfaceNumber)):
-            LOGGER.debug('replacing stock kernel driver with libusb')
+            _LOGGER.debug('replacing stock kernel driver with libusb')
             self.usbdev.detach_kernel_driver(self.bInterfaceNumber)
             self._attached = True
 
     def claim(self):
         """Explicitly claim the device from other programs."""
-        LOGGER.debug('explicitly claim interface')
+        _LOGGER.debug('explicitly claim interface')
         usb.util.claim_interface(self.usbdev, self.bInterfaceNumber)
 
     def release(self):
         """Release the device to other programs."""
-        LOGGER.debug('ensure interface is released')
+        _LOGGER.debug('ensure interface is released')
         usb.util.release_interface(self.usbdev, self.bInterfaceNumber)
 
     def close(self):
@@ -270,24 +270,24 @@ class PyUsbDevice:
         """
         self.release()
         if self._attached:
-            LOGGER.debug('restoring stock kernel driver')
+            _LOGGER.debug('restoring stock kernel driver')
             self.usbdev.attach_kernel_driver(self.bInterfaceNumber)
             self._attached = False
 
     def read(self, endpoint, length, timeout=None):
         """Read from endpoint."""
         data = self.usbdev.read(endpoint, length, timeout=timeout)
-        LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
+        _LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
         return data
 
     def write(self, endpoint, data, timeout=None):
         """Write to endpoint."""
-        LOGGER.debug('writting %d bytes: %r', len(data), LazyHexRepr(data))
+        _LOGGER.debug('writting %d bytes: %r', len(data), LazyHexRepr(data))
         return self.usbdev.write(endpoint, data, timeout=timeout)
 
     def ctrl_transfer(self, *args, **kwargs):
         """Submit a contrl transfer."""
-        LOGGER.debug('sending control transfer with %r, %r', args, kwargs)
+        _LOGGER.debug('sending control transfer with %r, %r', args, kwargs)
         return self.usbdev.ctrl_transfer(*args, **kwargs)
 
     @classmethod
@@ -384,7 +384,7 @@ class HidapiDevice:
         discarded = 0
         while self.hiddev.read(max_length=1, timeout_ms=timeout_ms):
             discarded += 1
-        LOGGER.debug('discarded %d previously enqueued reports', discarded)
+        _LOGGER.debug('discarded %d previously enqueued reports', discarded)
 
     def read(self, length):
         """Read raw report from HID.
@@ -398,7 +398,7 @@ class HidapiDevice:
         """
         self.hiddev.set_nonblocking(False)
         data = self.hiddev.read(length)
-        LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
+        _LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
         return data
 
     def write(self, data):
@@ -411,13 +411,13 @@ class HidapiDevice:
         > first byte should be set to 0. The report data itself should begin
         > at the second byte.
         """
-        LOGGER.debug('writting report 0x%02x with %d bytes: %r', data[0],
+        _LOGGER.debug('writting report 0x%02x with %d bytes: %r', data[0],
                      len(data) - 1, LazyHexRepr(data, start=1))
         res = self.hiddev.write(data)
         if res < 0:
                 raise OSError('Could not write to device')
         if res != len(data):
-            LOGGER.debug('wrote %d total bytes, expected %d', res, len(data))
+            _LOGGER.debug('wrote %d total bytes, expected %d', res, len(data))
         return res
 
     def get_feature_report(self, report_id, length):
@@ -431,7 +431,7 @@ class HidapiDevice:
         byte.
         """
         data = self.hiddev.get_feature_report(report_id, length)
-        LOGGER.debug('got feature report 0x%02x with %d bytes: %r', data[0],
+        _LOGGER.debug('got feature report 0x%02x with %d bytes: %r', data[0],
                      len(data) - 1, LazyHexRepr(data, start=1))
         return data
 
@@ -445,13 +445,13 @@ class HidapiDevice:
         > first byte should be set to 0. The report data itself should begin
         > at the second byte.
         """
-        LOGGER.debug('sending feature report 0x%02x with %d bytes: %r',
+        _LOGGER.debug('sending feature report 0x%02x with %d bytes: %r',
                      data[0], len(data) - 1, LazyHexRepr(data, start=1))
         res = self.hiddev.send_feature_report(data)
         if res < 0:
                 raise OSError('Could not send feature report to device')
         if res != len(data):
-            LOGGER.debug('sent %d total bytes, expected %d', res, len(data))
+            _LOGGER.debug('sent %d total bytes, expected %d', res, len(data))
         return res
 
     @classmethod
@@ -501,7 +501,7 @@ class HidapiBus(BaseBus):
         handles = HidapiDevice.enumerate(hid, vendor, product)
         drivers = sorted(find_all_subclasses(UsbHidDriver),
                          key=lambda x: (x.__module__, x.__name__))
-        LOGGER.debug('searching %s (%s)', self.__class__.__name__,
+        _LOGGER.debug('searching %s (%s)', self.__class__.__name__,
                      ', '.join(map(lambda x: x.__name__, drivers)))
         for handle in handles:
             if bus and handle.bus != bus:
@@ -510,7 +510,7 @@ class HidapiBus(BaseBus):
                 continue
             if usb_port and handle.port != usb_port:
                 continue
-            LOGGER.debug('found HID device %04x:%04x', handle.vendor_id,
+            _LOGGER.debug('found HID device %04x:%04x', handle.vendor_id,
                          handle.product_id)
             for drv in drivers:
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)
@@ -522,7 +522,7 @@ class PyUsbBus(BaseBus):
         """ Find compatible regular USB devices."""
         drivers = sorted(find_all_subclasses(UsbDriver),
                          key=lambda x: (x.__module__, x.__name__))
-        LOGGER.debug('searching %s (%s)', self.__class__.__name__,
+        _LOGGER.debug('searching %s (%s)', self.__class__.__name__,
                      ', '.join(map(lambda x: x.__name__, drivers)))
         for handle in PyUsbDevice.enumerate(vendor, product):
             if bus and handle.bus != bus:
@@ -531,7 +531,7 @@ class PyUsbBus(BaseBus):
                 continue
             if usb_port and handle.port != usb_port:
                 continue
-            LOGGER.debug('found USB device %04x:%04x', handle.vendor_id,
+            _LOGGER.debug('found USB device %04x:%04x', handle.vendor_id,
                          handle.product_id)
             for drv in drivers:
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -103,7 +103,7 @@ class BaseUsbDriver(BaseDriver):
             consargs = devargs.copy()
             consargs.update(kwargs)
             dev = cls(handle, description, **consargs)
-            _LOGGER.debug('instanced driver for {}'.format(description))
+            _LOGGER.debug('instanced driver for %s', description)
             yield dev
 
     def __init__(self, device, description, **kwargs):
@@ -185,8 +185,8 @@ class UsbHidDriver(BaseUsbDriver):
         # instantiated with a usb.core.Device
         if isinstance(device, usb.core.Device):
             clname = self.__class__.__name__
-            _LOGGER.warning('constructing a {} instance from a usb.core.Device has been deprecated, '
-                            'use {}.find_supported_devices() or pass a HidapiDevice handle'.format(clname, clname))
+            _LOGGER.warning('constructing a %s instance from a usb.core.Device has been deprecated, '
+                            'use %s.find_supported_devices() or pass a HidapiDevice handle', clname, clname)
             usbdev = device
             hidinfo = next(info for info in hid.enumerate(usbdev.idVendor, usbdev.idProduct)
                            if info['serial_number'] == usbdev.serial_number)
@@ -246,7 +246,7 @@ class PyUsbDevice:
             # FIXME device or handle might not be ready for use after set_configuration()
             cfg = self.usbdev.get_active_configuration()
         self.bInterfaceNumber = self._select_interface(cfg)
-        _LOGGER.debug('selected interface: {}'.format(self.bInterfaceNumber))
+        _LOGGER.debug('selected interface: %d', self.bInterfaceNumber)
         if (sys.platform.startswith('linux') and
                 self.usbdev.is_kernel_driver_active(self.bInterfaceNumber)):
             _LOGGER.debug('replacing stock kernel driver with libusb')
@@ -277,17 +277,17 @@ class PyUsbDevice:
     def read(self, endpoint, length, timeout=None):
         """Read from endpoint."""
         data = self.usbdev.read(endpoint, length, timeout=timeout)
-        _LOGGER.debug('read {} bytes: {}'.format(len(data), LazyHexRepr(data)))
+        _LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
         return data
 
     def write(self, endpoint, data, timeout=None):
         """Write to endpoint."""
-        _LOGGER.debug('writting {} bytes: {}'.format(len(data), LazyHexRepr(data)))
+        _LOGGER.debug('writting %d bytes: %r', len(data), LazyHexRepr(data))
         return self.usbdev.write(endpoint, data, timeout=timeout)
 
     def ctrl_transfer(self, *args, **kwargs):
         """Submit a contrl transfer."""
-        _LOGGER.debug('sending control transfer with {}, {}'.format(args, kwargs))
+        _LOGGER.debug('sending control transfer with %r, %r', args, kwargs)
         return self.usbdev.ctrl_transfer(*args, **kwargs)
 
     @classmethod
@@ -384,7 +384,7 @@ class HidapiDevice:
         discarded = 0
         while self.hiddev.read(max_length=1, timeout_ms=timeout_ms):
             discarded += 1
-        _LOGGER.debug('discarded {} previously enqueued reports'.format(discarded))
+        _LOGGER.debug('discarded %d previously enqueued reports', discarded)
 
     def read(self, length):
         """Read raw report from HID.
@@ -398,7 +398,7 @@ class HidapiDevice:
         """
         self.hiddev.set_nonblocking(False)
         data = self.hiddev.read(length)
-        _LOGGER.debug('read {} bytes: {}'.format(len(data), LazyHexRepr(data)))
+        _LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
         return data
 
     def write(self, data):
@@ -411,13 +411,13 @@ class HidapiDevice:
         > first byte should be set to 0. The report data itself should begin
         > at the second byte.
         """
-        _LOGGER.debug('writting report {:#04x} with {} bytes: {}'.format(data[0],
-                      len(data) - 1, LazyHexRepr(data, start=1)))
+        _LOGGER.debug('writting report 0x%02x with %d bytes: %r', data[0],
+                      len(data) - 1, LazyHexRepr(data, start=1))
         res = self.hiddev.write(data)
         if res < 0:
             raise OSError('Could not write to device')
         if res != len(data):
-            _LOGGER.debug('wrote {} total bytes, expected {}'.format(res, len(data)))
+            _LOGGER.debug('wrote %d total bytes, expected %d', res, len(data))
         return res
 
     def get_feature_report(self, report_id, length):
@@ -431,8 +431,8 @@ class HidapiDevice:
         byte.
         """
         data = self.hiddev.get_feature_report(report_id, length)
-        _LOGGER.debug('got feature report {:#04x} with {} bytes: {}'.format(data[0],
-                      len(data) - 1, LazyHexRepr(data, start=1)))
+        _LOGGER.debug('got feature report 0x%02x with %d bytes: %r', data[0],
+                      len(data) - 1, LazyHexRepr(data, start=1))
         return data
 
     def send_feature_report(self, data):
@@ -445,13 +445,13 @@ class HidapiDevice:
         > first byte should be set to 0. The report data itself should begin
         > at the second byte.
         """
-        _LOGGER.debug('sending feature report {:#04x} with {} bytes: {}'.format(
-                      data[0], len(data) - 1, LazyHexRepr(data, start=1)))
+        _LOGGER.debug('sending feature report 0x%02x with %d bytes: %r',
+                      data[0], len(data) - 1, LazyHexRepr(data, start=1))
         res = self.hiddev.send_feature_report(data)
         if res < 0:
             raise OSError('Could not send feature report to device')
         if res != len(data):
-            _LOGGER.debug('sent {} total bytes, expected {}'.format(res, len(data)))
+            _LOGGER.debug('sent %d total bytes, expected %d', res, len(data))
         return res
 
     @classmethod
@@ -501,8 +501,8 @@ class HidapiBus(BaseBus):
         handles = HidapiDevice.enumerate(hid, vendor, product)
         drivers = sorted(find_all_subclasses(UsbHidDriver),
                          key=lambda x: (x.__module__, x.__name__))
-        _LOGGER.debug('searching {} ({})'.format(self.__class__.__name__,
-                      ', '.join(map(lambda x: x.__name__, drivers))))
+        _LOGGER.debug('searching %s (%s)', self.__class__.__name__,
+                      ', '.join(map(lambda x: x.__name__, drivers)))
         for handle in handles:
             if bus and handle.bus != bus:
                 continue
@@ -510,8 +510,8 @@ class HidapiBus(BaseBus):
                 continue
             if usb_port and handle.port != usb_port:
                 continue
-            _LOGGER.debug('found HID device {:04x}:{:04x}'.format(handle.vendor_id,
-                          handle.product_id))
+            _LOGGER.debug('found HID device %04x:%04x', handle.vendor_id,
+                          handle.product_id)
             for drv in drivers:
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)
 
@@ -531,7 +531,7 @@ class PyUsbBus(BaseBus):
                 continue
             if usb_port and handle.port != usb_port:
                 continue
-            _LOGGER.debug('found USB device {:04x}:{:04x}'.format(handle.vendor_id,
-                          handle.product_id))
+            _LOGGER.debug('found USB device %04x:%04x', handle.vendor_id,
+                          handle.product_id)
             for drv in drivers:
                 yield from drv.probe(handle, vendor=vendor, product=product, **kwargs)

--- a/liquidctl/error.py
+++ b/liquidctl/error.py
@@ -4,15 +4,19 @@ Copyright (C) 2020–2020  Jonas Malaco and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+
 class ExpectationNotMet(Exception):
     """Unstable."""
     pass
 
+
 class NotSupportedByDevice(Exception):
     pass
 
+
 class NotSupportedByDriver(Exception):
     pass
+
 
 class UnsafeFeaturesNotEnabled(Exception):
     """Unstable."""

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -11,7 +11,7 @@ import tempfile
 
 from ast import literal_eval
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 XDG_RUNTIME_DIR = os.getenv('XDG_RUNTIME_DIR')
 
 
@@ -59,7 +59,7 @@ class _FilesystemBackend:
         if sys.platform == 'linux':
             # set the sticky bit to prevent removal during cleanup
             os.chmod(self._write_dir, 0o1700)
-        LOGGER.debug('data in %s', self._write_dir)
+        _LOGGER.debug('data in %s', self._write_dir)
 
     def load(self, key):
         for base in self._read_dirs:
@@ -73,12 +73,12 @@ class _FilesystemBackend:
                         value = None
                     else:
                         value = literal_eval(data)
-                    LOGGER.debug('loaded %s=%r (from %s)', key, value, path)
+                    _LOGGER.debug('loaded %s=%r (from %s)', key, value, path)
             except OSError as err:
-                LOGGER.warning('%s exists but cannot be read: %s', path, err)
+                _LOGGER.warning('%s exists but cannot be read: %s', path, err)
                 continue
             return value
-        LOGGER.debug('no data (file) found for %s', key)
+        _LOGGER.debug('no data (file) found for %s', key)
         return None
 
     def store(self, key, value):
@@ -90,7 +90,7 @@ class _FilesystemBackend:
             f.write(data)
             f.flush()
         os.replace(tmp, path)
-        LOGGER.debug('stored %s=%r (in %s)', key, value, path)
+        _LOGGER.debug('stored %s=%r (in %s)', key, value, path)
 
 
 class RuntimeStorage:

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -59,7 +59,7 @@ class _FilesystemBackend:
         if sys.platform == 'linux':
             # set the sticky bit to prevent removal during cleanup
             os.chmod(self._write_dir, 0o1700)
-        _LOGGER.debug('data in %s', self._write_dir)
+        _LOGGER.debug('data in {}'.format(self._write_dir))
 
     def load(self, key):
         for base in self._read_dirs:
@@ -73,12 +73,12 @@ class _FilesystemBackend:
                         value = None
                     else:
                         value = literal_eval(data)
-                    _LOGGER.debug('loaded %s=%r (from %s)', key, value, path)
+                    _LOGGER.debug('loaded {}={} (from {})'.format(key, value, path))
             except OSError as err:
-                _LOGGER.warning('%s exists but cannot be read: %s', path, err)
+                _LOGGER.warning('{} exists but cannot be read: {}'.format(path, err))
                 continue
             return value
-        _LOGGER.debug('no data (file) found for %s', key)
+        _LOGGER.debug('no data (file) found for {}'.format(key))
         return None
 
     def store(self, key, value):
@@ -90,7 +90,7 @@ class _FilesystemBackend:
             f.write(data)
             f.flush()
         os.replace(tmp, path)
-        _LOGGER.debug('stored %s=%r (in %s)', key, value, path)
+        _LOGGER.debug('stored {}={} (in {})'.format(key, value, path))
 
 
 class RuntimeStorage:

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -59,7 +59,7 @@ class _FilesystemBackend:
         if sys.platform == 'linux':
             # set the sticky bit to prevent removal during cleanup
             os.chmod(self._write_dir, 0o1700)
-        _LOGGER.debug('data in {}'.format(self._write_dir))
+        _LOGGER.debug('data in %s', self._write_dir)
 
     def load(self, key):
         for base in self._read_dirs:
@@ -73,12 +73,12 @@ class _FilesystemBackend:
                         value = None
                     else:
                         value = literal_eval(data)
-                    _LOGGER.debug('loaded {}={} (from {})'.format(key, value, path))
+                    _LOGGER.debug('loaded %s=%r (from %s)', key, value, path)
             except OSError as err:
-                _LOGGER.warning('{} exists but cannot be read: {}'.format(path, err))
+                _LOGGER.warning('%s exists but cannot be read: %s', path, err)
                 continue
             return value
-        _LOGGER.debug('no data (file) found for {}'.format(key))
+        _LOGGER.debug('no data (file) found for %s', key)
         return None
 
     def store(self, key, value):
@@ -90,7 +90,7 @@ class _FilesystemBackend:
             f.write(data)
             f.flush()
         os.replace(tmp, path)
-        _LOGGER.debug('stored {}={} (in {})'.format(key, value, path))
+        _LOGGER.debug('stored %s=%r (in %s)', key, value, path)
 
 
 class RuntimeStorage:

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -59,7 +59,7 @@ class Hue2Accessory(Enum):
     def _missing_(cls, value):
         dummy = object.__new__(cls)
         dummy.pretty_name = 'Unknown'
-        dummy._name_ = f'UNKNOWN_{value}'
+        dummy._name_ = 'UNKNOWN_{}'.format(value)
         dummy._value_ = value
         return dummy
 
@@ -93,7 +93,7 @@ class LazyHexRepr:
         self.sep = sep
 
     def __repr__(self):
-        hexvals = map(lambda x: '%02x' % x, self.data[self.start: self.end])
+        hexvals = map(lambda x: '{:02x}'.format(x), self.data[self.start: self.end])
         return self.sep.join(hexvals)
 
 
@@ -114,7 +114,7 @@ def clamp(value, clampmin, clampmax):
     """Clamp numeric `value` to interval [`clampmin`, `clampmax`]."""
     clamped = max(clampmin, min(clampmax, value))
     if clamped != value:
-        _LOGGER.debug('clamped %s to interval [%s, %s]', value, clampmin, clampmax)
+        _LOGGER.debug('clamped {} to interval [{}, {}]'.format(value, clampmin, clampmax))
     return clamped
 
 
@@ -285,12 +285,12 @@ def color_from_str(x):
     def parse_triple(sub, maxvalues):
         literal = literal_eval(sub)
         if not isinstance(literal, tuple) or len(literal) != 3:
-            raise ValueError(f'Expected 3-element triple: {x}')
+            raise ValueError('Expected 3-element triple: {}'.format(x))
         for value, maxvalue in zip(literal, maxvalues):
             if not isinstance(value, int) and not isinstance(value, float):
-                raise ValueError(f'Expected float or int: {value} in {x}')
+                raise ValueError('Expected float or int: {} in {}'.format(value, x))
             if value < 0 or value > maxvalue:
-                raise ValueError(f'Expected value in range [0, {maxvalue}]: {value} in {x}')
+                raise ValueError('Expected value in range [0, {}]: {} in {}'.format(maxvalue, value, x))
         return literal
 
     xl = x.lower()
@@ -311,7 +311,7 @@ def color_from_str(x):
     elif len(x) == 8 and xl.startswith('0x'):
         return list(bytes.fromhex(x[2:]))
     else:
-        raise ValueError(f'Cannot parse color: {x}')
+        raise ValueError('Cannot parse color: {}'.format(x))
 
 
 def check_unsafe(*reqs, unsafe=None, error=False, **kwargs):

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -114,7 +114,7 @@ def clamp(value, clampmin, clampmax):
     """Clamp numeric `value` to interval [`clampmin`, `clampmax`]."""
     clamped = max(clampmin, min(clampmax, value))
     if clamped != value:
-        _LOGGER.debug('clamped {} to interval [{}, {}]'.format(value, clampmin, clampmax))
+        _LOGGER.debug('clamped %s to interval [%s, %s]', value, clampmin, clampmax)
     return clamped
 
 

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -59,7 +59,7 @@ class Hue2Accessory(Enum):
     def _missing_(cls, value):
         dummy = object.__new__(cls)
         dummy.pretty_name = 'Unknown'
-        dummy._name_ = 'UNKNOWN_{}'.format(value)
+        dummy._name_ = f'UNKNOWN_{value}'
         dummy._value_ = value
         return dummy
 
@@ -93,7 +93,7 @@ class LazyHexRepr:
         self.sep = sep
 
     def __repr__(self):
-        hexvals = map(lambda x: '{:02x}'.format(x), self.data[self.start: self.end])
+        hexvals = map(lambda x: f'{x:02x}', self.data[self.start: self.end])
         return self.sep.join(hexvals)
 
 
@@ -285,12 +285,12 @@ def color_from_str(x):
     def parse_triple(sub, maxvalues):
         literal = literal_eval(sub)
         if not isinstance(literal, tuple) or len(literal) != 3:
-            raise ValueError('Expected 3-element triple: {}'.format(x))
+            raise ValueError(f'Expected 3-element triple: {x}')
         for value, maxvalue in zip(literal, maxvalues):
             if not isinstance(value, int) and not isinstance(value, float):
-                raise ValueError('Expected float or int: {} in {}'.format(value, x))
+                raise ValueError(f'Expected float or int: {value} in {x}')
             if value < 0 or value > maxvalue:
-                raise ValueError('Expected value in range [0, {}]: {} in {}'.format(maxvalue, value, x))
+                raise ValueError(f'Expected value in range [0, {maxvalue}]: {value} in {x}')
         return literal
 
     xl = x.lower()
@@ -311,7 +311,7 @@ def color_from_str(x):
     elif len(x) == 8 and xl.startswith('0x'):
         return list(bytes.fromhex(x[2:]))
     else:
-        raise ValueError('Cannot parse color: {}'.format(x))
+        raise ValueError(f'Cannot parse color: {x}')
 
 
 def check_unsafe(*reqs, unsafe=None, error=False, **kwargs):

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -12,7 +12,7 @@ from enum import Enum, unique
 
 from liquidctl.error import UnsafeFeaturesNotEnabled
 
-LOGGER = logging.getLogger(__name__)
+_LOGGER = logging.getLogger(__name__)
 
 HUE2_MAX_ACCESSORIES_IN_CHANNEL = 6
 
@@ -114,7 +114,7 @@ def clamp(value, clampmin, clampmax):
     """Clamp numeric `value` to interval [`clampmin`, `clampmax`]."""
     clamped = max(clampmin, min(clampmax, value))
     if clamped != value:
-        LOGGER.debug('clamped %s to interval [%s, %s]', value, clampmin, clampmax)
+        _LOGGER.debug('clamped %s to interval [%s, %s]', value, clampmin, clampmax)
     return clamped
 
 

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -145,6 +145,7 @@ def u16le_from(buffer, offset=0):
     """
     return int.from_bytes(buffer[offset : offset + 2], byteorder='little')
 
+
 def u16be_from(buffer, offset=0):
     """Read an unsigned 16-bit big-endian integer from `buffer`.
 

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -159,7 +159,7 @@ def u16be_from(buffer, offset=0):
 def delta(profile):
     """Compute a profile's Δx and Δy."""
     return [(cur[0]-prev[0], cur[1]-prev[1])
-            for cur,prev in zip(profile[1:], profile[:-1])]
+            for cur, prev in zip(profile[1:], profile[:-1])]
 
 
 def normalize_profile(profile, critx, max_value=100):

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -93,7 +93,7 @@ class LazyHexRepr:
         self.sep = sep
 
     def __repr__(self):
-        hexvals = map(lambda x: '%02x' % x, self.data[self.start : self.end])
+        hexvals = map(lambda x: '%02x' % x, self.data[self.start: self.end])
         return self.sep.join(hexvals)
 
 
@@ -143,7 +143,7 @@ def u16le_from(buffer, offset=0):
     >>> u16le_from(b'\x45\x05\x03', offset=1)
     773
     """
-    return int.from_bytes(buffer[offset : offset + 2], byteorder='little')
+    return int.from_bytes(buffer[offset: offset + 2], byteorder='little')
 
 
 def u16be_from(buffer, offset=0):
@@ -154,7 +154,7 @@ def u16be_from(buffer, offset=0):
     >>> u16be_from(b'\x45\x05\x03', offset=1)
     1283
     """
-    return int.from_bytes(buffer[offset : offset + 2], byteorder='big')
+    return int.from_bytes(buffer[offset: offset + 2], byteorder='big')
 
 
 def delta(profile):

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ import sys
 import setuptools
 from setuptools.command.develop import develop
 
+
 def get_static_version():
     """Read manually attributed version number.
 

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -97,7 +97,7 @@ class VirtualSmbus:
                  parent_driver='virtual'):
 
         self._open = False
-        self._data = [ [0] * register_count for _ in range(address_count) ]
+        self._data = [[0] * register_count for _ in range(address_count)]
 
         self.name = name
         self.description = description

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -7,6 +7,7 @@ Report = namedtuple('Report', ['number', 'data'])
 def noop(*args, **kwargs):
     return None
 
+
 class MockRuntimeStorage:
     def __init__(self, key_prefixes):
         self._cache = {}
@@ -96,7 +97,7 @@ class VirtualSmbus:
                  parent_driver='virtual'):
 
         self._open = False
-        self._data = [ [0] * register_count for _ in range(address_count) ] 
+        self._data = [ [0] * register_count for _ in range(address_count) ]
 
         self.name = name
         self.description = description

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,6 +1,7 @@
 import pytest
 from liquidctl.driver.base import BaseDriver
 
+
 class Virtual(BaseDriver):
     def __init__(self, **kwargs):
         self.kwargs = dict()

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -36,6 +36,7 @@ class _Mock690LcDevice():
     def _reset_sent(self):
         self._sent_xfers = deque()
 
+
 @pytest.fixture
 def mockModern690LcDevice():
     device = _Mock690LcDevice()
@@ -43,6 +44,7 @@ def mockModern690LcDevice():
 
     dev.connect()
     return dev
+
 
 @pytest.fixture
 def mockLegacy690LcDevice():
@@ -52,18 +54,21 @@ def mockLegacy690LcDevice():
     dev.connect()
     return dev
 
+
 def test_modern690Lc_device_not_totally_broken(mockModern690LcDevice):
     """A few reasonable example calls do not raise exceptions."""
+    dev = mockModern690LcDevice
 
-    mockModern690LcDevice.initialize()
-    status = mockModern690LcDevice.get_status()
-    mockModern690LcDevice.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
-                   time_per_color=3, time_off=1, alert_threshold=42,
-                   alert_color=[90, 80, 10])
-    mockModern690LcDevice.set_color(channel='led', mode='rainbow', colors=[], speed=5)
-    mockModern690LcDevice.set_speed_profile(channel='fan',
-                           profile=iter([(20, 20), (30, 50), (40, 100)]))
-    mockModern690LcDevice.set_fixed_speed(channel='pump', duty=50)
+    dev.initialize()
+    dev.get_status()
+    dev.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
+                  time_per_color=3, time_off=1, alert_threshold=42,
+                  alert_color=[90, 80, 10])
+    dev.set_color(channel='led', mode='rainbow', colors=[], speed=5)
+    dev.set_speed_profile(channel='fan',
+                          profile=iter([(20, 20), (30, 50), (40, 100)]))
+    dev.set_fixed_speed(channel='pump', duty=50)
+
 
 def test_modern690Lc_device_connect(mockModern690LcDevice):
     def mock_open():
@@ -71,9 +76,11 @@ def test_modern690Lc_device_connect(mockModern690LcDevice):
         opened = True
     mockModern690LcDevice.device.open = mock_open
     opened = False
+
     with mockModern690LcDevice.connect() as cm:
         assert cm == mockModern690LcDevice
         assert opened
+
 
 def test_modern690Lc_device_begin_transaction(mockModern690LcDevice):
     mockModern690LcDevice.device._reset_sent()
@@ -87,7 +94,8 @@ def test_modern690Lc_device_begin_transaction(mockModern690LcDevice):
     assert bmRequestType == 0x40
     assert wValue == 1
     assert wIndex == 0
-    assert datalen == None
+    assert datalen is None
+
 
 def test_legacy690Lc_device_not_totally_broken(mockLegacy690LcDevice):
     """A few reasonable example calls do not raise exceptions."""
@@ -96,10 +104,11 @@ def test_legacy690Lc_device_not_totally_broken(mockLegacy690LcDevice):
     dev.initialize()
     status = dev.get_status()
     dev.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
-                   time_per_color=3, time_off=1, alert_threshold=42,
-                   alert_color=[90, 80, 10])
+                  time_per_color=3, time_off=1, alert_threshold=42,
+                  alert_color=[90, 80, 10])
     dev.set_fixed_speed(channel='fan', duty=80)
     dev.set_fixed_speed(channel='pump', duty=50)
+
 
 def test_legacy690Lc_device_matches_leviathan_updates(mockLegacy690LcDevice):
     dev = mockLegacy690LcDevice
@@ -109,7 +118,7 @@ def test_legacy690Lc_device_matches_leviathan_updates(mockLegacy690LcDevice):
 
     dev.device._reset_sent()
     dev.set_color(channel='led', mode='fading', colors=[[0, 0, 255], [0, 255, 0]],
-                          time_per_color=1, alert_threshold=60, alert_color=[0, 0, 0])
+                  time_per_color=1, alert_threshold=60, alert_color=[0, 0, 0])
     _begin, (color_msgtype, color_ep, color_data) = dev.device._sent_xfers
     assert color_msgtype == 'write'
     assert color_ep == 2

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -80,7 +80,7 @@ class Modern690LcTestCase(unittest.TestCase):
         assert bmRequestType == 0x40
         assert wValue == 1
         assert wIndex == 0
-        assert datalen == None
+        assert datalen is None
 
 
 class Legacy690LcTestCase(unittest.TestCase):

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -51,11 +51,11 @@ class Modern690LcTestCase(unittest.TestCase):
         self.device.initialize()
         status = self.device.get_status()
         self.device.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
-                       time_per_color=3, time_off=1, alert_threshold=42,
-                       alert_color=[90, 80, 10])
+                              time_per_color=3, time_off=1, alert_threshold=42,
+                              alert_color=[90, 80, 10])
         self.device.set_color(channel='led', mode='rainbow', colors=[], speed=5)
         self.device.set_speed_profile(channel='fan',
-                               profile=iter([(20, 20), (30, 50), (40, 100)]))
+                                      profile=iter([(20, 20), (30, 50), (40, 100)]))
         self.device.set_fixed_speed(channel='pump', duty=50)
 
     def test_connect(self):
@@ -97,8 +97,8 @@ class Legacy690LcTestCase(unittest.TestCase):
         self.device.initialize()
         status = self.device.get_status()
         self.device.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
-                       time_per_color=3, time_off=1, alert_threshold=42,
-                       alert_color=[90, 80, 10])
+                              time_per_color=3, time_off=1, alert_threshold=42,
+                              alert_color=[90, 80, 10])
         self.device.set_fixed_speed(channel='fan', duty=80)
         self.device.set_fixed_speed(channel='pump', duty=50)
 

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -49,7 +49,7 @@ class Modern690LcTestCase(unittest.TestCase):
     def test_not_totally_broken(self):
         """A few reasonable example calls do not raise exceptions."""
         self.device.initialize()
-        status = self.device.get_status()
+        self.device.get_status()
         self.device.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
                               time_per_color=3, time_off=1, alert_threshold=42,
                               alert_color=[90, 80, 10])
@@ -95,7 +95,7 @@ class Legacy690LcTestCase(unittest.TestCase):
     def test_not_totally_broken(self):
         """A few reasonable example calls do not raise exceptions."""
         self.device.initialize()
-        status = self.device.get_status()
+        self.device.get_status()
         self.device.set_color(channel='led', mode='blinking', colors=iter([[3, 2, 1]]),
                               time_per_color=3, time_off=1, alert_threshold=42,
                               alert_color=[90, 80, 10])

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -3,6 +3,7 @@ from collections import deque
 from liquidctl.driver.asetek import Modern690Lc, Legacy690Lc, Hydro690Lc
 from _testutils import noop
 
+
 class _Mock690LcDevice():
     def __init__(self, vendor_id=None, product_id=None, release_number=None,
                  serial_number=None, bus=None, address=None, port=None):

--- a/tests/test_backwards_compatibility_10.py
+++ b/tests/test_backwards_compatibility_10.py
@@ -11,14 +11,14 @@ from liquidctl.version import __version__
 from _testutils import MockHidapiDevice
 
 SPECTRUM = [
-    (235,77,40),
-    (255,148,117),
-    (126,66,45),
-    (165,87,0),
-    (56,193,66),
-    (116,217,170),
-    (166,158,255),
-    (208,0,122)
+    (235, 77, 40),
+    (255, 148, 117),
+    (126, 66, 45),
+    (165, 87, 0),
+    (56, 193, 66),
+    (116, 217, 170),
+    (166, 158, 255),
+    (208, 0, 122)
 ]
 
 
@@ -44,7 +44,7 @@ class Pre11KrakenApisUsedByGkraken(unittest.TestCase):
 
     def test_deprecated_super_mode(self):
         # deprecated in favor of super-fixed, super-breathing and super-wave
-        self.device.set_color('sync', 'super', [(128,0,255)] + SPECTRUM, 'normal')
+        self.device.set_color('sync', 'super', [(128, 0, 255)] + SPECTRUM, 'normal')
 
     def test_status_order(self):
         # GKraken unreasonably expects a particular ordering

--- a/tests/test_backwards_compatibility_10.py
+++ b/tests/test_backwards_compatibility_10.py
@@ -21,6 +21,7 @@ SPECTRUM = [
     (208, 0, 122)
 ]
 
+
 @pytest.fixture
 def mockDevice():
     device = MockHidapiDevice()
@@ -30,21 +31,26 @@ def mockDevice():
     dev.connect()
     return dev
 
+
 def test_pre11_apis_find_does_not_raise():
     import liquidctl.cli
-    devices = liquidctl.cli.find_all_supported_devices()
+    liquidctl.cli.find_all_supported_devices()
+
 
 def test_pre11_apis_connect_as_initialize(mockDevice):
     # deprecated behavior in favor of connect()
     mockDevice.initialize()
 
+
 def test_pre11_apis_deprecated_super_mode(mockDevice):
     # deprecated in favor of super-fixed, super-breathing and super-wave
-    mockDevice.set_color('sync', 'super', [(128,0,255)] + SPECTRUM, 'normal')
+    mockDevice.set_color('sync', 'super', [(128, 0, 255)] + SPECTRUM, 'normal')
+
 
 def test_pre11_apis_status_order(mockDevice):
     # GKraken unreasonably expects a particular ordering
     pass
+
 
 def test_pre11_apis_finalize_as_connect_or_noop(mockDevice):
     # deprecated in favor of disconnect()

--- a/tests/test_backwards_compatibility_10.py
+++ b/tests/test_backwards_compatibility_10.py
@@ -25,7 +25,7 @@ SPECTRUM = [
 class Pre11CliApisUsedByGkraken(unittest.TestCase):
     def test_find_does_not_raise(self):
         import liquidctl.cli
-        devices = liquidctl.cli.find_all_supported_devices()
+        liquidctl.cli.find_all_supported_devices()
 
 
 class Pre11KrakenApisUsedByGkraken(unittest.TestCase):

--- a/tests/test_backwards_compatibility_11.py
+++ b/tests/test_backwards_compatibility_11.py
@@ -24,10 +24,10 @@ def test_construct_with_raw_pyusb_handle(monkeypatch):
     pyusb_handle = _MockPyUsbHandle(serial_number='123456789')
     liquidctl_device = Kraken2(pyusb_handle, 'Some device')
     assert liquidctl_device.device.vendor_id == pyusb_handle.idVendor, \
-            '<driver instance>.device points to incorrect physical device'
+        '<driver instance>.device points to incorrect physical device'
     assert liquidctl_device.device.product_id == pyusb_handle.idProduct, \
-            '<driver instance>.device points to incorrect physical device'
+        '<driver instance>.device points to incorrect physical device'
     assert liquidctl_device.device.serial_number == pyusb_handle.serial_number, \
-            '<driver instance>.device points to different physical unit'
+        '<driver instance>.device points to different physical unit'
     assert isinstance(liquidctl_device.device, HidapiDevice), \
-            '<driver instance>.device not properly converted to HidapiDevice instance'
+        '<driver instance>.device not properly converted to HidapiDevice instance'

--- a/tests/test_backwards_compatibility_12.py
+++ b/tests/test_backwards_compatibility_12.py
@@ -1,4 +1,5 @@
 import pytest
 
+
 def test_pre13_old_driver_names():
     from liquidctl.driver.nzxt_smart_device import NzxtSmartDeviceDriver

--- a/tests/test_backwards_compatibility_12.py
+++ b/tests/test_backwards_compatibility_12.py
@@ -1,5 +1,6 @@
 import unittest
 
+
 class Pre13NamesTestCase(unittest.TestCase):
     def test_old_driver_names(self):
         from liquidctl.driver.nzxt_smart_device import NzxtSmartDeviceDriver

--- a/tests/test_backwards_compatibility_13.py
+++ b/tests/test_backwards_compatibility_13.py
@@ -1,11 +1,13 @@
 import pytest
 
+
 def test_pre14_old_module_names():
     import liquidctl.driver.asetek
     import liquidctl.driver.corsair_hid_psu
     import liquidctl.driver.kraken_two
     import liquidctl.driver.nzxt_smart_device
     import liquidctl.driver.seasonic
+
 
 def test_pre14_old_driver_names():
     from liquidctl.driver.asetek import AsetekDriver

--- a/tests/test_backwards_compatibility_13.py
+++ b/tests/test_backwards_compatibility_13.py
@@ -1,5 +1,6 @@
 import unittest
 
+
 class Pre14NamesTestCase(unittest.TestCase):
     def test_old_module_names(self):
         import liquidctl.driver.asetek

--- a/tests/test_comander_pro.py
+++ b/tests/test_comander_pro.py
@@ -136,10 +136,10 @@ def test_connect_lighting(lightingNodeProDeviceUnconnected):
 def test_initialize_commander_pro(commanderProDevice):
 
     responses = [
-        '000009d4000000000000000000000000', # firmware
-        '00000500000000000000000000000000', # bootloader
-        '00010100010000000000000000000000', # temp probes
-        '00010102000000000000000000000000'  # fan probes
+        '000009d4000000000000000000000000',  # firmware
+        '00000500000000000000000000000000',  # bootloader
+        '00010100010000000000000000000000',  # temp probes
+        '00010102000000000000000000000000'   # fan probes
     ]
     for d in responses:
         commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
@@ -182,7 +182,7 @@ def test_initialize_commander_pro(commanderProDevice):
 
 def test_initialize_lighting_node(lightingNodeProDevice):
     responses = [
-        '000009d4000000000000000000000000', # firmware
+        '000009d4000000000000000000000000',  # firmware
         '00000500000000000000000000000000'  # bootloader
     ]
     for d in responses:
@@ -203,15 +203,15 @@ def test_initialize_lighting_node(lightingNodeProDevice):
 def test_get_status_commander_pro(commanderProDevice):
 
         responses = [
-            '000a8300000000000000000000000000', # temp sensor 1
-            '000b6a00000000000000000000000000', # temp sensor 2
-            '000a0e00000000000000000000000000', # temp sensor 4
-            '002f2200000000000000000000000000', # get 12v
-            '00136500000000000000000000000000', # get 5v
-            '000d1f00000000000000000000000000', # get 3.3v
-            '0003ac00000000000000000000000000', # fan speed 1
-            '0003ab00000000000000000000000000', # fan speed 2
-            '0003db00000000000000000000000000' # fan speed 3
+            '000a8300000000000000000000000000',  # temp sensor 1
+            '000b6a00000000000000000000000000',  # temp sensor 2
+            '000a0e00000000000000000000000000',  # temp sensor 4
+            '002f2200000000000000000000000000',  # get 12v
+            '00136500000000000000000000000000',  # get 5v
+            '000d1f00000000000000000000000000',  # get 3.3v
+            '0003ac00000000000000000000000000',  # fan speed 1
+            '0003ab00000000000000000000000000',  # fan speed 2
+            '0003db00000000000000000000000000'  # fan speed 3
         ]
         for d in responses:
             commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))

--- a/tests/test_comander_pro.py
+++ b/tests/test_comander_pro.py
@@ -223,61 +223,61 @@ def test_initialize_lighting_node(lightingNodeProDevice):
 
 def test_get_status_commander_pro(commanderProDevice):
 
-        responses = [
-            '000a8300000000000000000000000000',  # temp sensor 1
-            '000b6a00000000000000000000000000',  # temp sensor 2
-            '000a0e00000000000000000000000000',  # temp sensor 4
-            '002f2200000000000000000000000000',  # get 12v
-            '00136500000000000000000000000000',  # get 5v
-            '000d1f00000000000000000000000000',  # get 3.3v
-            '0003ac00000000000000000000000000',  # fan speed 1
-            '0003ab00000000000000000000000000',  # fan speed 2
-            '0003db00000000000000000000000000'  # fan speed 3
-        ]
-        for d in responses:
-            commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
+    responses = [
+        '000a8300000000000000000000000000',  # temp sensor 1
+        '000b6a00000000000000000000000000',  # temp sensor 2
+        '000a0e00000000000000000000000000',  # temp sensor 4
+        '002f2200000000000000000000000000',  # get 12v
+        '00136500000000000000000000000000',  # get 5v
+        '000d1f00000000000000000000000000',  # get 3.3v
+        '0003ac00000000000000000000000000',  # fan speed 1
+        '0003ab00000000000000000000000000',  # fan speed 2
+        '0003db00000000000000000000000000'  # fan speed 3
+    ]
+    for d in responses:
+        commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
 
-        commanderProDevice._data.store('fan_modes', [0x01, 0x01, 0x02, 0x00, 0x00, 0x00])
-        commanderProDevice._data.store('temp_sensors_connected', [0x01, 0x01, 0x00, 0x01])
+    commanderProDevice._data.store('fan_modes', [0x01, 0x01, 0x02, 0x00, 0x00, 0x00])
+    commanderProDevice._data.store('temp_sensors_connected', [0x01, 0x01, 0x00, 0x01])
 
-        res = commanderProDevice.get_status()
+    res = commanderProDevice.get_status()
 
-        assert len(res) == 13
+    assert len(res) == 13
 
-        # voltages
-        assert res[0][1] == 12.066   # 12v
-        assert res[1][1] == 4.965    # 5v
-        assert res[2][1] == 3.359    # 3.3v
+    # voltages
+    assert res[0][1] == 12.066   # 12v
+    assert res[1][1] == 4.965    # 5v
+    assert res[2][1] == 3.359    # 3.3v
 
-        # temp probes
-        assert res[3][1] == 26.91
-        assert res[4][1] == 29.22
-        assert res[5][1] == 0.0
-        assert res[6][1] == 25.74
+    # temp probes
+    assert res[3][1] == 26.91
+    assert res[4][1] == 29.22
+    assert res[5][1] == 0.0
+    assert res[6][1] == 25.74
 
-        # fans rpm
-        assert res[7][1] == 940
-        assert res[8][1] == 939
-        assert res[9][1] == 987
-        assert res[10][1] == 0
-        assert res[11][1] == 0
-        assert res[12][1] == 0
+    # fans rpm
+    assert res[7][1] == 940
+    assert res[8][1] == 939
+    assert res[9][1] == 987
+    assert res[10][1] == 0
+    assert res[11][1] == 0
+    assert res[12][1] == 0
 
-        # check the commands sent
-        sent = commanderProDevice.device.sent
-        assert len(sent) == 9
+    # check the commands sent
+    sent = commanderProDevice.device.sent
+    assert len(sent) == 9
 
-        assert sent[0].data[0] == 0x11
-        assert sent[1].data[0] == 0x11
-        assert sent[2].data[0] == 0x11
+    assert sent[0].data[0] == 0x11
+    assert sent[1].data[0] == 0x11
+    assert sent[2].data[0] == 0x11
 
-        assert sent[3].data[0] == 0x12
-        assert sent[4].data[0] == 0x12
-        assert sent[5].data[0] == 0x12
+    assert sent[3].data[0] == 0x12
+    assert sent[4].data[0] == 0x12
+    assert sent[5].data[0] == 0x12
 
-        assert sent[6].data[0] == 0x21
-        assert sent[7].data[0] == 0x21
-        assert sent[8].data[0] == 0x21
+    assert sent[6].data[0] == 0x21
+    assert sent[7].data[0] == 0x21
+    assert sent[8].data[0] == 0x21
 
 
 def test_get_status_lighting_pro(lightingNodeProDevice):
@@ -524,36 +524,36 @@ def test_set_fixed_speed_valid_unconfigured(commanderProDevice):
 
 
 def test_set_fixed_speed_valid_multi_fan(commanderProDevice):
-        responses = [
-            '00000000000000000000000000000000',
-            '00000000000000000000000000000000',
-            '00000000000000000000000000000000',
-            '00000000000000000000000000000000',
-            '00000000000000000000000000000000'
-        ]
+    responses = [
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000'
+    ]
 
-        for d in responses:
-            commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
+    for d in responses:
+        commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
 
-        commanderProDevice._data.store('fan_modes', [0x01, 0x00, 0x01, 0x01, 0x00, 0x00])
+    commanderProDevice._data.store('fan_modes', [0x01, 0x00, 0x01, 0x01, 0x00, 0x00])
 
-        commanderProDevice.set_fixed_speed('sync', 50)
+    commanderProDevice.set_fixed_speed('sync', 50)
 
-        # check the commands sent
-        sent = commanderProDevice.device.sent
-        assert len(sent) == 3
+    # check the commands sent
+    sent = commanderProDevice.device.sent
+    assert len(sent) == 3
 
-        assert sent[0].data[0] == 0x23
-        assert sent[0].data[1] == 0x00
-        assert sent[0].data[2] == 0x32
+    assert sent[0].data[0] == 0x23
+    assert sent[0].data[1] == 0x00
+    assert sent[0].data[2] == 0x32
 
-        assert sent[1].data[0] == 0x23
-        assert sent[1].data[1] == 0x02
-        assert sent[1].data[2] == 0x32
+    assert sent[1].data[0] == 0x23
+    assert sent[1].data[1] == 0x02
+    assert sent[1].data[2] == 0x32
 
-        assert sent[2].data[0] == 0x23
-        assert sent[2].data[1] == 0x03
-        assert sent[2].data[2] == 0x32
+    assert sent[2].data[0] == 0x23
+    assert sent[2].data[1] == 0x03
+    assert sent[2].data[2] == 0x32
 
 
 def test_set_fixed_speed_lighting(lightingNodeProDevice):

--- a/tests/test_comander_pro.py
+++ b/tests/test_comander_pro.py
@@ -21,17 +21,17 @@ from _testutils import MockHidapiDevice, Report, MockRuntimeStorage
 
 @pytest.fixture
 def commanderProDeviceUnconnected():
-    device = MockHidapiDevice(vendor_id=0x1B1C, product_id=0x0C10, address='addr')
+    device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c10, address='addr')
     return CommanderPro(device, 'Corsair Commander Pro (experimental)', 6, 4, 2)
 
 @pytest.fixture
 def lightingNodeProDeviceUnconnected():
-    device = MockHidapiDevice(vendor_id=0x1B1C, product_id=0x0C0B, address='addr')
+    device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c0b, address='addr')
     return CommanderPro(device, 'Corsair Lighting Node Pro (experimental)', 0, 0, 2)
 
 @pytest.fixture
 def commanderProDevice():
-    device = MockHidapiDevice(vendor_id=0x1B1C, product_id=0x0C10, address='addr')
+    device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c10, address='addr')
     pro =  CommanderPro(device, 'Corsair Commander Pro (experimental)', 6, 4, 2)
     pro.connect()
     pro._data = MockRuntimeStorage(key_prefixes='testing')
@@ -39,7 +39,7 @@ def commanderProDevice():
 
 @pytest.fixture
 def lightingNodeProDevice():
-    device = MockHidapiDevice(vendor_id=0x1B1C, product_id=0x0C0B, address='addr')
+    device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c0b, address='addr')
     node = CommanderPro(device, 'Corsair Lighting Node Pro (experimental)', 0, 0, 2)
     node.connect()
     node._data = MockRuntimeStorage(key_prefixes='testing')
@@ -101,7 +101,7 @@ def test_get_fan_mode_description_unknown():
     assert _get_fan_mode_description(0x03) == 'UNKNOWN'
     assert _get_fan_mode_description(0x04) == 'UNKNOWN'
     assert _get_fan_mode_description(0x10) == 'UNKNOWN'
-    assert _get_fan_mode_description(0xFF) == 'UNKNOWN'
+    assert _get_fan_mode_description(0xff) == 'UNKNOWN'
 
 def test_get_fan_mode_description_dc():
     assert _get_fan_mode_description(0x01) == 'DC'
@@ -554,9 +554,9 @@ def test_set_speed_profile_valid_multi_fan(commanderProDevice):
     assert sent[0].data[2] == 0x00
 
     assert sent[0].data[3] == 0x03
-    assert sent[0].data[4] == 0xE8
+    assert sent[0].data[4] == 0xe8
     assert sent[0].data[15] == 0x01
-    assert sent[0].data[16] == 0xF4
+    assert sent[0].data[16] == 0xf4
 
     assert sent[1].data[0] == 0x25
     assert sent[1].data[1] == 0x02
@@ -592,9 +592,9 @@ def test_set_speed_profile_invalid_temp_sensor(commanderProDevice):
     assert sent[0].data[2] == 0x03
 
     assert sent[0].data[3] == 0x03
-    assert sent[0].data[4] == 0xE8
+    assert sent[0].data[4] == 0xe8
     assert sent[0].data[15] == 0x01
-    assert sent[0].data[16] == 0xF4
+    assert sent[0].data[16] == 0xf4
 
 def test_set_speed_profile_no_temp_sensors(commanderProDevice):
     responses = [
@@ -643,9 +643,9 @@ def test_set_speed_profile_valid(commanderProDevice):
     assert sent[0].data[2] == 0x00
 
     assert sent[0].data[3] == 0x03
-    assert sent[0].data[4] == 0xE8
+    assert sent[0].data[4] == 0xe8
     assert sent[0].data[15] == 0x01
-    assert sent[0].data[16] == 0xF4
+    assert sent[0].data[16] == 0xf4
 
 def test_set_speed_profile_lighting(lightingNodeProDevice):
     responses = [
@@ -705,8 +705,8 @@ def test_set_color_hardware_clear(commanderProDevice):
     effect = {
             'channel': 0x01,
             'start_led': 0x00,
-            'num_leds': 0x0F,
-            'mode': 0x0A,
+            'num_leds': 0x0f,
+            'mode': 0x0a,
             'speed': 0x00,
             'direction': 0x00,
             'random_colors': 0x00,
@@ -740,8 +740,8 @@ def test_set_color_hardware_off(commanderProDevice):
     effect = {
             'channel': 0x01,
             'start_led': 0x00,
-            'num_leds': 0x0F,
-            'mode': 0x0A,
+            'num_leds': 0x0f,
+            'mode': 0x0a,
             'speed': 0x00,
             'direction': 0x00,
             'random_colors': 0x00,
@@ -915,7 +915,7 @@ def test_set_color_hardware_default_start_end(commanderProDevice):
     assert len(effects) == 1
 
 @pytest.mark.parametrize('startLED,expected', [
-    (1, 0x00), (30, 0x1D), (92, 0x5B)
+    (1, 0x00), (30, 0x1d), (92, 0x5b)
     ])
 def test_set_color_hardware_start_set(commanderProDevice, startLED, expected):
     responses = [
@@ -946,7 +946,7 @@ def test_set_color_hardware_start_set(commanderProDevice, startLED, expected):
     assert len(effects) == 1
 
 @pytest.mark.parametrize('numLED,expected', [
-    (1, 0x01), (30, 0x1E), (96, 0x5f)
+    (1, 0x01), (30, 0x1e), (96, 0x5f)
     ])
 def test_set_color_hardware_num_leds(commanderProDevice, numLED, expected):
     responses = [
@@ -998,7 +998,7 @@ def test_set_color_hardware_too_many_leds(commanderProDevice):
 
     assert sent[3].data[0] == 0x35
     assert sent[3].data[2] == 0x31  # start led
-    assert sent[3].data[3] == 0x2E  # num led
+    assert sent[3].data[3] == 0x2e  # num led
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
@@ -1191,7 +1191,7 @@ def test_set_color_hardware_too_few_colors(commanderProDevice):
 @pytest.mark.parametrize('modeStr,expected', [
     ('rainbow', 0x00), ('color_shift', 0x01), ('color_pulse', 0x02),
     ('color_wave', 0x03), ('fixed', 0x04), ('visor', 0x06), ('marquee', 0x07), ('blink', 0x08),
-    ('sequential', 0x09), ('sEqUeNtIaL', 0x09), ('rainbow2', 0x0A)
+    ('sequential', 0x09), ('sEqUeNtIaL', 0x09), ('rainbow2', 0x0a)
     ])
 def test_set_color_hardware_valid_mode(commanderProDevice, modeStr, expected):
     responses = [
@@ -1262,8 +1262,8 @@ def test_set_color_hardware_multipe_commands(commanderProDevice):
     effect = {
             'channel': 0x01,
             'start_led': 0x00,
-            'num_leds': 0x0F,
-            'mode': 0x0A,
+            'num_leds': 0x0f,
+            'mode': 0x0a,
             'speed': 0x00,
             'direction': 0x00,
             'random_colors': 0x00,

--- a/tests/test_comander_pro.py
+++ b/tests/test_comander_pro.py
@@ -5,29 +5,25 @@ from liquidctl.error import NotSupportedByDevice
 
 from _testutils import MockHidapiDevice, Report, MockRuntimeStorage
 
-
-
-
-
-
 # hardcoded responce data expected for some of the calls:
-
-#   -- init
 # commander pro: firmware request (0.9.214)
 # commander pro: bootloader req (2.3)
 # commander pro: get temp config ( 3 sensors)
 # commander pro: get fan configs (3 DC fans, 1 PWM fan) # note I have not tested it with pwm fans
 # commander pro:
 
+
 @pytest.fixture
 def commanderProDeviceUnconnected():
     device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c10, address='addr')
     return CommanderPro(device, 'Corsair Commander Pro (experimental)', 6, 4, 2)
 
+
 @pytest.fixture
 def lightingNodeProDeviceUnconnected():
     device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c0b, address='addr')
     return CommanderPro(device, 'Corsair Lighting Node Pro (experimental)', 0, 0, 2)
+
 
 @pytest.fixture
 def commanderProDevice():
@@ -36,6 +32,7 @@ def commanderProDevice():
     pro.connect()
     pro._data = MockRuntimeStorage(key_prefixes='testing')
     return pro
+
 
 @pytest.fixture
 def lightingNodeProDevice():
@@ -50,52 +47,67 @@ def lightingNodeProDevice():
 def test_prepare_profile_valid_max_rpm():
     assert _prepare_profile([[10, 400], [20, 5000]], 60) == [(10, 400), (20, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000)]
 
+
 def test_prepare_profile_add_max_rpm():
     assert _prepare_profile([[10, 400]], 60) == [(10, 400), (60, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000)]
     assert _prepare_profile([[10, 400], [20, 500], [30, 600], [40, 700], [50, 800]], 60) == [(10, 400), (20, 500), (30, 600), (40, 700), (50, 800), (60, 5000)]
+
 
 def test_prepare_profile_missing_max_rpm():
     with pytest.raises(ValueError):
         _prepare_profile([[10, 400], [20, 500], [30, 600], [40, 700], [50, 800], [55, 900]], 60)
 
+
 def test_prepare_profile_full_set():
     assert _prepare_profile([[10, 400], [20, 500], [30, 600], [40, 700], [45, 2000], [50, 5000]], 60) == [(10, 400), (20, 500), (30, 600), (40, 700), (45, 2000), (50, 5000)]
+
 
 def test_prepare_profile_too_many_points():
     with pytest.raises(ValueError):
         _prepare_profile([[10, 400], [20, 500], [30, 600], [40, 700], [50, 800], [55, 900]], 60)
 
+
 def test_prepare_profile_no_points():
     assert _prepare_profile([], 60) == [(60, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000)]
+
 
 def test_prepare_profile_empty_list():
     assert _prepare_profile([], 60) == [(60, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000)]
 
+
 def test_prepare_profile_above_max_temp():
     assert _prepare_profile([[10, 400], [70, 2000]], 60) == [(10, 400), (60, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000)]
+
 
 def test_prepare_profile_temp_low():
     assert _prepare_profile([[-10, 400], [70, 2000]], 60) == [(-10, 400), (60, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000)]
 
+
 def test_prepare_profile_max_temp():
     assert _prepare_profile([], 100) == [(100, 5000), (100, 5000), (100, 5000), (100, 5000), (100, 5000), (100, 5000)]
+
 
 ##### quoted
 def test_quoted_empty():
     assert _quoted() == ''
 
+
 def test_quoted_single():
     assert _quoted('one arg') == "'one arg'"
+
 
 def test_quoted_valid():
     assert _quoted('one', 'two') == "'one', 'two'"
 
+
 def test_quoted_not_string():
     assert _quoted('test', 500) == "'test', 500"
+
 
 ##### fan modes
 def test_get_fan_mode_description_auto():
     assert _get_fan_mode_description(0x00) == 'Auto/Disconnected'
+
 
 def test_get_fan_mode_description_unknown():
     assert _get_fan_mode_description(0x03) == 'UNKNOWN'
@@ -103,11 +115,14 @@ def test_get_fan_mode_description_unknown():
     assert _get_fan_mode_description(0x10) == 'UNKNOWN'
     assert _get_fan_mode_description(0xff) == 'UNKNOWN'
 
+
 def test_get_fan_mode_description_dc():
     assert _get_fan_mode_description(0x01) == 'DC'
 
+
 def test_get_fan_mode_description_pwm():
     assert _get_fan_mode_description(0x02) == 'PWM'
+
 
 ##### class methods
 def test_commander_constructor(commanderProDeviceUnconnected):
@@ -118,6 +133,7 @@ def test_commander_constructor(commanderProDeviceUnconnected):
     assert commanderProDeviceUnconnected._temp_probs == 4
     assert commanderProDeviceUnconnected._fan_count == 6
 
+
 def test_lighting_constructor(lightingNodeProDeviceUnconnected):
     assert lightingNodeProDeviceUnconnected._data == None
     assert lightingNodeProDeviceUnconnected._fan_names == []
@@ -125,13 +141,16 @@ def test_lighting_constructor(lightingNodeProDeviceUnconnected):
     assert lightingNodeProDeviceUnconnected._temp_probs == 0
     assert lightingNodeProDeviceUnconnected._fan_count == 0
 
+
 def test_connect_commander(commanderProDeviceUnconnected):
     commanderProDeviceUnconnected.connect()
     assert commanderProDeviceUnconnected._data != None
 
+
 def test_connect_lighting(lightingNodeProDeviceUnconnected):
     lightingNodeProDeviceUnconnected.connect()
     assert lightingNodeProDeviceUnconnected._data != None
+
 
 def test_initialize_commander_pro(commanderProDevice):
 
@@ -180,6 +199,7 @@ def test_initialize_commander_pro(commanderProDevice):
     assert data[2] == 0x00
     assert data[3] == 0x01
 
+
 def test_initialize_lighting_node(lightingNodeProDevice):
     responses = [
         '000009d4000000000000000000000000',  # firmware
@@ -200,6 +220,7 @@ def test_initialize_lighting_node(lightingNodeProDevice):
     data = lightingNodeProDevice._data.load('temp_sensors_connected', None)
     assert data == None
 
+
 def test_get_status_commander_pro(commanderProDevice):
 
         responses = [
@@ -215,7 +236,6 @@ def test_get_status_commander_pro(commanderProDevice):
         ]
         for d in responses:
             commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
-
 
         commanderProDevice._data.store('fan_modes', [0x01, 0x01, 0x02, 0x00, 0x00, 0x00])
         commanderProDevice._data.store('temp_sensors_connected', [0x01, 0x01, 0x00, 0x01])
@@ -259,10 +279,12 @@ def test_get_status_commander_pro(commanderProDevice):
         assert sent[7].data[0] == 0x21
         assert sent[8].data[0] == 0x21
 
+
 def test_get_status_lighting_pro(lightingNodeProDevice):
 
     res = lightingNodeProDevice.get_status()
     assert len(res) == 0
+
 
 def test_get_temp_valid_sensor_commander(commanderProDevice):
 
@@ -281,6 +303,7 @@ def test_get_temp_valid_sensor_commander(commanderProDevice):
     assert sent[0].data[0] == 0x11
     assert sent[0].data[1] == 1
 
+
 def test_get_temp_invalid_sensor_low_commander(commanderProDevice):
     response = '000a8300000000000000000000000000'
     commanderProDevice.device.preload_read(Report(0, bytes.fromhex(response)))
@@ -293,6 +316,7 @@ def test_get_temp_invalid_sensor_low_commander(commanderProDevice):
     # check the commands sent
     sent = commanderProDevice.device.sent
     assert len(sent) == 0
+
 
 def test_get_temp_invalid_sensor_high_commander(commanderProDevice):
     response = '000a8300000000000000000000000000'
@@ -307,6 +331,7 @@ def test_get_temp_invalid_sensor_high_commander(commanderProDevice):
     sent = commanderProDevice.device.sent
     assert len(sent) == 0
 
+
 def test_get_temp_lighting(lightingNodeProDevice):
     response = '000a8300000000000000000000000000'
     lightingNodeProDevice.device.preload_read(Report(0, bytes.fromhex(response)))
@@ -320,15 +345,14 @@ def test_get_temp_lighting(lightingNodeProDevice):
     sent = lightingNodeProDevice.device.sent
     assert len(sent) == 0
 
+
 def test_get_fan_rpm_valid_commander(commanderProDevice):
 
     response = '0003ac00000000000000000000000000'
     commanderProDevice.device.preload_read(Report(0, bytes.fromhex(response)))
-
     commanderProDevice._data.store('fan_modes', [0x01, 0x01, 0x02, 0x00, 0x00, 0x00])
 
     res = commanderProDevice._get_fan_rpm(1)
-
     assert res == 940
 
     # check the commands sent
@@ -336,6 +360,7 @@ def test_get_fan_rpm_valid_commander(commanderProDevice):
     assert len(sent) == 1
     assert sent[0].data[0] == 0x21
     assert sent[0].data[1] == 1
+
 
 def test_get_fan_rpm_invalid_low_commander(commanderProDevice):
 
@@ -351,6 +376,7 @@ def test_get_fan_rpm_invalid_low_commander(commanderProDevice):
     sent = commanderProDevice.device.sent
     assert len(sent) == 0
 
+
 def test_get_fan_rpm_invalid_high_commander(commanderProDevice):
     response = '0003ac00000000000000000000000000'
     commanderProDevice.device.preload_read(Report(0, bytes.fromhex(response)))
@@ -364,6 +390,7 @@ def test_get_fan_rpm_invalid_high_commander(commanderProDevice):
     sent = commanderProDevice.device.sent
     assert len(sent) == 0
 
+
 def test_get_fan_rpm_lighting(lightingNodeProDevice):
     response = '0003ac00000000000000000000000000'
     lightingNodeProDevice.device.preload_read(Report(0, bytes.fromhex(response)))
@@ -375,18 +402,22 @@ def test_get_fan_rpm_lighting(lightingNodeProDevice):
     sent = lightingNodeProDevice.device.sent
     assert len(sent) == 0
 
+
 def test_get_hw_fan_channels_all(commanderProDevice):
 
     res = commanderProDevice._get_hw_fan_channels('sync')
     assert res == [0, 1, 2, 3, 4, 5]
 
+
 def test_get_hw_fan_channels_uppercase(commanderProDevice):
     res = commanderProDevice._get_hw_fan_channels('FaN3')
     assert res == [2]
 
+
 def test_get_hw_fan_channels_lowercase(commanderProDevice):
     res = commanderProDevice._get_hw_fan_channels('fan2')
     assert res == [1]
+
 
 def test_get_hw_fan_channels_invalid(commanderProDevice):
     with pytest.raises(ValueError):
@@ -401,18 +432,22 @@ def test_get_hw_fan_channels_invalid(commanderProDevice):
     with pytest.raises(ValueError):
         commanderProDevice._get_hw_fan_channels('bob')
 
+
 def test_get_hw_led_channels_all(commanderProDevice):
 
     res = commanderProDevice._get_hw_led_channels('led')
     assert res == [0, 1]
 
+
 def test_get_hw_led_channels_uppercase(commanderProDevice):
     res = commanderProDevice._get_hw_led_channels('LeD2')
     assert res == [1]
 
+
 def test_get_hw_led_channels_lowercase(commanderProDevice):
     res = commanderProDevice._get_hw_led_channels('led1')
     assert res == [0]
+
 
 def test_get_hw_led_channels_invalid(commanderProDevice):
     with pytest.raises(ValueError):
@@ -424,11 +459,11 @@ def test_get_hw_led_channels_invalid(commanderProDevice):
     with pytest.raises(ValueError):
         commanderProDevice._get_hw_led_channels('bob')
 
+
 def test_set_fixed_speed_low(commanderProDevice):
 
     response = '00000000000000000000000000000000'
     commanderProDevice.device.preload_read(Report(0, bytes.fromhex(response)))
-
     commanderProDevice._data.store('fan_modes', [0x01, 0x01, 0x01, 0x01, 0x01, 0x01])
 
     commanderProDevice.set_fixed_speed('fan4', -10)
@@ -441,10 +476,10 @@ def test_set_fixed_speed_low(commanderProDevice):
     assert sent[0].data[1] == 0x03
     assert sent[0].data[2] == 0x00
 
+
 def test_set_fixed_speed_high(commanderProDevice):
     response = '00000000000000000000000000000000'
     commanderProDevice.device.preload_read(Report(0, bytes.fromhex(response)))
-
     commanderProDevice._data.store('fan_modes', [0x01, 0x01, 0x01, 0x01, 0x01, 0x01])
 
     commanderProDevice.set_fixed_speed('fan3', 110)
@@ -456,6 +491,7 @@ def test_set_fixed_speed_high(commanderProDevice):
     assert sent[0].data[0] == 0x23
     assert sent[0].data[1] == 0x02
     assert sent[0].data[2] == 0x64
+
 
 def test_set_fixed_speed_valid(commanderProDevice):
 
@@ -473,6 +509,7 @@ def test_set_fixed_speed_valid(commanderProDevice):
     assert sent[0].data[1] == 0x01
     assert sent[0].data[2] == 0x32
 
+
 def test_set_fixed_speed_valid_unconfigured(commanderProDevice):
 
     response = '00000000000000000000000000000000'
@@ -485,6 +522,7 @@ def test_set_fixed_speed_valid_unconfigured(commanderProDevice):
     sent = commanderProDevice.device.sent
     assert len(sent) == 0
 
+
 def test_set_fixed_speed_valid_multi_fan(commanderProDevice):
         responses = [
             '00000000000000000000000000000000',
@@ -496,7 +534,6 @@ def test_set_fixed_speed_valid_multi_fan(commanderProDevice):
 
         for d in responses:
             commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
-
 
         commanderProDevice._data.store('fan_modes', [0x01, 0x00, 0x01, 0x01, 0x00, 0x00])
 
@@ -518,6 +555,7 @@ def test_set_fixed_speed_valid_multi_fan(commanderProDevice):
         assert sent[2].data[1] == 0x03
         assert sent[2].data[2] == 0x32
 
+
 def test_set_fixed_speed_lighting(lightingNodeProDevice):
     response = '00000000000000000000000000000000'
     lightingNodeProDevice.device.preload_read(Report(0, bytes.fromhex(response)))
@@ -528,6 +566,7 @@ def test_set_fixed_speed_lighting(lightingNodeProDevice):
     # check the commands sent
     sent = lightingNodeProDevice.device.sent
     assert len(sent) == 0
+
 
 def test_set_speed_profile_valid_multi_fan(commanderProDevice):
     responses = [
@@ -566,6 +605,7 @@ def test_set_speed_profile_valid_multi_fan(commanderProDevice):
     assert sent[2].data[1] == 0x03
     assert sent[2].data[2] == 0x00
 
+
 def test_set_speed_profile_invalid_temp_sensor(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -596,6 +636,7 @@ def test_set_speed_profile_invalid_temp_sensor(commanderProDevice):
     assert sent[0].data[15] == 0x01
     assert sent[0].data[16] == 0xf4
 
+
 def test_set_speed_profile_no_temp_sensors(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -617,6 +658,7 @@ def test_set_speed_profile_no_temp_sensors(commanderProDevice):
     # check the commands sent
     sent = commanderProDevice.device.sent
     assert len(sent) == 0
+
 
 def test_set_speed_profile_valid(commanderProDevice):
     responses = [
@@ -647,6 +689,7 @@ def test_set_speed_profile_valid(commanderProDevice):
     assert sent[0].data[15] == 0x01
     assert sent[0].data[16] == 0xf4
 
+
 def test_set_speed_profile_lighting(lightingNodeProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -669,6 +712,7 @@ def test_set_speed_profile_lighting(lightingNodeProDevice):
     sent = lightingNodeProDevice.device.sent
     assert len(sent) == 0
 
+
 def test_set_speed_profile_valid_unconfigured(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -690,6 +734,7 @@ def test_set_speed_profile_valid_unconfigured(commanderProDevice):
     # check the commands sent
     sent = commanderProDevice.device.sent
     assert len(sent) == 0
+
 
 def test_set_color_hardware_clear(commanderProDevice):
     responses = [
@@ -725,6 +770,7 @@ def test_set_color_hardware_clear(commanderProDevice):
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
     assert effects == None
+
 
 def test_set_color_hardware_off(commanderProDevice):
     responses = [
@@ -764,6 +810,7 @@ def test_set_color_hardware_off(commanderProDevice):
 
     assert effects == None
 
+
 @pytest.mark.parametrize('directionStr,expected', [
     ('forward', 0x01), ('FORWARD', 0x01), ('fOrWaRd', 0x01),
     ('backward', 0x00), ('BACKWARD', 0x00), ('BaCkWaRd', 0x00)
@@ -796,6 +843,7 @@ def test_set_color_hardware_dirrection(commanderProDevice, directionStr, expecte
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_direction_default(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -824,6 +872,7 @@ def test_set_color_hardware_direction_default(commanderProDevice):
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_speed_default(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -851,6 +900,7 @@ def test_set_color_hardware_speed_default(commanderProDevice):
 
     assert effects != None
     assert len(effects) == 1
+
 
 @pytest.mark.parametrize('speedStr,expected', [
     ('slow', 0x02), ('SLOW', 0x02), ('SlOw', 0x02),
@@ -885,6 +935,7 @@ def test_set_color_hardware_speed(commanderProDevice, speedStr, expected):
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_default_start_end(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -913,6 +964,7 @@ def test_set_color_hardware_default_start_end(commanderProDevice):
 
     assert effects != None
     assert len(effects) == 1
+
 
 @pytest.mark.parametrize('startLED,expected', [
     (1, 0x00), (30, 0x1d), (92, 0x5b)
@@ -945,6 +997,7 @@ def test_set_color_hardware_start_set(commanderProDevice, startLED, expected):
     assert effects != None
     assert len(effects) == 1
 
+
 @pytest.mark.parametrize('numLED,expected', [
     (1, 0x01), (30, 0x1e), (96, 0x5f)
     ])
@@ -976,6 +1029,7 @@ def test_set_color_hardware_num_leds(commanderProDevice, numLED, expected):
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_too_many_leds(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1005,6 +1059,7 @@ def test_set_color_hardware_too_many_leds(commanderProDevice):
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_too_few_leds(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1033,6 +1088,7 @@ def test_set_color_hardware_too_few_leds(commanderProDevice):
 
     assert effects != None
     assert len(effects) == 1
+
 
 @pytest.mark.parametrize('channel,expected', [
     ('led1', 0x00), ('led', 0x00), ('LeD1', 0x00),
@@ -1069,6 +1125,7 @@ def test_set_color_hardware_channel(commanderProDevice, channel, expected):
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_random_color(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1097,6 +1154,7 @@ def test_set_color_hardware_random_color(commanderProDevice):
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_not_random_color(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1124,6 +1182,7 @@ def test_set_color_hardware_not_random_color(commanderProDevice):
 
     assert effects != None
     assert len(effects) == 1
+
 
 def test_set_color_hardware_too_many_colors(commanderProDevice):
     responses = [
@@ -1157,6 +1216,7 @@ def test_set_color_hardware_too_many_colors(commanderProDevice):
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_too_few_colors(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1187,6 +1247,7 @@ def test_set_color_hardware_too_few_colors(commanderProDevice):
 
     assert effects != None
     assert len(effects) == 1
+
 
 @pytest.mark.parametrize('modeStr,expected', [
     ('rainbow', 0x00), ('color_shift', 0x01), ('color_pulse', 0x02),
@@ -1220,6 +1281,7 @@ def test_set_color_hardware_valid_mode(commanderProDevice, modeStr, expected):
     assert effects != None
     assert len(effects) == 1
 
+
 def test_set_color_hardware_invalid_mode(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1244,6 +1306,7 @@ def test_set_color_hardware_invalid_mode(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
     assert effects == None
+
 
 def test_set_color_hardware_multipe_commands(commanderProDevice):
     responses = [
@@ -1285,6 +1348,7 @@ def test_set_color_hardware_multipe_commands(commanderProDevice):
     assert effects != None
     assert len(effects) == 2
 
+
 def test_send_command_valid_data(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1303,6 +1367,7 @@ def test_send_command_valid_data(commanderProDevice):
     assert sent[0].data[0] == 6
     assert sent[0].data[1] == 255
 
+
 def test_send_command_no_data(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1320,6 +1385,7 @@ def test_send_command_no_data(commanderProDevice):
     assert len(sent[0].data) == 64
     assert sent[0].data[0] == 6
     assert sent[0].data[1] == 0
+
 
 def test_send_command_data_too_long(commanderProDevice):
     responses = [

--- a/tests/test_comander_pro.py
+++ b/tests/test_comander_pro.py
@@ -127,7 +127,7 @@ def test_get_fan_mode_description_pwm():
 ##### class methods
 def test_commander_constructor(commanderProDeviceUnconnected):
 
-    assert commanderProDeviceUnconnected._data == None
+    assert commanderProDeviceUnconnected._data is None
     assert commanderProDeviceUnconnected._fan_names == ['fan1', 'fan2', 'fan3', 'fan4', 'fan5', 'fan6']
     assert commanderProDeviceUnconnected._led_names == ['led1', 'led2']
     assert commanderProDeviceUnconnected._temp_probs == 4
@@ -135,7 +135,7 @@ def test_commander_constructor(commanderProDeviceUnconnected):
 
 
 def test_lighting_constructor(lightingNodeProDeviceUnconnected):
-    assert lightingNodeProDeviceUnconnected._data == None
+    assert lightingNodeProDeviceUnconnected._data is None
     assert lightingNodeProDeviceUnconnected._fan_names == []
     assert lightingNodeProDeviceUnconnected._led_names == ['led1', 'led2']
     assert lightingNodeProDeviceUnconnected._temp_probs == 0
@@ -144,12 +144,12 @@ def test_lighting_constructor(lightingNodeProDeviceUnconnected):
 
 def test_connect_commander(commanderProDeviceUnconnected):
     commanderProDeviceUnconnected.connect()
-    assert commanderProDeviceUnconnected._data != None
+    assert commanderProDeviceUnconnected._data is not None
 
 
 def test_connect_lighting(lightingNodeProDeviceUnconnected):
     lightingNodeProDeviceUnconnected.connect()
-    assert lightingNodeProDeviceUnconnected._data != None
+    assert lightingNodeProDeviceUnconnected._data is not None
 
 
 def test_initialize_commander_pro(commanderProDevice):
@@ -182,7 +182,7 @@ def test_initialize_commander_pro(commanderProDevice):
     assert res[11][1] == 'Auto/Disconnected'
 
     data = commanderProDevice._data.load('fan_modes', None)
-    assert data != None
+    assert data is not None
     assert len(data) == 6
     assert data[0] == 0x01
     assert data[1] == 0x01
@@ -192,7 +192,7 @@ def test_initialize_commander_pro(commanderProDevice):
     assert data[5] == 0x00
 
     data = commanderProDevice._data.load('temp_sensors_connected', None)
-    assert data != None
+    assert data is not None
     assert len(data) == 4
     assert data[0] == 0x01
     assert data[1] == 0x01
@@ -215,10 +215,10 @@ def test_initialize_lighting_node(lightingNodeProDevice):
     assert res[1][1] == '0.5'
 
     data = lightingNodeProDevice._data.load('fan_modes', None)
-    assert data == None
+    assert data is None
 
     data = lightingNodeProDevice._data.load('temp_sensors_connected', None)
-    assert data == None
+    assert data is None
 
 
 def test_get_status_commander_pro(commanderProDevice):
@@ -769,7 +769,7 @@ def test_set_color_hardware_clear(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects == None
+    assert effects is None
 
 
 def test_set_color_hardware_off(commanderProDevice):
@@ -808,7 +808,7 @@ def test_set_color_hardware_off(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects == None
+    assert effects is None
 
 
 @pytest.mark.parametrize('directionStr,expected', [
@@ -840,7 +840,7 @@ def test_set_color_hardware_dirrection(commanderProDevice, directionStr, expecte
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -869,7 +869,7 @@ def test_set_color_hardware_direction_default(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -898,7 +898,7 @@ def test_set_color_hardware_speed_default(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -932,7 +932,7 @@ def test_set_color_hardware_speed(commanderProDevice, speedStr, expected):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -962,7 +962,7 @@ def test_set_color_hardware_default_start_end(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -994,7 +994,7 @@ def test_set_color_hardware_start_set(commanderProDevice, startLED, expected):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1026,7 +1026,7 @@ def test_set_color_hardware_num_leds(commanderProDevice, numLED, expected):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1056,7 +1056,7 @@ def test_set_color_hardware_too_many_leds(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1086,7 +1086,7 @@ def test_set_color_hardware_too_few_leds(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1122,7 +1122,7 @@ def test_set_color_hardware_channel(commanderProDevice, channel, expected):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1151,7 +1151,7 @@ def test_set_color_hardware_random_color(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1180,7 +1180,7 @@ def test_set_color_hardware_not_random_color(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1213,7 +1213,7 @@ def test_set_color_hardware_too_many_colors(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1245,7 +1245,7 @@ def test_set_color_hardware_too_few_colors(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1278,7 +1278,7 @@ def test_set_color_hardware_valid_mode(commanderProDevice, modeStr, expected):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 1
 
 
@@ -1305,7 +1305,7 @@ def test_set_color_hardware_invalid_mode(commanderProDevice):
     assert len(sent) == 0
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
-    assert effects == None
+    assert effects is None
 
 
 def test_set_color_hardware_multipe_commands(commanderProDevice):
@@ -1345,7 +1345,7 @@ def test_set_color_hardware_multipe_commands(commanderProDevice):
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
-    assert effects != None
+    assert effects is not None
     assert len(effects) == 2
 
 

--- a/tests/test_comander_pro.py
+++ b/tests/test_comander_pro.py
@@ -28,7 +28,7 @@ def lightingNodeProDeviceUnconnected():
 @pytest.fixture
 def commanderProDevice():
     device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c10, address='addr')
-    pro =  CommanderPro(device, 'Corsair Commander Pro (experimental)', 6, 4, 2)
+    pro = CommanderPro(device, 'Corsair Commander Pro (experimental)', 6, 4, 2)
     pro.connect()
     pro._data = MockRuntimeStorage(key_prefixes='testing')
     return pro
@@ -43,7 +43,7 @@ def lightingNodeProDevice():
     return node
 
 
-#### prepare profile
+# prepare profile
 def test_prepare_profile_valid_max_rpm():
     assert _prepare_profile([[10, 400], [20, 5000]], 60) == [(10, 400), (20, 5000), (60, 5000), (60, 5000), (60, 5000), (60, 5000)]
 
@@ -87,7 +87,7 @@ def test_prepare_profile_max_temp():
     assert _prepare_profile([], 100) == [(100, 5000), (100, 5000), (100, 5000), (100, 5000), (100, 5000), (100, 5000)]
 
 
-##### quoted
+# quoted
 def test_quoted_empty():
     assert _quoted() == ''
 
@@ -104,7 +104,7 @@ def test_quoted_not_string():
     assert _quoted('test', 500) == "'test', 500"
 
 
-##### fan modes
+# fan modes
 def test_get_fan_mode_description_auto():
     assert _get_fan_mode_description(0x00) == 'Auto/Disconnected'
 
@@ -124,7 +124,7 @@ def test_get_fan_mode_description_pwm():
     assert _get_fan_mode_description(0x02) == 'PWM'
 
 
-##### class methods
+# class methods
 def test_commander_constructor(commanderProDeviceUnconnected):
 
     assert commanderProDeviceUnconnected._data is None

--- a/tests/test_corsair_hid_psu.py
+++ b/tests/test_corsair_hid_psu.py
@@ -28,10 +28,10 @@ class CorsairHidPsuTestCase(unittest.TestCase):
     def test_not_totally_broken(self):
         """A few reasonable example calls do not raise exceptions."""
         self.device.initialize()
-        status = self.device.get_status()
+        self.device.get_status()
 
     def test_dont_inject_report_ids(self):
-        status = self.device.set_fixed_speed(channel='fan', duty=50)
+        self.device.set_fixed_speed(channel='fan', duty=50)
         report_id, report_data = self.mock_hid.sent[0]
         assert report_id == 0
         assert len(report_data) == 64

--- a/tests/test_corsair_hid_psu.py
+++ b/tests/test_corsair_hid_psu.py
@@ -19,9 +19,10 @@ def mockPsuDevice():
     device = _MockPsuDevice(vendor_id=0x1b1c, product_id=0x1c05, address='addr')
     return CorsairHidPsu(device, 'mock Corsair HX750i PSU')
 
+
 def test_corsair_psu_not_totally_broken(mockPsuDevice):
 
-    status = mockPsuDevice.set_fixed_speed(channel='fan', duty=50)
+    mockPsuDevice.set_fixed_speed(channel='fan', duty=50)
     report_id, report_data = mockPsuDevice.device.sent[0]
     assert report_id == 0
     assert len(report_data) == 64
@@ -29,7 +30,7 @@ def test_corsair_psu_not_totally_broken(mockPsuDevice):
 
 def test_corsair_psu_dont_inject_report_ids(mockPsuDevice):
 
-    status = mockPsuDevice.set_fixed_speed(channel='fan', duty=50)
+    mockPsuDevice.set_fixed_speed(channel='fan', duty=50)
     report_id, report_data = mockPsuDevice.device.sent[0]
     assert report_id == 0
     assert len(report_data) == 64

--- a/tests/test_ddr4.py
+++ b/tests/test_ddr4.py
@@ -244,7 +244,6 @@ def test_vengeance_rgb_asserts_rgb_address_validity(vengeance_rgb):
             dimm.set_color('led', 'off', [], unsafe=enable)
 
 
-
 def test_vengeance_rgb_sets_color_to_off(vengeance_rgb):
     enable = ['smbus', 'vengeance_rgb']
     smbus, dimm = vengeance_rgb
@@ -375,7 +374,7 @@ def test_vengeance_rgb_animation_transition_ticks_overrides_tp1(vengeance_rgb):
         assert smbus.read_byte_data(0x59, 0xa5) == 0x20
 
 
-def test_vengeance_rgb_animation_transition_ticks_overrides_tp1(vengeance_rgb):
+def test_vengeance_rgb_animation_transition_ticks_overrides_tp2(vengeance_rgb):
     enable = ['smbus', 'vengeance_rgb']
     smbus, dimm = vengeance_rgb
 

--- a/tests/test_ddr4.py
+++ b/tests/test_ddr4.py
@@ -109,7 +109,7 @@ def test_tse2004_ignores_not_allowed_buses(smbus, monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(smbus, attr, val)
             assert list(Ddr4Temperature.probe(smbus)) == [], \
-                    f'changing {attr} did not cause a mismatch'
+                f'changing {attr} did not cause a mismatch'
 
 
 def test_tse2004_does_not_match_non_ee1004_device(smbus):

--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -206,9 +206,8 @@ class HydroPlatinumTestCase(unittest.TestCase):
 
         self.assertEqual(len(self.mock_hid.sent), 0)
 
-
     def test_short_enough_storage_path(self):
-        assert len(self.device._data._backend._write_dir) < _WIN_MAX_PATH;
+        assert len(self.device._data._backend._write_dir) < _WIN_MAX_PATH
         assert self.device._data._backend._write_dir.endswith('3142')
 
     def test_bad_stored_data(self):

--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -25,6 +25,7 @@ def h115iPlatinumDevice():
 
     return dev
 
+
 class _H115iPlatinumDevice(MockHidapiDevice):
     def __init__(self):
         super().__init__(vendor_id=0xffff, product_id=0x0c17, address=_SAMPLE_PATH)
@@ -64,6 +65,7 @@ def test_h115i_platinum_device_connect(h115iPlatinumDevice):
         assert cm == dev
         assert opened
 
+
 def test_h115i_platinum_device_command_format(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
     dev.initialize()
@@ -79,6 +81,7 @@ def test_h115i_platinum_device_command_format(h115iPlatinumDevice):
         assert data[0] == 0x3f
         assert data[1] >> 3 == i + 1
         assert data[-1] == compute_pec(data[1:-1])
+
 
 def test_h115i_platinum_device_command_format_enabled(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
@@ -99,6 +102,7 @@ def test_h115i_platinum_device_command_format_enabled(h115iPlatinumDevice):
         assert data[1] >> 3 == i + 1
         assert data[-1] == compute_pec(data[1:-1])
 
+
 def test_h115i_platinum_device_get_status(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
     temp, fan1, fan2, pump = dev.get_status()
@@ -109,6 +113,7 @@ def test_h115i_platinum_device_get_status(h115iPlatinumDevice):
     assert pump[1] == dev.device.pump_speed
     assert dev.device.sent[0].data[1] & 0b111 == 0
     assert dev.device.sent[0].data[2] == 0xff
+
 
 def test_h115i_platinum_device_handle_real_statuses(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
@@ -128,6 +133,7 @@ def test_h115i_platinum_device_handle_real_statuses(h115iPlatinumDevice):
         assert len(status) == 4
         assert status[0][1] != dev.device.temperature
 
+
 def test_h115i_platinum_device_initialize_status(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
     dev._data.store('leds_enabled', 1)
@@ -135,6 +141,7 @@ def test_h115i_platinum_device_initialize_status(h115iPlatinumDevice):
 
     assert fw_version[1] == '%d.%d.%d' % dev.device.fw_version
     assert dev._data.load('leds_enabled', of_type=int, default=1) == 0
+
 
 def test_h115i_platinum_device_common_cooling_prefix(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
@@ -149,6 +156,7 @@ def test_h115i_platinum_device_common_cooling_prefix(h115iPlatinumDevice):
         # opaque but apparently important prefix (see @makk50's comments in #82):
         assert data[0x3:0xb] == [0x0, 0xff, 0x5] + 5 * [0xff]
 
+
 def test_h115i_platinum_device_set_pump_mode(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
     dev.initialize(pump_mode='extreme')
@@ -156,6 +164,7 @@ def test_h115i_platinum_device_set_pump_mode(h115iPlatinumDevice):
 
     with pytest.raises(KeyError):
         dev.initialize(pump_mode='invalid')
+
 
 def test_h115i_platinum_device_fixed_fan_speeds(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
@@ -169,6 +178,7 @@ def test_h115i_platinum_device_fixed_fan_speeds(h115iPlatinumDevice):
 
     with pytest.raises(ValueError):
         dev.set_fixed_speed('invalid', 0)
+
 
 def test_h115i_platinum_device_custom_fan_profiles(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
@@ -187,13 +197,14 @@ def test_h115i_platinum_device_custom_fan_profiles(h115iPlatinumDevice):
     with pytest.raises(ValueError):
         dev.set_speed_profile('fan', zip(range(10), range(10)))
 
+
 def test_h115i_platinum_device_address_leds(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
     colors = [[i + 3, i + 2, i + 1] for i in range(0, 24 * 3, 3)]
     encoded = list(range(1, 24 * 3 + 1))
     dev.set_color(channel='led', mode='super-fixed', colors=iter(colors))
 
-    assert len(dev.device.sent) == 5 # 3 for enable, 2 for off
+    assert len(dev.device.sent) == 5  # 3 for enable, 2 for off
     assert dev.device.sent[0].data[1] & 0b111 == 0b001
     assert dev.device.sent[1].data[1] & 0b111 == 0b010
     assert dev.device.sent[2].data[1] & 0b111 == 0b011
@@ -201,6 +212,7 @@ def test_h115i_platinum_device_address_leds(h115iPlatinumDevice):
     assert dev.device.sent[3].data[2:62] == encoded[:60]
     assert dev.device.sent[4].data[1] & 0b111 == 0b101
     assert dev.device.sent[4].data[2:14] == encoded[60:]
+
 
 def test_h115i_platinum_device_synchronize(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
@@ -209,7 +221,7 @@ def test_h115i_platinum_device_synchronize(h115iPlatinumDevice):
 
     dev.set_color(channel='led', mode='fixed', colors=iter(colors))
 
-    assert len(dev.device.sent) == 5 # 3 for enable, 2 for off
+    assert len(dev.device.sent) == 5  # 3 for enable, 2 for off
 
     assert dev.device.sent[0].data[1] & 0b111 == 0b001
     assert dev.device.sent[1].data[1] & 0b111 == 0b010
@@ -220,13 +232,15 @@ def test_h115i_platinum_device_synchronize(h115iPlatinumDevice):
     assert dev.device.sent[4].data[1] & 0b111 == 0b101
     assert dev.device.sent[4].data[2:14] == encoded[60:]
 
+
 def test_h115i_platinum_device_leds_off(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
     dev.set_color(channel='led', mode='off', colors=iter([]))
-    assert len(dev.device.sent) == 5 # 3 for enable, 2 for off
+    assert len(dev.device.sent) == 5  # 3 for enable, 2 for off
 
     for _, data in dev.device.sent[3:5]:
         assert data[2:62] == [0] * 60
+
 
 def test_h115i_platinum_device_invalid_color_modes(h115iPlatinumDevice):
     dev = h115iPlatinumDevice
@@ -239,6 +253,7 @@ def test_h115i_platinum_device_invalid_color_modes(h115iPlatinumDevice):
 
     assert len(dev.device.sent) == 0
 
+
 def test_h115i_platinum_device_short_enough_storage_path():
     description = 'Mock H115i Platinum'
     kwargs = {'fan_count': 2, 'rgb_fans': True}
@@ -246,10 +261,11 @@ def test_h115i_platinum_device_short_enough_storage_path():
     dev = HydroPlatinum(device, description, **kwargs)
     dev.connect()
 
-    assert len(dev._data._backend._write_dir) < _WIN_MAX_PATH;
+    assert len(dev._data._backend._write_dir) < _WIN_MAX_PATH
     assert dev._data._backend._write_dir.endswith('3142')
 
+
 def test_h115i_platinum_device_bad_stored_data(h115iPlatinumDevice):
-    dev = h115iPlatinumDevice
+    h115iPlatinumDevice
     # TODO
     pass

--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -167,7 +167,7 @@ class HydroPlatinumTestCase(unittest.TestCase):
         colors = [[i + 3, i + 2, i + 1] for i in range(0, 24 * 3, 3)]
         encoded = list(range(1, 24 * 3 + 1))
         self.device.set_color(channel='led', mode='super-fixed', colors=iter(colors))
-        self.assertEqual(len(self.mock_hid.sent), 5) # 3 for enable, 2 for off
+        self.assertEqual(len(self.mock_hid.sent), 5)  # 3 for enable, 2 for off
         self.assertEqual(self.mock_hid.sent[0].data[1] & 0b111, 0b001)
         self.assertEqual(self.mock_hid.sent[1].data[1] & 0b111, 0b010)
         self.assertEqual(self.mock_hid.sent[2].data[1] & 0b111, 0b011)
@@ -180,7 +180,7 @@ class HydroPlatinumTestCase(unittest.TestCase):
         colors = [[3, 2, 1]]
         encoded = [1, 2, 3] * 24
         self.device.set_color(channel='led', mode='fixed', colors=iter(colors))
-        self.assertEqual(len(self.mock_hid.sent), 5) # 3 for enable, 2 for off
+        self.assertEqual(len(self.mock_hid.sent), 5)  # 3 for enable, 2 for off
 
         self.assertEqual(self.mock_hid.sent[0].data[1] & 0b111, 0b001)
         self.assertEqual(self.mock_hid.sent[1].data[1] & 0b111, 0b010)
@@ -193,7 +193,7 @@ class HydroPlatinumTestCase(unittest.TestCase):
 
     def test_leds_off(self):
         self.device.set_color(channel='led', mode='off', colors=iter([]))
-        self.assertEqual(len(self.mock_hid.sent), 5) # 3 for enable, 2 for off
+        self.assertEqual(len(self.mock_hid.sent), 5)  # 3 for enable, 2 for off
         for _, data in self.mock_hid.sent[3:5]:
             self.assertEqual(data[2:62], [0] * 60)
 

--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -10,6 +10,7 @@ _SAMPLE_PATH = (r'IOService:/AppleACPIPlatformExpert/PCI0@0/AppleACPIPCI/XHC@14/
                 r'2000/IOUSBHostInterface@0/AppleUserUSBHostHIDDevice+Win\\#!&3142')
 _WIN_MAX_PATH = 260  # Windows API should be the bottleneck
 
+
 class _H115iPlatinumDevice(MockHidapiDevice):
     def __init__(self):
         super().__init__(vendor_id=0xffff, product_id=0x0c17, address=_SAMPLE_PATH)

--- a/tests/test_kraken2.py
+++ b/tests/test_kraken2.py
@@ -3,6 +3,7 @@ from liquidctl.driver.kraken2 import Kraken2
 from _testutils import MockHidapiDevice
 from liquidctl.error import NotSupportedByDevice
 
+
 @pytest.fixture
 def mockKrakenXDevice():
     device = _MockKrakenDevice(fw_version=(6, 0, 2))
@@ -10,6 +11,7 @@ def mockKrakenXDevice():
 
     dev.connect()
     return dev
+
 
 @pytest.fixture
 def mockOldKrakenXDevice():
@@ -19,6 +21,7 @@ def mockOldKrakenXDevice():
     dev.connect()
     return dev
 
+
 @pytest.fixture
 def mockKrakenMDevice():
     device = _MockKrakenDevice(fw_version=(6, 0, 2))
@@ -26,6 +29,7 @@ def mockKrakenMDevice():
 
     dev.connect()
     return dev
+
 
 class _MockKrakenDevice(MockHidapiDevice):
     def __init__(self, fw_version):
@@ -49,6 +53,7 @@ class _MockKrakenDevice(MockHidapiDevice):
         buf[0xe] = patch
         return buf[:length]
 
+
 def test_kraken_connect(mockKrakenXDevice):
     def mock_open():
         nonlocal opened
@@ -59,7 +64,8 @@ def test_kraken_connect(mockKrakenXDevice):
 
     with mockKrakenXDevice.connect() as cm:
         assert cm == mockKrakenXDevice
-        assert opened == True
+        assert opened
+
 
 def test_kraken_get_status(mockKrakenXDevice):
     fan, fw_ver, temp, pump = sorted(mockKrakenXDevice.get_status())
@@ -69,16 +75,19 @@ def test_kraken_get_status(mockKrakenXDevice):
     assert fan[1] == mockKrakenXDevice.device.fan_speed
     assert pump[1] == mockKrakenXDevice.device.pump_speed
 
+
 def test_kraken_not_totally_broken(mockKrakenXDevice):
     """Reasonable example calls to untested APIs do not raise exceptions."""
+    dev = mockKrakenXDevice
 
-    mockKrakenXDevice.initialize()
-    mockKrakenXDevice.set_color(channel='ring', mode='loading', colors=iter([[90, 80, 0]]),
-                          speed='slowest')
-    mockKrakenXDevice.set_speed_profile(channel='fan',
-                                  profile=iter([(20, 20), (30, 40), (40, 100)]))
-    mockKrakenXDevice.set_fixed_speed(channel='pump', duty=50)
-    mockKrakenXDevice.set_instantaneous_speed(channel='pump', duty=50)
+    dev.initialize()
+    dev.set_color(channel='ring', mode='loading', colors=iter([[90, 80, 0]]),
+                  speed='slowest')
+    dev.set_speed_profile(channel='fan',
+                          profile=iter([(20, 20), (30, 40), (40, 100)]))
+    dev.set_fixed_speed(channel='pump', duty=50)
+    dev.set_instantaneous_speed(channel='pump', duty=50)
+
 
 def test_kraken_set_fixed_speeds(mockOldKrakenXDevice):
     mockOldKrakenXDevice.set_fixed_speed(channel='fan', duty=42)
@@ -91,6 +100,7 @@ def test_kraken_set_fixed_speeds(mockOldKrakenXDevice):
     assert pump_report.number == 2
     assert pump_report.data[0:4] == [0x4d, 0x40, 0, 84]
 
+
 def test_kraken_speed_profiles_not_supported(mockOldKrakenXDevice):
 
     with pytest.raises(NotSupportedByDevice):
@@ -99,9 +109,11 @@ def test_kraken_speed_profiles_not_supported(mockOldKrakenXDevice):
     with pytest.raises(NotSupportedByDevice):
         mockOldKrakenXDevice.set_speed_profile('pump', [(20, 84)])
 
+
 def test_krakenM_get_status(mockKrakenMDevice):
     (fw_ver,) = mockKrakenMDevice.get_status()
-    assert fw_ver[1] ==  '6.0.2'
+    assert fw_ver[1] == '6.0.2'
+
 
 def test_krakenM_speed_control_not_supported(mockKrakenMDevice):
     with pytest.raises(NotSupportedByDevice):
@@ -116,8 +128,10 @@ def test_krakenM_speed_control_not_supported(mockKrakenMDevice):
     with pytest.raises(NotSupportedByDevice):
         mockKrakenMDevice.set_speed_profile('pump', [(20, 84)])
 
+
 def test_krakenM_not_totally_broken(mockKrakenMDevice):
     """Reasonable example calls to untested APIs do not raise exceptions."""
-    mockKrakenMDevice.initialize()
-    mockKrakenMDevice.set_color(channel='ring', mode='loading', colors=iter([[90, 80, 0]]),
-                          speed='slowest')
+    dev = mockKrakenMDevice
+    dev.initialize()
+    dev.set_color(channel='ring', mode='loading', colors=iter([[90, 80, 0]]),
+                  speed='slowest')

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -20,6 +20,7 @@ _FAULTY_STATUS = bytes.fromhex(
     '0000000000000000000000000000000000000000000000000000000000000000'
 )
 
+
 class _MockKrakenDevice(MockHidapiDevice):
     def __init__(self, raw_led_channels):
         super().__init__()

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -25,8 +25,8 @@ _FAULTY_STATUS = bytes.fromhex(
 def mockKrakenXDevice():
     device = _MockKrakenDevice(raw_led_channels=len(_COLOR_CHANNELS_KRAKENX) - 1)
     dev = KrakenX3(device, 'Corsair Kraken X73',
-            speed_channels=_SPEED_CHANNELS_KRAKENX,
-            color_channels=_COLOR_CHANNELS_KRAKENX)
+                   speed_channels=_SPEED_CHANNELS_KRAKENX,
+                   color_channels=_COLOR_CHANNELS_KRAKENX)
 
     dev.connect()
     return dev
@@ -36,11 +36,12 @@ def mockKrakenXDevice():
 def mockKrakenZDevice():
     device = _MockKrakenDevice(raw_led_channels=0)
     dev = KrakenZ3(device, 'Mock Kraken Z73',
-           speed_channels=_SPEED_CHANNELS_KRAKENZ,
-           color_channels={})
+                   speed_channels=_SPEED_CHANNELS_KRAKENZ,
+                   color_channels={})
 
     dev.connect()
     return dev
+
 
 class _MockKrakenDevice(MockHidapiDevice):
     def __init__(self, raw_led_channels):
@@ -59,6 +60,7 @@ class _MockKrakenDevice(MockHidapiDevice):
                 reply[15 + 2 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_LOGO.value
         self.preload_read(Report(0, reply))
 
+
 def test_kracken_x_device_parses_status_fields(mockKrakenXDevice):
     mockKrakenXDevice.device.preload_read(Report(0, _SAMPLE_STATUS))
     temperature, pump_speed, pump_duty = mockKrakenXDevice.get_status()
@@ -73,20 +75,26 @@ def test_kracken_x_device_warns_if_faulty_temperature(mockKrakenXDevice, caplog)
 
     assert 'unexpected temperature reading' in caplog.text
 
+
 def test_kracken_x_device_not_totally_broken(mockKrakenXDevice):
     """Reasonable example calls to untested APIs do not raise exceptions."""
-    infos = mockKrakenXDevice.initialize()
-    mockKrakenXDevice.set_color(channel='ring', mode='fixed', colors=iter([[3, 2, 1]]),
-                          speed='fastest')
-    mockKrakenXDevice.set_speed_profile(channel='pump',
-                                  profile=iter([(20, 20), (30, 50), (40, 100)]))
-    mockKrakenXDevice.set_fixed_speed(channel='pump', duty=50)
+    dev = mockKrakenXDevice
+
+    dev.initialize()
+    dev.set_color(channel='ring', mode='fixed', colors=iter([[3, 2, 1]]),
+                  speed='fastest')
+    dev.set_speed_profile(channel='pump',
+                          profile=iter([(20, 20), (30, 50), (40, 100)]))
+    dev.set_fixed_speed(channel='pump', duty=50)
+
 
 def test_kracken_z_device_not_totally_broken(mockKrakenZDevice):
     """Reasonable example calls to untested APIs do not raise exceptions."""
-    infos = mockKrakenZDevice.initialize()
-    mockKrakenZDevice.device.preload_read(Report(0, _SAMPLE_STATUS))
-    status = mockKrakenZDevice.get_status()
-    mockKrakenZDevice.set_speed_profile(channel='fan',
-                                  profile=iter([(20, 20), (30, 50), (40, 100)]))
-    mockKrakenZDevice.set_fixed_speed(channel='pump', duty=50)
+    dev = mockKrakenZDevice
+
+    dev.initialize()
+    dev.device.preload_read(Report(0, _SAMPLE_STATUS))
+    dev.get_status()
+    dev.set_speed_profile(channel='fan',
+                          profile=iter([(20, 20), (30, 50), (40, 100)]))
+    dev.set_fixed_speed(channel='pump', duty=50)

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -65,7 +65,7 @@ class KrakenX3TestCase(unittest.TestCase):
 
     def test_not_totally_broken(self):
         """Reasonable example calls to untested APIs do not raise exceptions."""
-        infos = self.device.initialize()
+        self.device.initialize()
         self.device.set_color(channel='ring', mode='fixed', colors=iter([[3, 2, 1]]),
                               speed='fastest')
         self.device.set_speed_profile(channel='pump',
@@ -86,9 +86,9 @@ class KrakenZ3TestCase(unittest.TestCase):
 
     def test_not_totally_broken(self):
         """Reasonable example calls to untested APIs do not raise exceptions."""
-        infos = self.device.initialize()
+        self.device.initialize()
         self.mock_hid.preload_read(Report(0, _SAMPLE_STATUS))
-        status = self.device.get_status()
+        self.device.get_status()
         self.device.set_speed_profile(channel='fan',
                                       profile=iter([(20, 20), (30, 50), (40, 100)]))
         self.device.set_fixed_speed(channel='pump', duty=50)

--- a/tests/test_nvidia.py
+++ b/tests/test_nvidia.py
@@ -36,7 +36,7 @@ def test_evga_pascal_finds_devices(evga_1080_ftw_bus, monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(smbus, attr, val)
             assert list(EvgaPascal.probe(smbus)) == [], \
-                    f'changing {attr} did not cause a mismatch'
+                f'changing {attr} did not cause a mismatch'
 
     assert list(map(type, EvgaPascal.probe(smbus))) == [EvgaPascal]
 
@@ -209,7 +209,7 @@ def test_rog_turing_does_not_find_devices(monkeypatch):
         with monkeypatch.context() as m:
             m.setattr(smbus, attr, val)
             assert list(RogTuring.probe(smbus)) == [], \
-                    f'changing {attr} did not cause a mismatch'
+                f'changing {attr} did not cause a mismatch'
 
     # with unsafe features addresses can be checked and none match
     assert list(map(type, RogTuring.probe(smbus, unsafe='smbus,rog_turing'))) == []

--- a/tests/test_nvidia.py
+++ b/tests/test_nvidia.py
@@ -173,7 +173,7 @@ def create_strix_2080ti_oc_bus(controller_address=None):
             parent_driver='nvidia',
     )
 
-    if controller_address == None:
+    if controller_address is None:
         return smbus
 
     smbus.open()

--- a/tests/test_nzxt_epsu.py
+++ b/tests/test_nzxt_epsu.py
@@ -2,6 +2,7 @@ import pytest
 from liquidctl.driver.nzxt_epsu import NzxtEPsu
 from _testutils import MockHidapiDevice, Report
 
+
 class _MockPsuDevice(MockHidapiDevice):
     def write(self, data):
         super().write(data)
@@ -14,21 +15,23 @@ class _MockPsuDevice(MockHidapiDevice):
             reply[2:4] = (0x11, 0x41)
         self.preload_read(Report(0, reply[0:]))
 
+
 @pytest.fixture
 def mockPsuDevice():
     device = _MockPsuDevice()
     return NzxtEPsu(device, 'mock NZXT E500 PSU')
+
 
 def test_psu_device_initialize(mockPsuDevice):
     mockPsuDevice.initialize()
 
     assert len(mockPsuDevice.device.sent) == 0
 
+
 def test_psu_device_status(mockPsuDevice):
 
     mockPsuDevice.connect()
     status = mockPsuDevice.get_status()
-
 
     fw = next(filter(lambda x: x[0] == 'Firmware version', status))
     assert fw == ('Firmware version', 'A017/40983', '')

--- a/tests/test_nzxt_epsu.py
+++ b/tests/test_nzxt_epsu.py
@@ -36,7 +36,6 @@ class NzxtEPsuTestCase(unittest.TestCase):
         assert fw == ('Firmware version', 'A017/40983', '')
 
     def test_dont_inject_report_ids(self):
-        status = self.device.get_status()
+        self.device.get_status()
         get_fw = self.mock_hid.sent[0]
         assert get_fw == Report(0, [0xad, 0, 3, 1, 0x60, 0xfc] + 58*[0])
-

--- a/tests/test_rgb_fusion2.py
+++ b/tests/test_rgb_fusion2.py
@@ -24,20 +24,22 @@ _INIT_8297_SAMPLE = Report(_INIT_8297_DATA[0], _INIT_8297_DATA[1:])
 @pytest.fixture
 def mockRgbFusion2_5702Device():
     device = MockHidapiDevice(vendor_id=0x048d, product_id=0x5702, address='addr')
-    dev =  RgbFusion2(device, 'mock 5702 Controller')
+    dev = RgbFusion2(device, 'mock 5702 Controller')
 
     dev.connect()
     return dev
+
 
 class Mock8297HidInterface(MockHidapiDevice):
     def get_feature_report(self, report_id, length):
         """Get a feature report emulating out of spec behavior of the device."""
         return super().get_feature_report(0, length)
 
+
 @pytest.fixture
 def mockRgbFusion2_8297Device():
     device = Mock8297HidInterface(vendor_id=0x048d, product_id=0x8297, address='addr')
-    dev =  RgbFusion2(device, 'mock 8297 Controller')
+    dev = RgbFusion2(device, 'mock 8297 Controller')
 
     dev.connect()
     return dev
@@ -51,16 +53,19 @@ def test_fusion2_5702_device_command_format(mockRgbFusion2_5702Device):
 
     for i, (report, data) in enumerate(mockRgbFusion2_5702Device.device.sent):
         assert report == 0xcc
-        assert len(data) ==  63  # TODO double check, more likely to be 64
+        assert len(data) == 63  # TODO double check, more likely to be 64
+
 
 def test_fusion2_5702_device_get_status(mockRgbFusion2_5702Device):
     assert mockRgbFusion2_5702Device.get_status() == []
+
 
 def test_fusion2_5702_device_initialize_status(mockRgbFusion2_5702Device):
     mockRgbFusion2_5702Device.device.preload_read(_INIT_5702_SAMPLE)
     name, fw_version = mockRgbFusion2_5702Device.initialize()
     assert name[1] == "IT5702-GIGABYTE V1.0.10.0"
     assert fw_version[1] == '1.0.10.0'
+
 
 def test_fusion2_5702_device_off_with_some_channel(mockRgbFusion2_5702Device):
     colors = [[0xff, 0, 0x80]]  # should be ignored
@@ -71,6 +76,7 @@ def test_fusion2_5702_device_off_with_some_channel(mockRgbFusion2_5702Device):
     assert max(set_color.data[13:16]) == 0
     assert max(set_color.data[21:27]) == 0
 
+
 def test_fusion2_5702_device_fixed_with_some_channel(mockRgbFusion2_5702Device):
     colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
     mockRgbFusion2_5702Device.set_color(channel='led7', mode='fixed', colors=iter(colors))
@@ -79,6 +85,7 @@ def test_fusion2_5702_device_fixed_with_some_channel(mockRgbFusion2_5702Device):
     assert set_color.data[10] == 0x01
     assert set_color.data[13:16] == [0x80, 0x00, 0xff]
     assert max(set_color.data[21:27]) == 0
+
 
 def test_fusion2_5702_device_pulse_with_some_channel_and_speed(mockRgbFusion2_5702Device):
     colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
@@ -90,6 +97,7 @@ def test_fusion2_5702_device_pulse_with_some_channel_and_speed(mockRgbFusion2_57
     assert set_color.data[13:16] == [0x80, 0x00, 0xff]
     assert set_color.data[21:27] == [0xe8, 0x03, 0xe8, 0x03, 0xf4, 0x01]
 
+
 def test_fusion2_5702_device_flash_with_some_channel_and_speed(mockRgbFusion2_5702Device):
     colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
     mockRgbFusion2_5702Device.set_color(channel='led6', mode='flash', colors=iter(colors), speed='slowest')
@@ -100,10 +108,11 @@ def test_fusion2_5702_device_flash_with_some_channel_and_speed(mockRgbFusion2_57
     assert set_color.data[13:16] == [0x80, 0x00, 0xff]
     assert set_color.data[21:27] == [0x64, 0x00, 0x64, 0x00, 0x60, 0x09]
 
+
 def test_fusion2_5702_device_double_flash_with_some_channel_and_speed_and_uppercase(mockRgbFusion2_5702Device):
     colors = [[0xff, 0, 0x80], [0x30, 0x30, 0x30]]  # second color should be ignored
     mockRgbFusion2_5702Device.set_color(channel='LED5', mode='DOUBLE-FLASH', colors=iter(colors),
-                          speed='LUDICROUS')
+                                        speed='LUDICROUS')
     set_color, execute = mockRgbFusion2_5702Device.device.sent
 
     assert set_color.data[0:2] == [0x24, 0x10]
@@ -111,10 +120,11 @@ def test_fusion2_5702_device_double_flash_with_some_channel_and_speed_and_upperc
     assert set_color.data[13:16] == [0x80, 0x00, 0xff]
     assert set_color.data[21:27] == [0x64, 0x00, 0x64, 0x00, 0x40, 0x06]
 
+
 def test_fusion2_5702_device_color_cycle_with_some_channel_and_speed(mockRgbFusion2_5702Device):
     colors = [[0xff, 0, 0x80]]  # should be ignored
     mockRgbFusion2_5702Device.set_color(channel='led4', mode='color-cycle', colors=iter(colors),
-                          speed='fastest')
+                                        speed='fastest')
     set_color, execute = mockRgbFusion2_5702Device.device.sent
 
     assert set_color.data[0:2] == [0x23, 0x08]
@@ -122,6 +132,7 @@ def test_fusion2_5702_device_color_cycle_with_some_channel_and_speed(mockRgbFusi
     assert max(set_color.data[13:16]) == 0
     assert set_color.data[21:27] == [0x26, 0x02, 0xc2, 0x01, 0x00, 0x00]
     # TODO brightness
+
 
 def test_fusion2_5702_device_common_behavior_in_all_set_color_writes(mockRgbFusion2_5702Device):
     colors = [[0xff, 0, 0x80]]
@@ -133,10 +144,12 @@ def test_fusion2_5702_device_common_behavior_in_all_set_color_writes(mockRgbFusi
         assert execute.data[0:2] == [0x28, 0xff]
         assert max(execute.data[2:]) == 0
 
+
 def test_fusion2_5702_device_sync_channel(mockRgbFusion2_5702Device):
     colors = [[0xff, 0, 0x80]]
     mockRgbFusion2_5702Device.set_color(channel='sync', mode='fixed', colors=iter(colors))
     assert len(mockRgbFusion2_5702Device.device.sent) == 8 + 1  # 8 × set + execute
+
 
 def test_fusion2_5702_device_reset_all_channels(mockRgbFusion2_5702Device):
     mockRgbFusion2_5702Device.reset_all_channels()
@@ -146,6 +159,7 @@ def test_fusion2_5702_device_reset_all_channels(mockRgbFusion2_5702Device):
     execute = mockRgbFusion2_5702Device.device.sent[-1]
     assert execute.data[0:2] == [0x28, 0xff]
     assert max(execute.data[2:]) == 0
+
 
 def test_fusion2_5702_device_invalid_set_color_arguments(mockRgbFusion2_5702Device):
 
@@ -160,6 +174,7 @@ def test_fusion2_5702_device_invalid_set_color_arguments(mockRgbFusion2_5702Devi
 
     with pytest.raises(KeyError):
         mockRgbFusion2_5702Device.set_color('led1', 'pulse', [[0xff, 0, 0x80]], speed='invalid')
+
 
 def test_fusion2_8297_device_initialize_status(mockRgbFusion2_8297Device):
     mockRgbFusion2_8297Device.device.preload_read(_INIT_8297_SAMPLE)

--- a/tests/test_smart_device.py
+++ b/tests/test_smart_device.py
@@ -19,7 +19,7 @@ class SmartDeviceTestCase(unittest.TestCase):
         for i in range(3):
             self.mock_hid.preload_read(Report(0, bytes(63)))
         self.device.initialize()
-        status = self.device.get_status()
+        self.device.get_status()
         self.device.set_color(channel='led', mode='breathing', colors=iter([[142, 24, 68]]),
                               speed='fastest')
         self.device.set_fixed_speed(channel='fan3', duty=50)

--- a/tests/test_smart_device.py
+++ b/tests/test_smart_device.py
@@ -3,14 +3,13 @@ from liquidctl.driver.smart_device import SmartDevice
 from _testutils import MockHidapiDevice, Report
 
 
-
 @pytest.fixture
 def mockSmartDevice():
     device = MockHidapiDevice(vendor_id=0x1e71, product_id=0x1714, address='addr')
     return SmartDevice(device, 'mock NZXT Smart Device V1', speed_channel_count=3, color_channel_count=1)
 
 
-##### class methods
+# class methods
 def test_smart_device_constructor(mockSmartDevice):
 
     assert mockSmartDevice._speed_channels == {
@@ -21,15 +20,17 @@ def test_smart_device_constructor(mockSmartDevice):
 
     assert mockSmartDevice._color_channels == {'led': (0), }
 
+
 def test_smart_device_not_totally_broken(mockSmartDevice):
+    dev = mockSmartDevice
 
     for i in range(3):
-        mockSmartDevice.device.preload_read(Report(0, bytes(63)))
+        dev.device.preload_read(Report(0, bytes(63)))
 
-    mockSmartDevice.initialize()
-    status = mockSmartDevice.get_status()
+    dev.initialize()
+    dev.get_status()
 
-    mockSmartDevice.set_color(channel='led', mode='breathing', colors=iter([[142, 24, 68]]),
-                          speed='fastest')
+    dev.set_color(channel='led', mode='breathing', colors=iter([[142, 24, 68]]),
+                  speed='fastest')
 
-    mockSmartDevice.set_fixed_speed(channel='fan3', duty=50)
+    dev.set_fixed_speed(channel='fan3', duty=50)

--- a/tests/test_smart_device2.py
+++ b/tests/test_smart_device2.py
@@ -2,6 +2,7 @@ import pytest
 from liquidctl.driver.smart_device import SmartDevice2
 from _testutils import MockHidapiDevice, Report
 
+
 class _MockSmartDevice2(MockHidapiDevice):
     def __init__(self, raw_speed_channels, raw_led_channels):
         super().__init__()
@@ -20,6 +21,7 @@ class _MockSmartDevice2(MockHidapiDevice):
                 reply[15 + 2 * 6] = 0x11
         self.preload_read(Report(reply[0], reply[1:]))
 
+
 @pytest.fixture
 def mockSmartDevice2():
     device = _MockSmartDevice2(raw_speed_channels=3, raw_led_channels=2)
@@ -27,7 +29,8 @@ def mockSmartDevice2():
     dev.connect()
     return dev
 
-##### class methods
+
+# class methods
 def test_smart_device2_constructor(mockSmartDevice2):
 
     assert mockSmartDevice2._speed_channels == {
@@ -42,13 +45,15 @@ def test_smart_device2_constructor(mockSmartDevice2):
             'sync': (0b011),
         }
 
+
 def test_smart_device2_not_totally_broken(mockSmartDevice2):
+    dev = mockSmartDevice2
 
-    mockSmartDevice2.initialize()
-    mockSmartDevice2.device.preload_read(Report(0, [0x67, 0x02] + [0] * 62))
-    status = mockSmartDevice2.get_status()
+    dev.initialize()
+    dev.device.preload_read(Report(0, [0x67, 0x02] + [0] * 62))
+    dev.get_status()
 
-    mockSmartDevice2.set_color(channel='led1', mode='breathing', colors=iter([[142, 24, 68]]),
-                          speed='fastest')
+    dev.set_color(channel='led1', mode='breathing', colors=iter([[142, 24, 68]]),
+                  speed='fastest')
 
-    mockSmartDevice2.set_fixed_speed(channel='fan3', duty=50)
+    dev.set_fixed_speed(channel='fan3', duty=50)

--- a/tests/test_smart_device2.py
+++ b/tests/test_smart_device2.py
@@ -39,7 +39,7 @@ class SmartDevice2TestCase(unittest.TestCase):
         """A few reasonable example calls do not raise exceptions."""
         self.device.initialize()
         self.mock_hid.preload_read(Report(0, [0x67, 0x02] + [0] * 62))
-        status = self.device.get_status()
+        self.device.get_status()
         self.device.set_color(channel='led1', mode='breathing', colors=iter([[142, 24, 68]]),
                               speed='fastest')
         self.device.set_fixed_speed(channel='fan3', duty=50)

--- a/tests/test_smbus.py
+++ b/tests/test_smbus.py
@@ -66,7 +66,7 @@ def test_aborts_if_sysfs_is_missing_devices(emulated_smbus, tmpdir):
 
 def test_finds_a_device(emulated_smbus, tmpdir):
     i2c_root = tmpdir.mkdir('sys').mkdir('bus').mkdir('i2c')
-    device1 = i2c_root.mkdir('devices').mkdir('i2c-42')
+    i2c_root.mkdir('devices').mkdir('i2c-42')
 
     virtual_bus = LinuxI2c(i2c_root=i2c_root)
 
@@ -78,9 +78,9 @@ def test_finds_a_device(emulated_smbus, tmpdir):
 def test_ignores_non_bus_sysfs_entries(emulated_smbus, tmpdir):
     i2c_root = tmpdir.mkdir('sys').mkdir('bus').mkdir('i2c')
     devices = i2c_root.mkdir('devices')
-    device1 = devices.mkdir('i2c-0')
-    device2 = devices.mkdir('0-0050')  # SPD info chip on i2c-0
-    device3 = devices.mkdir('i2c-DELL0829:00')  # i2c HID chip from Dell laptop
+    devices.mkdir('i2c-0')
+    devices.mkdir('0-0050')  # SPD info chip on i2c-0
+    devices.mkdir('i2c-DELL0829:00')  # i2c HID chip from Dell laptop
 
     virtual_bus = LinuxI2c(i2c_root=i2c_root)
 
@@ -92,8 +92,8 @@ def test_ignores_non_bus_sysfs_entries(emulated_smbus, tmpdir):
 def test_honors_a_bus_filter(emulated_smbus, tmpdir):
     i2c_root = tmpdir.mkdir('sys').mkdir('bus').mkdir('i2c')
     devices = i2c_root.mkdir('devices')
-    device1 = devices.mkdir('i2c-0')
-    device1 = devices.mkdir('i2c-1')
+    devices.mkdir('i2c-0')
+    devices.mkdir('i2c-1')
 
     virtual_bus = LinuxI2c(i2c_root=i2c_root)
 
@@ -144,7 +144,7 @@ def test_connects(emulated_device):
 
 def test_loading_unnavailable_eeprom_returns_none(emulated_device):
     bus, dev = emulated_device
-    assert bus.load_eeprom(0x51) is not None
+    assert bus.load_eeprom(0x51) is None
 
 
 def test_loads_eeprom(emulated_device):

--- a/tests/test_smbus.py
+++ b/tests/test_smbus.py
@@ -144,7 +144,7 @@ def test_connects(emulated_device):
 
 def test_loading_unnavailable_eeprom_returns_none(emulated_device):
     bus, dev = emulated_device
-    assert bus.load_eeprom(0x51) == None
+    assert bus.load_eeprom(0x51) is not None
 
 
 def test_loads_eeprom(emulated_device):

--- a/tests/test_usb.py
+++ b/tests/test_usb.py
@@ -10,6 +10,7 @@ def emulated_hid_device():
     hiddev = MockHidapiDevice()
     return UsbHidDriver(hiddev, 'Test')
 
+
 @pytest.fixture
 def emulated_usb_device():
     usbdev = MockHidapiDevice()  # hack, should mock PyUsbDevice
@@ -32,6 +33,7 @@ def test_hid_connects(emulated_hid_device):
         assert cm == dev
         assert opened
 
+
 def test_hid_disconnect(emulated_hid_device):
     dev = emulated_hid_device
 
@@ -43,7 +45,8 @@ def test_hid_disconnect(emulated_hid_device):
     opened = True
 
     dev.disconnect()
-    assert opened == False
+    assert not opened
+
 
 def test_usb_connects(emulated_usb_device):
     dev = emulated_usb_device
@@ -59,6 +62,7 @@ def test_usb_connects(emulated_usb_device):
         assert cm == dev
         assert opened
 
+
 def test_usb_disconnect(emulated_usb_device):
     dev = emulated_usb_device
 
@@ -70,4 +74,4 @@ def test_usb_disconnect(emulated_usb_device):
     opened = True
 
     dev.disconnect()
-    assert opened == False
+    assert not opened


### PR DESCRIPTION
This _should_ resolve is most of the tasks for issue #231. 
This will also close: #257

- [x] Checked all log messages start with a lowercase
- [x] All the log messages now use old style format strings 
- [x] fixed a bug with the direction flags where it was spelled wrong
- [x] changed all occurrences of  `LOGGER` to `_LOGGER`  to match the style guideline
- [x] fixed a lot of the flake8 errors
 
used the old style format strings for logs and `PEP 498` elsewhere


TODO in a future PR:
- check the exceptions
- make code more consistent
