### PR TITLE
Add FreeBSD to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Dependencies:
 
 liquidctl requires root privileges (doas or sudo) by default.
 
-NB: As of March 20, 2021, HIDAP (`comms/hidapi`), which is required for `comms/py-hidapi` (and, thus, liquidctl), must be built from the latest port rather than installed as a package, as the package is out of date. Make sure that you have HIDAPI version 0.10.1 or later installed prior to installing `comms/py-hidapi` and liquidctl. Then, liquidctl will work as expected.
+Note: as of March 20, 2021, HIDAPI (`comms/hidapi`), [ ... ]
 
 
 ## Installing on Windows

--- a/README.md
+++ b/README.md
@@ -186,21 +186,9 @@ Optional steps:
 
 liquidctl is maintained in the Ports Collection (thanks to ehaupt@FreeBSD.org), and it is available as a pre-built binary package.
 
-Port:
-
-`sysutils/py-liquidctl`
-
-Binary:
-
-`pkg install py37-liquidctl`
-
-Dependencies:
-
-`devel/py-docopt`
-
-`comms/py-hidapi`
-
-`devel/py-pyusb`
+- port: `sysutils/py-liquidctl`
+- binary: `pkg install py37-liquidctl`
+- dependencies: `devel/py-docopt`, `comms/py-hidapi`, `devel/py-pyusb`
 
 liquidctl requires root privileges (doas or sudo) by default.
 

--- a/README.md
+++ b/README.md
@@ -55,20 +55,21 @@ NZXT Kraken X (X42, X52, X62 or X72)
 
 1.  [Supported devices](#supported-devices)
 2.  [Installing on Linux](#installing-on-linux)
-3.  [Installing on Windows](#installing-on-windows)
-4.  [Installing on macOS](#installing-on-macos)
-5.  [The command-line interface](#introducing-the-command-line-interface)
+3.  [Installing on FreeBSD](#installing-on-freebsd)
+4.  [Installing on Windows](#installing-on-windows)
+5.  [Installing on macOS](#installing-on-macos)
+6.  [The command-line interface](#introducing-the-command-line-interface)
      1. [Listing and selecting devices](#listing-and-selecting-devices)
      2. [Initializing and interacting with devices](#initializing-and-interacting-with-devices)
      3. [Supported color specification formats](#supported-color-specification-formats)
-6.  [Automation and running at boot](#automation-and-running-at-boot)
+7.  [Automation and running at boot](#automation-and-running-at-boot)
      1. [Set up Linux using systemd](#set-up-linux-using-systemd)
      2. [Set up Windows using Task Scheduler](#set-up-windows-using-task-scheduler)
      3. [Set up macOS using launchd](#set-up-macos-using-launchd)
-7.  [Troubleshooting](#troubleshooting)
-8.  [Additional documentation](#additional-documentation)
-9.  [License](#license)
-10. [Related projects](#related-projects-2020-edition)
+8.  [Troubleshooting](#troubleshooting)
+9.  [Additional documentation](#additional-documentation)
+10.  [License](#license)
+11. [Related projects](#related-projects-2020-edition)
 
 
 ## Supported devices
@@ -179,6 +180,31 @@ Optional steps:
 
 [udev rules]: extra/linux/71-liquidctl.rules
 [bash completions]: extra/completions/liquidctl.bash
+
+
+## Installing on FreeBSD
+
+liquidctl is maintained in the Ports Collection (thanks to ehaupt@FreeBSD.org), and it is available as a pre-built binary package.
+
+Port:
+
+`sysutils/py-liquidctl`
+
+Binary:
+
+`pkg install py37-liquidctl`
+
+Dependencies:
+
+`devel/py-docopt`
+
+`comms/py-hidapi`
+
+`devel/py-pyusb`
+
+liquidctl requires root privileges (doas or sudo) by default.
+
+NB: As of March 20, 2021, HIDAP (`comms/hidapi`), which is required for `comms/py-hidapi` (and, thus, liquidctl), must be built from the latest port rather than installed as a package, as the package is out of date. Make sure that you have HIDAPI version 0.10.1 or later installed prior to installing `comms/py-hidapi` and liquidctl. Then, liquidctl will work as expected.
 
 
 ## Installing on Windows

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ liquidctl is maintained in the Ports Collection (thanks to ehaupt@FreeBSD.org), 
 - binary: `pkg install py37-liquidctl`
 - dependencies: `devel/py-docopt`, `comms/py-hidapi`, `devel/py-pyusb`
 
-liquidctl requires root privileges (doas or sudo) by default.
+By default, root privileges (`doas` or `sudo`) are required to run liquidctl.
 
 Note: as of March 20, 2021, HIDAPI (`comms/hidapi`), [ ... ]
 

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ Optional steps:
 [bash completions]: extra/completions/liquidctl.bash
 
 
-## Installing on FreeBSD (or DragonFlyBSD)
+## Installing on FreeBSD
 
 liquidctl is maintained in the FreeBSD Ports Collection (thanks to ehaupt@FreeBSD.org), and it is available as a pre-built binary package.
 
@@ -195,6 +195,10 @@ By default, root privileges (`doas` or `sudo`) are required to run liquidctl.
 To gain full access as a normal user without `doas` or `sudo`, see devd(8). Also, you might consider manually changing the permission of the file of the USB device for an individual session with `chown`, e.g. `sudo chown [user] /dev/ugen[#.#]`.
 
 Note: as of March 20, 2021, HIDAPI (`comms/hidapi`), which is required for `comms/py-hidapi` (and, thus, liquidctl), must be built from the latest port rather than installed as a package, as the latest package is out of date. Make sure that you have HIDAPI version 0.10.1 or later installed prior to installing `comms/py-hidapi` and liquidctl. Then, liquidctl will work as expected.
+
+### DragonFly BSD
+
+ehaupt@FreeBSD.org's work is also available in DragonFly Ports. 
 
 
 ## Installing on Windows

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ NZXT Kraken X (X42, X52, X62 or X72)
 
 1.  [Supported devices](#supported-devices)
 2.  [Installing on Linux](#installing-on-linux)
-3.  [Installing on FreeBSD or DragonFlyBSD](#installing-on-freebsd-or-dragonflybsd)
+3.  [Installing on FreeBSD](#installing-on-freebsd)
 4.  [Installing on Windows](#installing-on-windows)
 5.  [Installing on macOS](#installing-on-macos)
 6.  [The command-line interface](#introducing-the-command-line-interface)
@@ -182,9 +182,7 @@ Optional steps:
 [bash completions]: extra/completions/liquidctl.bash
 
 
-## Installing on FreeBSD or DragonFlyBSD
-
-### FreeBSD
+## Installing on FreeBSD (or DragonFlyBSD)
 
 liquidctl is maintained in the FreeBSD Ports Collection (thanks to ehaupt@FreeBSD.org), and it is available as a pre-built binary package.
 
@@ -194,13 +192,9 @@ liquidctl is maintained in the FreeBSD Ports Collection (thanks to ehaupt@FreeBS
 
 By default, root privileges (`doas` or `sudo`) are required to run liquidctl.
 
-To gain full access as a normal user without `doas` or `sudo`, see devd(8) (FreeBSD-specific guide needed). Also, you might consider manually changing the permission of the file of the USB device for an individual session with `chown`, e.g. `sudo chown [user] /dev/ugen[#.#]`.
+To gain full access as a normal user without `doas` or `sudo`, see devd(8). Also, you might consider manually changing the permission of the file of the USB device for an individual session with `chown`, e.g. `sudo chown [user] /dev/ugen[#.#]`.
 
 Note: as of March 20, 2021, HIDAPI (`comms/hidapi`), which is required for `comms/py-hidapi` (and, thus, liquidctl), must be built from the latest port rather than installed as a package, as the latest package is out of date. Make sure that you have HIDAPI version 0.10.1 or later installed prior to installing `comms/py-hidapi` and liquidctl. Then, liquidctl will work as expected.
-
-### DragonFlyBSD
-
-liquidctl is available in DragonFly Ports, having been transferred from the FreeBSD Ports Collection. Installation and use should be the same as in FreeBSD (verification needed).
 
 
 ## Installing on Windows

--- a/README.md
+++ b/README.md
@@ -182,9 +182,11 @@ Optional steps:
 [bash completions]: extra/completions/liquidctl.bash
 
 
-## Installing on FreeBSD
+## Installing on FreeBSD or DragonFlyBSD
 
-liquidctl is maintained in the Ports Collection (thanks to ehaupt@FreeBSD.org), and it is available as a pre-built binary package.
+### FreeBSD
+
+liquidctl is maintained in the FreeBSD Ports Collection (thanks to ehaupt@FreeBSD.org), and it is available as a pre-built binary package.
 
 - port: `sysutils/py-liquidctl`
 - binary: `pkg install py37-liquidctl`
@@ -192,7 +194,13 @@ liquidctl is maintained in the Ports Collection (thanks to ehaupt@FreeBSD.org), 
 
 By default, root privileges (`doas` or `sudo`) are required to run liquidctl.
 
-Note: as of March 20, 2021, HIDAPI (`comms/hidapi`), [ ... ]
+To gain full access as a normal user without `doas` or `sudo`, see devd(8) (FreeBSD-specific guide needed). Also, you might consider manually changing the permission of the file of the USB device for an individual session with `chown`, e.g. `sudo chown [user] /dev/ugen[#.#]`.
+
+Note: as of March 20, 2021, HIDAP (`comms/hidapi`), which is required for `comms/py-hidapi` (and, thus, liquidctl), must be built from the latest port rather than installed as a package, as the latest package is out of date. Make sure that you have HIDAPI version 0.10.1 or later installed prior to installing `comms/py-hidapi` and liquidctl. Then, liquidctl will work as expected.
+
+### DragonFlyBSD
+
+liquidctl is available in DragonFly Ports, having been transferred from the FreeBSD Ports Collection. Installation and use should be the same as in FreeBSD (verification needed).
 
 
 ## Installing on Windows

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ NZXT Kraken X (X42, X52, X62 or X72)
 
 1.  [Supported devices](#supported-devices)
 2.  [Installing on Linux](#installing-on-linux)
-3.  [Installing on FreeBSD](#installing-on-freebsd)
+3.  [Installing on FreeBSD or DragonFlyBSD](#installing-on-freebsd-or-dragonflybsd)
 4.  [Installing on Windows](#installing-on-windows)
 5.  [Installing on macOS](#installing-on-macos)
 6.  [The command-line interface](#introducing-the-command-line-interface)

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ By default, root privileges (`doas` or `sudo`) are required to run liquidctl.
 
 To gain full access as a normal user without `doas` or `sudo`, see devd(8) (FreeBSD-specific guide needed). Also, you might consider manually changing the permission of the file of the USB device for an individual session with `chown`, e.g. `sudo chown [user] /dev/ugen[#.#]`.
 
-Note: as of March 20, 2021, HIDAP (`comms/hidapi`), which is required for `comms/py-hidapi` (and, thus, liquidctl), must be built from the latest port rather than installed as a package, as the latest package is out of date. Make sure that you have HIDAPI version 0.10.1 or later installed prior to installing `comms/py-hidapi` and liquidctl. Then, liquidctl will work as expected.
+Note: as of March 20, 2021, HIDAPI (`comms/hidapi`), which is required for `comms/py-hidapi` (and, thus, liquidctl), must be built from the latest port rather than installed as a package, as the latest package is out of date. Make sure that you have HIDAPI version 0.10.1 or later installed prior to installing `comms/py-hidapi` and liquidctl. Then, liquidctl will work as expected.
 
 ### DragonFlyBSD
 


### PR DESCRIPTION
Add FreeBSD to README

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Add automated tests cases
- [ ] Conform to the style guide in `docs/developer/style-guide.md`
- [ ] Verify that all automated tests pass
- [ ] Verify that the changes work as expected on real hardware
- [ ] [New CLI flag?] Adjust the completion scripts in `extra/completions/`
- [ ] [New device?] Regenerate `extra/linux/71-liquidctl.rules` (see file header)
- [ ] [New device?] Add entry to the README's supported device list with applicable notes (at least `EN`)
- [ ] [New driver?] Document the protocol in `docs/developer/protocol/`
- [ ] Update (or add) applicable `docs/*guide.md` device guides
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [X] Update the README and other applicable documentation pages
- [ ] Submit relevant device data to https://github.com/liquidctl/collected-device-data
