### PR TITLE
added basic file locking capabilities for unix and windows

### DIFF
--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -88,8 +88,7 @@ def _sequence(storage):
     """
 
     while True:
-        seq = storage.load('sequence', of_type=int, default=0) % 31 + 1
-        storage.store('sequence', seq)
+        seq = storage.load_store('sequence', lambda x : x % 31 + 1, of_type=int, default=0)
         yield seq
 
 

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -89,7 +89,7 @@ def _sequence(storage):
 
     while True:
         seq = storage.load_store('sequence', lambda x : x % 31 + 1, of_type=int, default=0)
-        yield seq
+        yield seq[1]
 
 
 def _prepare_profile(original):

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -112,7 +112,7 @@ class RuntimeStorage:
     def load(self, key, of_type=None, default=None):
         """Unstable API."""
 
-        with _shared_lock(key):
+        with self._shared_lock(key):
             value = self._backend.load(key)
 
         if value is None:
@@ -125,7 +125,7 @@ class RuntimeStorage:
     def load_store(self, key, func, of_type=None, default=None):
         """Unstable API."""
 
-        with _exclusive_lock(key):
+        with self._exclusive_lock(key):
             value = self._backend.load(key)
 
             if value is None:
@@ -138,16 +138,16 @@ class RuntimeStorage:
             newValue = func(value)
             self._backend.store(key, newValue)
 
-        return vlue
+        return value
 
     def store(self, key, value):
         """Unstable API."""
-        with _exclusive_lock(key):
+        with self._exclusive_lock(key):
             self._backend.store(key, value)
         return value
 
     @contextmanager
-    def _shared_lock(key):
+    def _shared_lock(self, key):
 
         lockFile = self._backend.lockFile(key)
 
@@ -174,7 +174,7 @@ class RuntimeStorage:
                 f.close()
 
     @contextmanager
-    def _exclusive_lock(key):
+    def _exclusive_lock(self, key):
         lockFile = self._backend.lockFile(key)
 
         if sys.platform == 'win32':

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -138,7 +138,7 @@ class RuntimeStorage:
             newValue = func(value)
             self._backend.store(key, newValue)
 
-        return value
+        return newValue
 
     def store(self, key, value):
         """Unstable API."""

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -68,10 +68,8 @@ class _FilesystemBackend:
         _LOGGER.debug('data in %s', self._write_dir)
 
     def load(self, key):
-        _LOGGER.debug('%r', self._read_dirs)
         for base in self._read_dirs:
             path = os.path.join(base, key)
-            _LOGGER.debug('%s', key)
             if not os.path.isfile(path):
                 continue
             try:

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -119,15 +119,12 @@ class _FilesystemBackend:
                 if not os.path.isfile(read_path):
                     continue
                 try:
-                    if read_path == path:
+                    if os.path.samefile(read_path, path):
                         # we already have an exclusive lock to this file
                         data = f.read().strip()
                         f.seek(0)
                     else:
-                        # it appears that in some cases, if `read_file` and `path` point
-                        # to the same file, acquiring a shared lock on `aux` could
-                        # downgrade our lock on `f`
-                        with self._open_with_lock(read_path, os.O_RDWR) as aux:
+                        with self._open_with_lock(read_path, os.O_RDWR, shared=True) as aux:
                             data = aux.read().strip()
 
                     if not data:

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -130,12 +130,11 @@ class _FilesystemBackend:
 
                     value = literal_eval(data)
                     _LOGGER.debug('loaded %s=%r (from %s)', key, value, read_path)
+                    break
                 except OSError as err:
                     _LOGGER.warning('%s exists but could not be read: %s', read_path, err)
                 except ValueError as err:
                     _LOGGER.warning('%s exists but was corrupted: %s', key, err)
-                else:
-                    break
             else:
                 _LOGGER.debug('no data (file) found for %s', key)
 

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -122,7 +122,7 @@ class _FilesystemBackend:
                         data = f.read().strip()
                         f.seek(0)
                     else:
-                        with self._open_with_lock(read_path, os.O_RDWR, shared=True) as aux:
+                        with self._open_with_lock(read_path, os.O_RDONLY, shared=True) as aux:
                             data = aux.read().strip()
 
                     if not data:

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -104,8 +104,8 @@ class _FilesystemBackend:
 
         _LOGGER.debug('stored %s=%r (in %s)', key, value, path)
 
-    def lockFile(self, key):
-        return os.path.join(self._write_dir, f'${key}.lock')
+    def _lock_file(self, key):
+        return os.path.join(self._write_dir, f'{key}.lock')
 
     def load_store(self, key, func):
         with self._exclusive_lock(key):
@@ -115,9 +115,9 @@ class _FilesystemBackend:
 
 
     @contextmanager
-    def _shared_lock(self, key, locked):
+    def _shared_lock(self, key, locked=False):
 
-        lockFile = self.lockFile(key)
+        lockFile = self._lock_file(key)
         if not locked:
             if sys.platform == 'win32':
                 again = True
@@ -128,7 +128,7 @@ class _FilesystemBackend:
                     except FileExistsError:
                         again = True
             else:
-                f = open(lockFile, 'r')
+                f = open(lockFile, 'w')
                 fcntl.flock(f, fcntl.LOCK_SH)
 
         try:
@@ -143,8 +143,8 @@ class _FilesystemBackend:
                     f.close()
 
     @contextmanager
-    def _exclusive_lock(self, key, locked):
-        lockFile = self.lockFile(key)
+    def _exclusive_lock(self, key, locked=False):
+        lockFile = self._lock_file(key)
 
         if not locked:
             if sys.platform == 'win32':

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -121,7 +121,7 @@ class _FilesystemBackend:
         if not locked:
             if sys.platform == 'win32':
                 again = True
-                while not again:
+                while again:
                     try:
                         f = open(lockFile, 'x')
                         again = False
@@ -149,7 +149,7 @@ class _FilesystemBackend:
         if not locked:
             if sys.platform == 'win32':
                 again = True
-                while not again:
+                while again:
                     try:
                         f = open(lockFile, 'x')
                         again = False

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -148,6 +148,7 @@ class _FilesystemBackend:
             data = repr(new_value)
             assert literal_eval(data) == new_value, 'encode/decode roundtrip fails'
             f.write(data)
+            f.truncate()
             f.flush()  # ensure flushing before automatic unlocking
 
             _LOGGER.debug('replaced with %s=%r (stored in %s)', key, new_value, path)

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -55,7 +55,7 @@ class _FilesystemBackend:
         return key
 
     def __init__(self, key_prefixes, runtime_dirs=get_runtime_dirs()):
-        key_prefixes = map(self._sanitize, key_prefixes)
+        key_prefixes = [self._sanitize(p) for p in key_prefixes]
         # compute read and write dirs from base runtime dirs: the first base
         # dir is selected for writes and prefered for reads
         self._read_dirs = [os.path.join(x, *key_prefixes) for x in runtime_dirs]

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -8,13 +8,14 @@ import logging
 import os
 import sys
 import tempfile
+from ast import literal_eval
+from contextlib import contextmanager
+
 if sys.platform == 'win32':
     import msvcrt
 else:
     import fcntl
 
-from ast import literal_eval
-from contextlib import contextmanager
 
 _LOGGER = logging.getLogger(__name__)
 XDG_RUNTIME_DIR = os.getenv('XDG_RUNTIME_DIR')
@@ -201,8 +202,6 @@ class RuntimeStorage:
                 value = default
             elif of_type and not isinstance(value, of_type):
                 value = default
-            else:
-                value = value
             return func(value)
 
         return self._backend.load_store(key, l)

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -177,7 +177,9 @@ class RuntimeStorage:
     """Unstable API."""
 
     def __init__(self, key_prefixes, backend=None):
-        self._backend = backend if backend is not None else _FilesystemBackend(key_prefixes)
+        if not backend:
+            backend = _FilesystemBackend(key_prefixes)
+        self._backend = backend
 
     def load(self, key, of_type=None, default=None):
         """Unstable API."""

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -160,14 +160,7 @@ class _FilesystemBackend:
             else:
                 fcntl.flock(f, fcntl.LOCK_EX)
 
-            try:
-                yield f
-            finally:
-                if sys.platform == 'win32':
-                    f.seek(0)
-                    msvcrt.locking(f.fileno(), msvcrt.LK_UNLCK, 1)
-                else:
-                    fcntl.flock(f, fcntl.LOCK_UN)
+            yield f
 
 
 class RuntimeStorage:

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -32,6 +32,27 @@ class MockRuntimeStorage:
         self._cache[key] = value
         return value
 
+    def load_store(self, key, func, of_type=None, default=None):
+        """Unstable API."""
+
+        if key in self._cache:
+            value = self._cache[key]
+        else:
+            value = None
+
+        if value is None:
+            value = deepcopy(default)
+        elif of_type and not isinstance(value, of_type):
+            value = deepcopy(default)
+        else:
+            value = deepcopy(value)
+
+        newValue = func(value)
+        self._cache[key] = newValue
+
+        return newValue
+
+
 
 class MockHidapiDevice:
     def __init__(self, vendor_id=None, product_id=None, release_number=None,

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -47,10 +47,10 @@ class MockRuntimeStorage:
         else:
             value = deepcopy(value)
 
-        newValue = func(value)
-        self._cache[key] = newValue
+        new_value = func(value)
+        self._cache[key] = new_value
 
-        return newValue
+        return (value, new_value)
 
 
 

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -1,6 +1,8 @@
 import os
 from collections import deque, namedtuple
-from copy import deepcopy
+from tempfile import mkdtemp
+
+from liquidctl.keyval import RuntimeStorage, _FilesystemBackend
 
 Report = namedtuple('Report', ['number', 'data'])
 
@@ -9,49 +11,12 @@ def noop(*args, **kwargs):
     return None
 
 
-class MockRuntimeStorage:
-    def __init__(self, key_prefixes):
-        self._cache = {}
-
-    def load(self, key, of_type=None, default=None):
-        """Unstable API."""
-        if key in self._cache:
-            value = self._cache[key]
-        else:
-            value = None
-
-        if value is None:
-            return deepcopy(default)
-        elif of_type and not isinstance(value, of_type):
-            return deepcopy(default)
-        else:
-            return deepcopy(value)
-
-    def store(self, key, value):
-        """Unstable API."""
-        self._cache[key] = value
-        return value
-
-    def load_store(self, key, func, of_type=None, default=None):
-        """Unstable API."""
-
-        if key in self._cache:
-            value = self._cache[key]
-        else:
-            value = None
-
-        if value is None:
-            value = deepcopy(default)
-        elif of_type and not isinstance(value, of_type):
-            value = deepcopy(default)
-        else:
-            value = deepcopy(value)
-
-        new_value = func(value)
-        self._cache[key] = new_value
-
-        return (value, new_value)
-
+class MockRuntimeStorage(RuntimeStorage):
+    def __init__(self, key_prefixes, backend=None):
+        if not backend:
+            run_dir = mkdtemp('run_dir')
+            backend = _FilesystemBackend(key_prefixes, runtime_dirs=[run_dir])
+        super().__init__(key_prefixes, backend)
 
 
 class MockHidapiDevice:

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -1,5 +1,5 @@
 import pytest
-from _testutils import MockPyusbDevice
+from _testutils import MockPyusbDevice, MockRuntimeStorage
 
 from collections import deque
 
@@ -20,7 +20,10 @@ def mockLegacy690LcDevice():
     device = MockPyusbDevice(vendor_id=0xffff, product_id=0xb200, bus=1, port=(1,))
     dev = Legacy690Lc(device, 'Mock Legacy 690LC')
 
-    dev.connect()
+    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage.store('leds_enabled', 0)
+
+    dev.connect(runtime_storage=runtime_storage)
     return dev
 
 

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -20,7 +20,7 @@ def mockLegacy690LcDevice():
     device = MockPyusbDevice(vendor_id=0xffff, product_id=0xb200, bus=1, port=(1,))
     dev = Legacy690Lc(device, 'Mock Legacy 690LC')
 
-    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])
     runtime_storage.store('leds_enabled', 0)
 
     dev.connect(runtime_storage=runtime_storage)

--- a/tests/test_commander_pro.py
+++ b/tests/test_commander_pro.py
@@ -29,8 +29,10 @@ def lightingNodeProDeviceUnconnected():
 def commanderProDevice():
     device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c10, address='addr')
     pro = CommanderPro(device, 'Corsair Commander Pro (experimental)', 6, 4, 2)
-    pro.connect()
-    pro._data = MockRuntimeStorage(key_prefixes='testing')
+
+
+    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    pro.connect(runtime_storage=runtime_storage)
     return pro
 
 
@@ -38,16 +40,16 @@ def commanderProDevice():
 def lightingNodeProDevice():
     device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c0b, address='addr')
     node = CommanderPro(device, 'Corsair Lighting Node Pro (experimental)', 0, 0, 2)
-    node.connect()
-    node._data = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    node.connect(runtime_storage=runtime_storage)
     return node
 
 @pytest.fixture
 def lightingNodeCoreDevice():
     device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c1a, address='addr')
     node = CommanderPro(device, 'Corsair Lighting Node Core (experimental)', 0, 0, 1)
-    node.connect()
-    node._data = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    node.connect(runtime_storage=runtime_storage)
     return node
 
 

--- a/tests/test_commander_pro.py
+++ b/tests/test_commander_pro.py
@@ -31,7 +31,7 @@ def commanderProDevice():
     pro = CommanderPro(device, 'Corsair Commander Pro (experimental)', 6, 4, 2)
 
 
-    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])
     pro.connect(runtime_storage=runtime_storage)
     return pro
 
@@ -40,7 +40,7 @@ def commanderProDevice():
 def lightingNodeProDevice():
     device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c0b, address='addr')
     node = CommanderPro(device, 'Corsair Lighting Node Pro (experimental)', 0, 0, 2)
-    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])
     node.connect(runtime_storage=runtime_storage)
     return node
 
@@ -48,7 +48,7 @@ def lightingNodeProDevice():
 def lightingNodeCoreDevice():
     device = MockHidapiDevice(vendor_id=0x1b1c, product_id=0x0c1a, address='addr')
     node = CommanderPro(device, 'Corsair Lighting Node Core (experimental)', 0, 0, 1)
-    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])
     node.connect(runtime_storage=runtime_storage)
     return node
 

--- a/tests/test_hydro_platinum.py
+++ b/tests/test_hydro_platinum.py
@@ -19,7 +19,7 @@ def h115iPlatinumDevice():
     device = _MockHydroPlatinumDevice()
     dev = HydroPlatinum(device, description, **kwargs)
 
-    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])
     runtime_storage.store('leds_enabled', 0)
 
     dev.connect(runtime_storage=runtime_storage)
@@ -33,7 +33,7 @@ def h100iPlatinumSeDevice():
     device = _MockHydroPlatinumDevice()
     dev = HydroPlatinum(device, description, **kwargs)
 
-    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])
     runtime_storage.store('leds_enabled', 0)
 
     dev.connect(runtime_storage=runtime_storage)
@@ -47,7 +47,7 @@ def h150iProXTDevice():
     device = _MockHydroPlatinumDevice()
     dev = HydroPlatinum(device, description, **kwargs)
 
-    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])
     runtime_storage.store('leds_enabled', 0)
 
     dev.connect(runtime_storage=runtime_storage)
@@ -86,7 +86,7 @@ class _MockHydroPlatinumDevice(MockHidapiDevice):
 
 
 def test_sequence_numbers_are_correctly_generated():
-    runtime_storage = MockRuntimeStorage(key_prefixes='testing')
+    runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])
     sequence = _sequence(runtime_storage)
 
     for i in range(1, 32):

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -1,10 +1,13 @@
 import pytest
-
+from multiprocessing import Process
+import time
+import os
+import sys
 from pathlib import Path
 
+from liquidctl.keyval import _FilesystemBackend
 
 def test_fs_backend_handles_values_corupted_with_nulls(tmpdir, caplog):
-    from liquidctl.keyval import _FilesystemBackend
 
     run_dir = tmpdir.mkdir('run_dir')
     store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
@@ -18,3 +21,244 @@ def test_fs_backend_handles_values_corupted_with_nulls(tmpdir, caplog):
 
     assert val is None
     assert 'was corrupted' in caplog.text
+
+
+# this is the process that will test the load store code
+def inc_proccess(store):
+
+    def l(x):
+        time.sleep(2)
+        return x+1
+
+    store.load_store('key', l)
+
+
+def test_fs_backend_load_store(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    store.store('key', 42)
+
+    p1 = Process(target=inc_proccess, args=(store,))
+    p2 = Process(target=inc_proccess, args=(store,))
+    p3 = Process(target=inc_proccess, args=(store,))
+    p4 = Process(target=inc_proccess, args=(store,))
+
+    startTime = time.time()
+    p1.start()
+    p2.start()
+    p3.start()
+    p4.start()
+
+    p1.join()
+    p2.join()
+    p3.join()
+    p4.join()
+
+    endTime = time.time()
+    diffTime = (endTime-startTime)
+
+    val = store.load('key')
+
+    assert val == 46
+    assert diffTime == pytest.approx(8, rel=0.01)   # check that the sleeps add up
+
+
+@pytest.mark.parametrize('key', [
+    'key1', 'key-value', 'new_key', 'ob1', 'abracadabra'
+    ])
+def test_fs_backend_lock_file(tmpdir, key):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    file = store._lock_file(key)
+    assert os.path.basename(file) == f'{key}.lock'
+
+
+def test_fs_backend_shared_lock_locked(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    with store._shared_lock('key', locked=True):
+        assert not os.path.exists(store._lock_file('key'))
+
+
+def test_fs_backend_exclusive_lock_locked(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    with store._exclusive_lock('key', locked=True):
+        assert not os.path.exists(store._lock_file('key'))
+
+
+def test_fs_backend_shared_lock(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    with store._shared_lock('key'):
+        assert os.path.exists(store._lock_file('key'))
+
+    if sys.platform == 'win32':
+        assert not os.path.exists(store._lock_file('key'))
+
+
+def test_fs_backend_exclusive_lock(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    with store._exclusive_lock('key'):
+        assert os.path.exists(store._lock_file('key'))
+
+    if sys.platform == 'win32':
+        assert not os.path.exists(store._lock_file('key'))
+
+
+# this is the process that will test if multiple proccesses can share a lock
+def shared_lock_sleep(store):
+
+    with store._shared_lock('key'):
+        time.sleep(2)
+
+# this is the process that will test if multiple proccesses can share a lock def shared_lock_sleep(store):
+def exclusive_lock_sleep(store):
+
+    with store._exclusive_lock('key'):
+        time.sleep(2)
+
+
+def test_fs_backend_share_lock(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    store.store('key', 42)
+
+    p1 = Process(target=shared_lock_sleep, args=(store,))
+    p2 = Process(target=shared_lock_sleep, args=(store,))
+    p3 = Process(target=shared_lock_sleep, args=(store,))
+    p4 = Process(target=shared_lock_sleep, args=(store,))
+
+    startTime = time.time()
+    p1.start()
+    p2.start()
+    p3.start()
+    p4.start()
+
+    p1.join()
+    p2.join()
+    p3.join()
+    p4.join()
+
+    endTime = time.time()
+    diffTime = (endTime-startTime)
+
+
+    # no shared locks on windows
+    if sys.platform == 'win32':
+        assert diffTime == pytest.approx(8, rel=0.1)   # check that the sleeps add up
+    else:
+        assert diffTime == pytest.approx(2, rel=0.1)   # check that the sleeps add up
+
+
+def test_fs_backend_exclusive_lock(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    store.store('key', 42)
+
+    p1 = Process(target=exclusive_lock_sleep, args=(store,))
+    p2 = Process(target=exclusive_lock_sleep, args=(store,))
+    p3 = Process(target=exclusive_lock_sleep, args=(store,))
+    p4 = Process(target=exclusive_lock_sleep, args=(store,))
+
+    startTime = time.time()
+    p1.start()
+    p2.start()
+    p3.start()
+    p4.start()
+
+    p1.join()
+    p2.join()
+    p3.join()
+    p4.join()
+
+    endTime = time.time()
+    diffTime = (endTime-startTime)
+
+    assert diffTime == pytest.approx(8, rel=0.1)   # check that the sleeps add up
+
+
+def test_fs_backend_mixed_lock_exclusive_first(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    store.store('key', 42)
+
+    p1 = Process(target=exclusive_lock_sleep, args=(store,))
+    p2 = Process(target=shared_lock_sleep, args=(store,))
+    p3 = Process(target=shared_lock_sleep, args=(store,))
+    p4 = Process(target=shared_lock_sleep, args=(store,))
+
+    startTime = time.time()
+    p1.start()
+    time.sleep(0.1)
+    p2.start()
+    p3.start()
+    p4.start()
+
+    p1.join()
+    p2.join()
+    p3.join()
+    p4.join()
+
+    endTime = time.time()
+    diffTime = (endTime-startTime)
+
+    # no shared locks on windows
+    if sys.platform == 'win32':
+        assert diffTime == pytest.approx(8.1, rel=0.1)   # check that the sleeps add up
+    else:
+        assert diffTime == pytest.approx(4.1, rel=0.1)   # check that the sleeps add up
+
+
+def test_fs_backend_mixed_lock_shared_first(tmpdir):
+
+    run_dir = tmpdir.mkdir('run_dir')
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    store.store('key', 42)
+
+    p1 = Process(target=shared_lock_sleep, args=(store,))
+    p2 = Process(target=shared_lock_sleep, args=(store,))
+    p3 = Process(target=exclusive_lock_sleep, args=(store,))
+    p4 = Process(target=shared_lock_sleep, args=(store,))
+
+    startTime = time.time()
+    p1.start()
+    time.sleep(0.1)
+    p2.start()
+    p3.start()
+    time.sleep(0.1)
+    p4.start()
+
+    p1.join()
+    p2.join()
+    p3.join()
+    p4.join()
+
+    endTime = time.time()
+    diffTime = (endTime-startTime)
+
+    # no shared locks on windows
+    if sys.platform == 'win32':
+        assert diffTime == pytest.approx(8.2, rel=0.1)   # check that the sleeps add up
+    else:
+        assert diffTime == pytest.approx(4.2, rel=0.1)   # check that the sleeps add up

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -103,7 +103,21 @@ def test_fs_backend_load_store_loads_from_fallback_dir(tmpdir):
     store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir, fb_dir])
     assert store.load_store('key', lambda x: x + 1) == (42, 43)
 
-    assert fallback.load('key') == 42, 'fallback location was changed'
+    assert fallback.load('key') == 42, 'content in fallback location changed'
+
+
+def test_fs_backend_load_store_loads_from_fallback_dir_that_is_symlink(tmpdir):
+    run_dir = tmpdir.mkdir('run_dir')
+    fb_dir = os.path.join(run_dir, 'symlink')
+    os.symlink(run_dir, fb_dir, target_is_directory=True)
+
+    # don't store any initial value so that the fallback location is checked
+
+    store = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir, fb_dir])
+    assert store.load_store('key', lambda x: 42) == (None, 42)
+
+    fallback = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[fb_dir])
+    assert fallback.load('key') == 42, 'content in fallback symlink did not change'
 
 
 def test_fs_backend_load_store_is_atomic(tmpdir):

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -62,7 +62,7 @@ def test_fs_backend_load_store(tmpdir):
     val = store.load('key')
 
     assert val == 46
-    assert diffTime == pytest.approx(8, rel=0.01)   # check that the sleeps add up
+    assert diffTime == pytest.approx(8, rel=1)   # check that the sleeps add up
 
 
 @pytest.mark.parametrize('key', [
@@ -161,9 +161,9 @@ def test_fs_backend_share_lock(tmpdir):
 
     # no shared locks on windows
     if sys.platform == 'win32':
-        assert diffTime == pytest.approx(8, rel=0.1)   # check that the sleeps add up
+        assert diffTime == pytest.approx(8, rel=1)   # check that the sleeps add up
     else:
-        assert diffTime == pytest.approx(2, rel=0.1)   # check that the sleeps add up
+        assert diffTime == pytest.approx(2, rel=1)   # check that the sleeps add up
 
 
 def test_fs_backend_exclusive_lock(tmpdir):
@@ -192,7 +192,7 @@ def test_fs_backend_exclusive_lock(tmpdir):
     endTime = time.time()
     diffTime = (endTime-startTime)
 
-    assert diffTime == pytest.approx(8, rel=0.1)   # check that the sleeps add up
+    assert diffTime == pytest.approx(8, rel=1)   # check that the sleeps add up
 
 
 def test_fs_backend_mixed_lock_exclusive_first(tmpdir):
@@ -224,9 +224,9 @@ def test_fs_backend_mixed_lock_exclusive_first(tmpdir):
 
     # no shared locks on windows
     if sys.platform == 'win32':
-        assert diffTime == pytest.approx(8.1, rel=0.1)   # check that the sleeps add up
+        assert diffTime == pytest.approx(8.1, rel=1)   # check that the sleeps add up
     else:
-        assert diffTime == pytest.approx(4.1, rel=0.1)   # check that the sleeps add up
+        assert diffTime == pytest.approx(4.1, rel=1)   # check that the sleeps add up
 
 
 def test_fs_backend_mixed_lock_shared_first(tmpdir):
@@ -259,6 +259,6 @@ def test_fs_backend_mixed_lock_shared_first(tmpdir):
 
     # no shared locks on windows
     if sys.platform == 'win32':
-        assert diffTime == pytest.approx(8.2, rel=0.1)   # check that the sleeps add up
+        assert diffTime == pytest.approx(8.2, rel=1)   # check that the sleeps add up
     else:
-        assert diffTime == pytest.approx(4.2, rel=0.1)   # check that the sleeps add up
+        assert diffTime == pytest.approx(4.2, rel=1)   # check that the sleeps add up

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -160,6 +160,8 @@ def test_fs_backend_share_lock(tmpdir):
     # no shared locks on windows
     if sys.platform == 'win32':
         assert diffTime == pytest.approx(8, rel=1)   # check that the sleeps add up
+    elif sys.platform == 'dawrin':
+        diffTime == pytest.approx(8, rel=1)
     else:
         assert diffTime == pytest.approx(2, rel=1)   # check that the sleeps add up
 
@@ -223,6 +225,8 @@ def test_fs_backend_mixed_lock_exclusive_first(tmpdir):
     # no shared locks on windows
     if sys.platform == 'win32':
         assert diffTime == pytest.approx(8.1, rel=1)   # check that the sleeps add up
+    elif sys.platform == 'dawrin':
+        diffTime == pytest.approx(8.1, rel=1)
     else:
         assert diffTime == pytest.approx(4.1, rel=1)   # check that the sleeps add up
 
@@ -258,5 +262,7 @@ def test_fs_backend_mixed_lock_shared_first(tmpdir):
     # no shared locks on windows
     if sys.platform == 'win32':
         assert diffTime == pytest.approx(8.2, rel=1)   # check that the sleeps add up
+    elif sys.platform == 'dawrin':
+        diffTime == pytest.approx(8.2, rel=1)
     else:
-        assert diffTime == pytest.approx(4.2, rel=1)   # check that the sleeps add up
+        assert diffTime == pytest.approx(4.2, rel=1)  # check that the sleeps add up

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -107,6 +107,10 @@ def test_fs_backend_load_store_loads_from_fallback_dir(tmpdir):
 
 
 def test_fs_backend_load_store_loads_from_fallback_dir_that_is_symlink(tmpdir):
+    # should deadlock if there is a problem with the lock type or with the
+    # handling of fallback paths that point to the same principal/write
+    # directory
+
     run_dir = tmpdir.mkdir('run_dir')
     fb_dir = os.path.join(run_dir, 'symlink')
     os.symlink(run_dir, fb_dir, target_is_directory=True)

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -34,7 +34,7 @@ def test_fs_backend_load_store(tmpdir):
     p2 = Process(target=_mp_increment_key, args=(run_dir, 'prefix', 'key', .5))
     p3 = Process(target=_mp_increment_key, args=(run_dir, 'prefix', 'key', .5))
 
-    startTime = time.time()
+    start_time = time.monotonic()
     p1.start()
     p2.start()
     p3.start()
@@ -43,13 +43,13 @@ def test_fs_backend_load_store(tmpdir):
     p2.join()
     p3.join()
 
-    endTime = time.time()
-    diffTime = (endTime-startTime)
+    end_time = time.monotonic()
+    elapsed = (end_time-start_time)
 
     val = store.load('key')
 
     assert val == 45
-    assert diffTime == pytest.approx(1.5, abs=.25)   # check that the sleeps add up
+    assert elapsed >= 1.5
 
 
 @pytest.mark.parametrize('key', [
@@ -114,7 +114,7 @@ def test_fs_backend_share_lock(tmpdir):
     p2 = Process(target=_mp_shared_sleep, args=(run_dir, 'prefix', 'key', .5))
     p3 = Process(target=_mp_shared_sleep, args=(run_dir, 'prefix', 'key', .5))
 
-    startTime = time.time()
+    start_time = time.monotonic()
     p1.start()
     p2.start()
     p3.start()
@@ -123,14 +123,14 @@ def test_fs_backend_share_lock(tmpdir):
     p2.join()
     p3.join()
 
-    endTime = time.time()
-    diffTime = (endTime-startTime)
+    end_time = time.monotonic()
+    elapsed = (end_time-start_time)
 
     if sys.platform == 'win32':
         # no shared locks on windows
-        assert diffTime == pytest.approx(1.5, abs=.25)
+        assert elapsed >= 1.5
     else:
-        assert diffTime == pytest.approx(.5, abs=.25)
+        assert 0.5 <= elapsed < 1.5
 
 
 def test_fs_backend_exclusive_lock(tmpdir):
@@ -142,17 +142,17 @@ def test_fs_backend_exclusive_lock(tmpdir):
     p1 = Process(target=_mp_exclusive_sleep, args=(run_dir, 'prefix', 'key', .5))
     p2 = Process(target=_mp_exclusive_sleep, args=(run_dir, 'prefix', 'key', .5))
 
-    startTime = time.time()
+    start_time = time.monotonic()
     p1.start()
     p2.start()
 
     p1.join()
     p2.join()
 
-    endTime = time.time()
-    diffTime = (endTime-startTime)
+    end_time = time.monotonic()
+    elapsed = (end_time-start_time)
 
-    assert diffTime == pytest.approx(1, abs=.25)
+    assert elapsed >= 1
 
 
 def test_fs_backend_mixed_lock_exclusive_first(tmpdir):
@@ -165,7 +165,7 @@ def test_fs_backend_mixed_lock_exclusive_first(tmpdir):
     p2 = Process(target=_mp_shared_sleep, args=(run_dir, 'prefix', 'key', .5))
     p3 = Process(target=_mp_shared_sleep, args=(run_dir, 'prefix', 'key', .5))
 
-    startTime = time.time()
+    start_time = time.monotonic()
     p1.start()
     time.sleep(0.1)
     p2.start()
@@ -175,14 +175,14 @@ def test_fs_backend_mixed_lock_exclusive_first(tmpdir):
     p2.join()
     p3.join()
 
-    endTime = time.time()
-    diffTime = (endTime-startTime)
+    end_time = time.monotonic()
+    elapsed = (end_time-start_time)
 
     if sys.platform == 'win32':
         # no shared locks on windows
-        assert diffTime == pytest.approx(1.5, abs=.25)
+        assert elapsed >= 1.5
     else:
-        assert diffTime == pytest.approx(1.0, abs=.25)
+        assert 1 <= elapsed < 1.5
 
 
 def test_fs_backend_mixed_lock_shared_first(tmpdir):
@@ -195,7 +195,7 @@ def test_fs_backend_mixed_lock_shared_first(tmpdir):
     p2 = Process(target=_mp_shared_sleep, args=(run_dir, 'prefix', 'key', .5))
     p3 = Process(target=_mp_exclusive_sleep, args=(run_dir, 'prefix', 'key', .5))
 
-    startTime = time.time()
+    start_time = time.monotonic()
     p1.start()
     p2.start()
     time.sleep(0.1)
@@ -205,14 +205,14 @@ def test_fs_backend_mixed_lock_shared_first(tmpdir):
     p2.join()
     p3.join()
 
-    endTime = time.time()
-    diffTime = (endTime-startTime)
+    end_time = time.monotonic()
+    elapsed = (end_time-start_time)
 
     if sys.platform == 'win32':
         # no shared locks on windows
-        assert diffTime == pytest.approx(1.5, abs=.25)
+        assert elapsed >= 1.5
     else:
-        assert diffTime == pytest.approx(1.0, abs=.25)
+        assert 1 <= elapsed < 1.5
 
 
 def _mp_increment_key(run_dir, prefix, key, sleep):

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -8,6 +8,26 @@ from pathlib import Path
 from liquidctl.keyval import _FilesystemBackend
 
 
+def test_fs_stores_truncate_appropriately(tmpdir):
+    run_dir = tmpdir.mkdir('run_dir')
+
+    # use a separate reader to prevent caching from masking issues
+    writer = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+    reader = _FilesystemBackend(key_prefixes=['prefix'], runtime_dirs=[run_dir])
+
+    writer.store('key', 42)
+    assert reader.load('key') == 42
+
+    writer.store('key', 1)
+    assert reader.load('key') == 1
+
+    writer.load_store('key', lambda _: 42)
+    assert reader.load('key') == 42
+
+    writer.load_store('key', lambda _: 1)
+    assert reader.load('key') == 1
+
+
 def test_fs_backend_loads_from_fallback_dir(tmpdir):
     run_dir = tmpdir.mkdir('run_dir')
     fb_dir = tmpdir.mkdir('fb_dir')

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -160,8 +160,6 @@ def test_fs_backend_share_lock(tmpdir):
     # no shared locks on windows
     if sys.platform == 'win32':
         assert diffTime == pytest.approx(8, rel=1)   # check that the sleeps add up
-    elif sys.platform == 'dawrin':
-        diffTime == pytest.approx(8, rel=1)
     else:
         assert diffTime == pytest.approx(2, rel=1)   # check that the sleeps add up
 
@@ -225,8 +223,6 @@ def test_fs_backend_mixed_lock_exclusive_first(tmpdir):
     # no shared locks on windows
     if sys.platform == 'win32':
         assert diffTime == pytest.approx(8.1, rel=1)   # check that the sleeps add up
-    elif sys.platform == 'dawrin':
-        diffTime == pytest.approx(8.1, rel=1)
     else:
         assert diffTime == pytest.approx(4.1, rel=1)   # check that the sleeps add up
 
@@ -262,7 +258,5 @@ def test_fs_backend_mixed_lock_shared_first(tmpdir):
     # no shared locks on windows
     if sys.platform == 'win32':
         assert diffTime == pytest.approx(8.2, rel=1)   # check that the sleeps add up
-    elif sys.platform == 'dawrin':
-        diffTime == pytest.approx(8.2, rel=1)
     else:
-        assert diffTime == pytest.approx(4.2, rel=1)  # check that the sleeps add up
+        assert diffTime == pytest.approx(4.2, rel=1)   # check that the sleeps add up

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -103,8 +103,7 @@ def test_fs_backend_shared_lock(tmpdir):
     with store._shared_lock('key'):
         assert os.path.exists(store._lock_file('key'))
 
-    if sys.platform == 'win32':
-        assert not os.path.exists(store._lock_file('key'))
+    assert os.path.exists(store._lock_file('key'))
 
 
 def test_fs_backend_exclusive_lock(tmpdir):
@@ -115,8 +114,7 @@ def test_fs_backend_exclusive_lock(tmpdir):
     with store._exclusive_lock('key'):
         assert os.path.exists(store._lock_file('key'))
 
-    if sys.platform == 'win32':
-        assert not os.path.exists(store._lock_file('key'))
+    assert os.path.exists(store._lock_file('key'))
 
 
 # this is the process that will test if multiple proccesses can share a lock


### PR DESCRIPTION
Closes #274

This should solve issues with multiple instances of liquidctl running at the same time having issues with concurrent access of the data file. 

This is being resolved by using lock files to make the functions for the `RuntimeStorage` class atomic. 

Also adds the function `load_store()` which can get a value, update it and then save it atomically.


- [x] write tests to validate that the calls are atomic
- [x] write tests to validate that multiple `load()`'s can happen at the same time
- [x] update all usages to use the atomic `load_store` function where applicable

There may be an issue on windows that if the program crashes before the lock file can be deleted it will not be able to acquire the lock again, and the program will hang. 
 