### PR TITLE
Corsair H100i Platinum SE Number of LEDs fix

### DIFF
--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -299,7 +299,9 @@ class HydroPlatinum(UsbHidDriver):
         data3 = bytes(itertools.chain(*((b, g, r) for r, g, b in expanded[40:])))
 
         self._send_command(_FEATURE_LIGHTING, _CMD_SET_LIGHTING1, data=data1)
-        self._send_command(_FEATURE_LIGHTING, _CMD_SET_LIGHTING2, data=data2)
+        
+        if self._led_count > 20:
+            self._send_command(_FEATURE_LIGHTING, _CMD_SET_LIGHTING2, data=data2)
 
         if self._led_count > 40:
             self._send_command(_FEATURE_LIGHTING, _CMD_SET_LIGHTING3, data=data3)


### PR DESCRIPTION
Closes #267 and #242.

Changed support to work with a different number of LED's that come with the different stock Hydro Platinum AIO coolers.

This changes one of the options that is passed to the constructor for the `HydroPlatinum` driver. Changed `rgb_fans`  boolean option in the HydroPlatinum driver to a `fan_leds` integer option that is set to the number of LEDs that are on each fan that comes with the cooler.

For the SE cooler that comes with LL fans (16 leds each) this bumps the total number of LEDs to 48, which is too many for to fit in the 2 color commands that are sent. Because of that a 3rd color message is now sent when necessary. 
~~There should be no change for any existing devices.~~