### PR TITLE
Lighting Node Core Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The following devices are supported by this version of liquidctl.  See each guid
 | DDR4 DRAM | [DIMMs with a standard temperature sensor](docs/ddr4-guide.md) | SMBus | <sup>_EUXN_</sup> |
 | Fan/LED controller | [Corsair Commander Pro](docs/corsair-commander-guide.md) | USB HID | <sup>_EN_</sup> |
 | Fan/LED controller | [Corsair Lighting Node Pro](docs/corsair-commander-guide.md) | USB HID | <sup>_EN_</sup> |
+| Fan/LED controller | [Corsair Lighting Node Core](docs/corsair-commander-guide.md) | USB HID | <sup>_EN_</sup> |
 | Fan/LED controller | [NZXT Grid+ V3](docs/nzxt-smart-device-v1-guide.md) | USB HID | |
 | Fan/LED controller | [NZXT HUE 2, HUE 2 Ambient](docs/nzxt-hue2-guide.md) | USB HID | |
 | Fan/LED controller | [NZXT RGB & Fan Controller](docs/nzxt-hue2-guide.md) | USB HID | |

--- a/docs/corsair-commander-guide.md
+++ b/docs/corsair-commander-guide.md
@@ -1,7 +1,7 @@
 # Corsair Commander Pro
 _Driver API and source code available in [`liquidctl.driver.commander_pro`](../liquidctl/driver/commander_pro.py)._
 
-This driver will also work for the Corsair Lighting Node Pro Devices.
+This driver will also work for the Corsair Lighting Node Pro, and Lighting Node Core Devices.
 
 ## Initializing the device
 
@@ -37,7 +37,7 @@ Corsair Lighting Node Pro (experimental)
 
 ## Retrieving the fan speeds, temperatures and voltages
 
-The Lighting Node Pro does not have a status message.
+The Lighting Node Pro and Lighting Node Core do not have a status message.
 
 
 The Commander Pro is able to retrieve the current fan speeds as well as
@@ -69,7 +69,7 @@ Corsair Commander Pro (experimental)
 
 ## Programming the fan speeds
 
-The Lighting Node Pro Does not have any fans to control.
+The Lighting Node Pro and Lighting Node Core do not have any fans to control.
 
 
 Each fan can be set to either a fixed duty cycle, or a profile consisting of up
@@ -110,7 +110,7 @@ This will use a maximum temperature of 100 degrees.
 ## Controlling the LEDs
 
 
-The devices have 2 lighting channels that can have up to 96 leds connected to each.
+The devices have 2 lighting channels.
 LED channels are specified as either `led1` or `led2` with channel 1 being the default.
 
 The table bellow summarizes the available modes, and their associated

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -90,6 +90,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c02", TAG+="uacc
 # Corsair Hydro H80i v2
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c08", TAG+="uaccess"
 
+# Corsair Lighting Node Core
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c1a", TAG+="uaccess"
+
 # Corsair Lighting Node Pro
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c0b", TAG+="uaccess"
 

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -212,6 +212,7 @@ Internal data used by some drivers.
 .
 .SS Corsair Commander Pro
 .SS Corsair Lighting Node Pro
+.SS Corsair Lighting Node Core
 Cooling channels: \fIsync\fR, \fIfan[1\-5]\fR. (Commander Pro only)
 .PP
 Lighting channels: \fIled1\fR, \fIled2\fR.

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -121,6 +121,8 @@ class CommanderPro(UsbHidDriver):
             {'fan_count': 6, 'temp_probs': 4, 'led_channels': 2}),
         (0x1b1c, 0x0c0b, None, 'Corsair Lighting Node Pro (experimental)',
             {'fan_count': 0, 'temp_probs': 0, 'led_channels': 2}),
+        (0x1b1c, 0x0c1a, None, 'Corsair Lighting Node Core (experimental)',
+            {'fan_count': 0, 'temp_probs': 0, 'led_channels': 2}),
     ]
 
     def __init__(self, device, description, fan_count, temp_probs, led_channels, **kwargs):
@@ -201,7 +203,7 @@ class CommanderPro(UsbHidDriver):
         """
 
         if self.device.product_id != 0x0c10:
-            _LOGGER.debug('only the commander pro supports this')
+            _LOGGER.debug('only the Commander Pro supports this')
             return []
 
         connected_temp_sensors = self._data.load('temp_sensors_connected', default=[0]*self._temp_probs)
@@ -444,8 +446,8 @@ class CommanderPro(UsbHidDriver):
 
         direction = _LED_DIRECTION_FORWARD if direction == 'forward' else _LED_DIRECTION_BACKWARD
         speed = _LED_SPEED_SLOW if speed == 'slow' else _LED_SPEED_FAST if speed == 'fast' else _LED_SPEED_MEDIUM
-        start_led = clamp(start_led, 1, 96) - 1
-        num_leds = clamp(maximum_leds, 1, 96-start_led-1)  # there is a current firmware limitation of 96 led's per channel
+        start_led = clamp(start_led, 1, 255) - 1
+        num_leds = clamp(maximum_leds, 1, 255 - start_led - 1)
         random_colors = 0x00 if mode_str == 'off' or len(colors) != 0 else 0x01
         mode = _MODES.get(mode, -1)
 
@@ -465,6 +467,12 @@ class CommanderPro(UsbHidDriver):
 
         saved_effects = [] if mode_str == 'off' else self._data.load('saved_effects', default=[])
         saved_effects += [lighting_effect]
+
+        # check to make sure that too many LED effects are not being sent.
+        # the max seems to be 8 as found here https://github.com/liquidctl/liquidctl/issues/154#issuecomment-762372583
+        if len(saved_effects) > 8:
+            _LOGGER.warning(f'too many lighting effects. Run `liquidctl set {channel} color clear` to reset the effect')
+            return
 
         self._data.store('saved_effects', None if mode_str == 'off' else saved_effects)
 

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -122,7 +122,7 @@ class CommanderPro(UsbHidDriver):
         (0x1b1c, 0x0c0b, None, 'Corsair Lighting Node Pro (experimental)',
             {'fan_count': 0, 'temp_probs': 0, 'led_channels': 2}),
         (0x1b1c, 0x0c1a, None, 'Corsair Lighting Node Core (experimental)',
-            {'fan_count': 0, 'temp_probs': 0, 'led_channels': 2}),
+            {'fan_count': 0, 'temp_probs': 0, 'led_channels': 1}),
     ]
 
     def __init__(self, device, description, fan_count, temp_probs, led_channels, **kwargs):
@@ -442,12 +442,12 @@ class CommanderPro(UsbHidDriver):
         mode = mode_str.lower()
 
         # default to channel 1 if channel 2 is not specified.
-        led_channel = 1 if channel == 'led2' else 0
+        led_channel = 1 if channel == 'led2' && len(self._led_names) != 1 else 0
 
         direction = _LED_DIRECTION_FORWARD if direction == 'forward' else _LED_DIRECTION_BACKWARD
         speed = _LED_SPEED_SLOW if speed == 'slow' else _LED_SPEED_FAST if speed == 'fast' else _LED_SPEED_MEDIUM
-        start_led = clamp(start_led, 1, 255) - 1
-        num_leds = clamp(maximum_leds, 1, 255 - start_led - 1)
+        start_led = clamp(start_led, 1, 204) - 1
+        num_leds = clamp(maximum_leds, 1, 204 - start_led - 1)
         random_colors = 0x00 if mode_str == 'off' or len(colors) != 0 else 0x01
         mode = _MODES.get(mode, -1)
 

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -442,7 +442,7 @@ class CommanderPro(UsbHidDriver):
         mode = mode_str.lower()
 
         # default to channel 1 if channel 2 is not specified.
-        led_channel = 1 if channel == 'led2' && len(self._led_names) != 1 else 0
+        led_channel = 1 if channel == 'led2' and len(self._led_names) != 1 else 0
 
         direction = _LED_DIRECTION_FORWARD if direction == 'forward' else _LED_DIRECTION_BACKWARD
         speed = _LED_SPEED_SLOW if speed == 'slow' else _LED_SPEED_FAST if speed == 'fast' else _LED_SPEED_MEDIUM

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -1,4 +1,5 @@
 import os
+from copy import deepcopy
 from collections import deque, namedtuple
 
 Report = namedtuple('Report', ['number', 'data'])
@@ -20,11 +21,11 @@ class MockRuntimeStorage:
             value = None
 
         if value is None:
-            return default
+            return deepcopy(default)
         elif of_type and not isinstance(value, of_type):
-            return default
+            return deepcopy(default)
         else:
-            return value
+            return deepcopy(value)
 
     def store(self, key, value):
         """Unstable API."""

--- a/tests/test_comander_pro.py
+++ b/tests/test_comander_pro.py
@@ -42,6 +42,15 @@ def lightingNodeProDevice():
     node._data = MockRuntimeStorage(key_prefixes='testing')
     return node
 
+@pytest.fixture
+def lightingNodeCoreDevice():
+    device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c1a, address='addr')
+    node = CommanderPro(device, 'Corsair Lighting Node Core (experimental)', 0, 0, 1)
+    node.connect()
+    node._data = MockRuntimeStorage(key_prefixes='testing')
+    return node
+
+
 
 # prepare profile
 def test_prepare_profile_valid_max_rpm():
@@ -690,7 +699,7 @@ def test_set_speed_profile_valid(commanderProDevice):
     assert sent[0].data[16] == 0xf4
 
 
-def test_set_speed_profile_lighting(lightingNodeProDevice):
+def test_set_speed_profile_node(lightingNodeProDevice):
     responses = [
         '00000000000000000000000000000000',
         '00000000000000000000000000000000',
@@ -710,6 +719,29 @@ def test_set_speed_profile_lighting(lightingNodeProDevice):
 
     # check the commands sent
     sent = lightingNodeProDevice.device.sent
+    assert len(sent) == 0
+
+
+def test_set_speed_profile_core(lightingNodeCoreDevice):
+    responses = [
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000'
+    ]
+
+    for d in responses:
+        lightingNodeCoreDevice.device.preload_read(Report(0, bytes.fromhex(d)))
+
+    lightingNodeCoreDevice._data.store('temp_sensors_connected', [0x01, 0x00, 0x00, 0x00])
+    lightingNodeCoreDevice._data.store('fan_modes', [0x01, 0x00, 0x01, 0x01, 0x00, 0x00])
+
+    with pytest.raises(NotSupportedByDevice):
+        lightingNodeCoreDevice.set_speed_profile('sync', [(10, 500), (20, 1000)])
+
+    # check the commands sent
+    sent = lightingNodeCoreDevice.device.sent
     assert len(sent) == 0
 
 
@@ -1030,7 +1062,6 @@ def test_set_color_hardware_num_leds(commanderProDevice, numLED, expected):
     assert len(effects) == 1
 
 
-# there is no longer too many LEDs
 def test_set_color_hardware_too_many_leds(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1045,15 +1076,15 @@ def test_set_color_hardware_too_many_leds(commanderProDevice):
     for d in responses:
         commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
     colors = [[0xaa, 0xbb, 0xcc]]
-    commanderProDevice.set_color('led1', 'fixed', colors, start_led=50, maximum_leds=50)
+    commanderProDevice.set_color('led1', 'fixed', colors, start_led=200, maximum_leds=50)
 
     # check the commands sent
     sent = commanderProDevice.device.sent
     assert len(sent) == 5
 
     assert sent[3].data[0] == 0x35
-    assert sent[3].data[2] == 0x31  # start led
-    assert sent[3].data[3] == 0x32  # num led
+    assert sent[3].data[2] == 0xc7  # start led
+    assert sent[3].data[3] == 0x04  # num led
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
@@ -1348,6 +1379,98 @@ def test_set_color_hardware_multipe_commands(commanderProDevice):
 
     assert effects is not None
     assert len(effects) == 2
+
+
+def test_set_color_hardware_last_commands(commanderProDevice):
+
+    for i in range(15):
+        commanderProDevice.device.preload_read(Report(0, bytes.fromhex('00000000000000000000000000000000')))
+
+    effect = {
+            'channel': 0x01,
+            'start_led': 0x00,
+            'num_leds': 0x0f,
+            'mode': 0x0a,
+            'speed': 0x00,
+            'direction': 0x00,
+            'random_colors': 0x00,
+            'colors': [0xaa, 0xbb, 0xcc]
+        }
+    commanderProDevice._data.store('saved_effects', [effect, effect, effect, effect, effect, effect, effect])
+
+    commanderProDevice.set_color('led1', 'fixed', [[0x00, 0x11, 0x22]], start_led=16, maximum_leds=5)
+
+    # check the commands sent
+    sent = commanderProDevice.device.sent
+    assert len(sent) == 12
+
+    effects = commanderProDevice._data.load('saved_effects', default=None)
+
+    assert effects is not None
+    assert len(effects) == 8
+
+
+
+def test_set_color_hardware_max_commands(commanderProDevice):
+
+    for i in range(15):
+        commanderProDevice.device.preload_read(Report(0, bytes.fromhex('00000000000000000000000000000000')))
+
+    effect = {
+            'channel': 0x01,
+            'start_led': 0x00,
+            'num_leds': 0x0f,
+            'mode': 0x0a,
+            'speed': 0x00,
+            'direction': 0x00,
+            'random_colors': 0x00,
+            'colors': [0xaa, 0xbb, 0xcc]
+        }
+    commanderProDevice._data.store('saved_effects', [effect, effect, effect, effect, effect, effect, effect, effect])
+
+    commanderProDevice.set_color('led1', 'fixed', [[0x00, 0x11, 0x22]], start_led=16, maximum_leds=5)
+
+    # check the commands sent
+    sent = commanderProDevice.device.sent
+    assert len(sent) == 0
+
+    effects = commanderProDevice._data.load('saved_effects', default=None)
+
+    assert effects is not None
+    assert len(effects) == 8
+
+
+def test_set_color_hardware_too_many_commands(commanderProDevice):
+    responses = [
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000',
+        '00000000000000000000000000000000'
+    ]
+
+    for d in responses:
+        commanderProDevice.device.preload_read(Report(0, bytes.fromhex(d)))
+
+    effect = {
+            'channel': 0x01,
+            'start_led': 0x00,
+            'num_leds': 0x0f,
+            'mode': 0x0a,
+            'speed': 0x00,
+            'direction': 0x00,
+            'random_colors': 0x00,
+            'colors': [0xaa, 0xbb, 0xcc]
+        }
+    commanderProDevice._data.store('saved_effects', [effect, effect, effect, effect, effect, effect, effect, effect, effect])
+
+    commanderProDevice.set_color('led1', 'fixed', [[0x00, 0x11, 0x22]], start_led=16, maximum_leds=5)
+
+    # check the commands sent
+    sent = commanderProDevice.device.sent
+    assert len(sent) == 0
 
 
 def test_send_command_valid_data(commanderProDevice):

--- a/tests/test_comander_pro.py
+++ b/tests/test_comander_pro.py
@@ -999,7 +999,7 @@ def test_set_color_hardware_start_set(commanderProDevice, startLED, expected):
 
 
 @pytest.mark.parametrize('numLED,expected', [
-    (1, 0x01), (30, 0x1e), (96, 0x5f)
+    (1, 0x01), (30, 0x1e), (96, 0x60)
     ])
 def test_set_color_hardware_num_leds(commanderProDevice, numLED, expected):
     responses = [
@@ -1030,6 +1030,7 @@ def test_set_color_hardware_num_leds(commanderProDevice, numLED, expected):
     assert len(effects) == 1
 
 
+# there is no longer too many LEDs
 def test_set_color_hardware_too_many_leds(commanderProDevice):
     responses = [
         '00000000000000000000000000000000',
@@ -1052,7 +1053,7 @@ def test_set_color_hardware_too_many_leds(commanderProDevice):
 
     assert sent[3].data[0] == 0x35
     assert sent[3].data[2] == 0x31  # start led
-    assert sent[3].data[3] == 0x2e  # num led
+    assert sent[3].data[3] == 0x32  # num led
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 


### PR DESCRIPTION
Closes #154.

This enables support for the Corsair Lighting Node Core.

- [x] update man pages with new device
- [x] update readme with new device
- [x] added device id to the commander pro driver
- [x] added device usage to the commander pro driver docs
- [x] create tests for the new device
- [x] create tests for the new limited number of effect commands
- [x] figure out why led channel 2 does not seem to be working