### PR TITLE
Add --json machine readable output for list/initialize/status

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,9 +41,8 @@ install:
   - cmd: C:\Python39-x64\python -m pip freeze | find "pyinstaller" >> extra\windows\included.txt
   - cmd: echo libusb %LIBUSB_VERSION% >> extra\windows\included.txt
   - cmd: C:\Python39-x64\python --version >> extra\windows\included.txt
-  # run unit tests and module doctests
+  # install pytest
   - cmd: C:\Python39-x64\python -m pip install pytest
-  - cmd: C:\Python39-x64\python -m pytest
 
 build_script:
   - cmd: C:\Python39-x64\Scripts\pyinstaller --add-data VS2019\MS64\dll\*;. --clean -F liquidctl\cli.py --name liquidctl --onefile --distpath .
@@ -64,7 +63,11 @@ after_build:
   - cmd: CertUtil -hashfile %DIST_PACKAGE%.zip SHA256
 
 test_script:
+  # ensure the bundled binary can find/use libusb
   - cmd: liquidctl.exe list --verbose --debug
+  # copy the libusb DLLs and run the unit and doctests
+  - cmd: copy VS2019\MS64\dll\* C:\Windows\System32\
+  - cmd: C:\Python39-x64\python -m pytest
 
 artifacts:
   - path: "*.zip"

--- a/extra/completions/liquidctl.bash
+++ b/extra/completions/liquidctl.bash
@@ -74,6 +74,7 @@ _liquidctl_main() {
     local boolean_options="
     --verbose -v
     --debug -g
+    --json
     --version
     --help
     --single-12v-ocp

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -176,6 +176,10 @@ Output additional information.
 .B \-g\fR, \fP\-\-debug
 Show debug information on \fIstderr\fR.
 .TP
+.B \-\-json
+Output machine-readable JSON.  Only supported with
+.BR list ,\  initialize \ and\  status .
+.TP
 .B \-\-version
 Display the version number.
 .TP
@@ -184,6 +188,10 @@ Show the embedded help.
 .
 .SH EXIT STATUS
 1 if there was an error, 0 otherwise.
+.
+.SH ENVIRONMENT
+If \fBLANG\fR is set to \fIC\fR, non-ASCII characters are escaped from the
+output of \fB\-\-json\fR.
 .
 .SH FILES
 .TP

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -214,8 +214,7 @@ def _list_devices_human(devices, *, using_filters, device_id, verbose, debug, **
 
 
 def _dev_status_obj(dev, status):
-    # unlike the humans, machines want to know everything; don't suppress
-    # devices without status data (typically from initialize)
+    # don't suppress devices without status data (typically from initialize)
     if not status:
         status = []
 
@@ -338,6 +337,12 @@ def main():
     logging.basicConfig(level=log_level, handlers=[log_handler])
 
     _LOGGER.debug('running %s', _gen_version())
+
+    # unlike humans, machines want to know everything; imply verbose everywhere
+    # other than when setting default logging level and format (which are
+    # inherently for human consumption)
+    if args['--json']:
+        args['--verbose'] = True
 
     opts = _make_opts(args)
     filter_count = sum(1 for opt in opts if opt in _FILTER_OPTIONS)

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -42,8 +42,7 @@ Other device options:
 Other interface options:
   -v, --verbose                  Output additional information
   -g, --debug                    Show debug information on stderr
-  --json                         Output machine readable JSON
-                                 (list/initialization/status)
+  --json                         JSON output (list/initialization/status)
   --version                      Display the version number
   --help                         Show this message
 

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -143,15 +143,15 @@ _VALUE_FORMATS = {
 _LOGGER = logging.getLogger(__name__)
 
 
-def getattr_or(object, name, default=None):
-    """Call `getattr` and return `default` on exceptions."""
-    try:
-        return getattr(object, name, default)
-    except Exception:
-        return default
-
-
 def _list_devices_objs(devices):
+
+    def getattr_or(object, name, default=None):
+        """Call `getattr` and return `default` on exceptions."""
+        try:
+            return getattr(object, name, default)
+        except Exception:
+            return default
+
     return [
         {
             # replace the experimental suffix with a proper field

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -143,6 +143,14 @@ _VALUE_FORMATS = {
 _LOGGER = logging.getLogger(__name__)
 
 
+def getattr_or(object, name, default=None):
+    """Call `getattr` and return `default` on exceptions."""
+    try:
+        return getattr(object, name, default)
+    except Exception:
+        return default
+
+
 def _list_devices_objs(devices):
     return [
         {
@@ -151,7 +159,7 @@ def _list_devices_objs(devices):
             'vendor_id': dev.vendor_id,
             'product_id': dev.product_id,
             'release_number': dev.release_number,
-            'serial_number': getattr(dev, 'serial_number', None),
+            'serial_number': getattr_or(dev, 'serial_number', None),
             'bus': dev.bus,
             'address': dev.address,
             'port': dev.port,

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -365,7 +365,7 @@ def main():
     if args['list']:
         if args['--json']:
             objs = _list_devices_objs(selected)
-            json.dump(objs, sys.stdout, ensure_ascii=(os.getenv('LANG', None) == 'C'))
+            print(json.dumps(objs, ensure_ascii=(os.getenv('LANG', None) == 'C')))
         else:
             _list_devices_human(selected, using_filters=bool(filter_count),
                                 device_id=device_id, json=json, **opts)
@@ -437,7 +437,7 @@ def main():
         sys.exit(errors)
 
     if args['--json']:
-        json.dump(obj_buf, sys.stdout, ensure_ascii=(os.getenv('LANG', None) == 'C'))
+        print(json.dumps(obj_buf, ensure_ascii=(os.getenv('LANG', None) == 'C')))
 
     sys.exit(0)
 

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -225,7 +225,7 @@ def _dev_status_obj(dev, status):
         if isinstance(val, datetime.timedelta):
             val = val.total_seconds()
             unit = 's'
-        return (key, val, unit)
+        return { 'key': key, 'value': val, 'unit': unit }
 
     # suppress the experimental suffix, `list` reports it in `.experimental`
     return {

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -213,7 +213,9 @@ class VirtualBusDevice(BaseDriver):
 
     def initialize(self, *args, **kwargs):
         self.call_args['initialize'] = CallArgs(args, kwargs)
-        return self.get_status(**kwargs)
+        return [
+            ('Firmware version', '3.14.16', ''),
+        ]
 
     def get_status(self, *args, **kwargs):
         self.call_args['status'] = CallArgs(args, kwargs)
@@ -224,6 +226,15 @@ class VirtualBusDevice(BaseDriver):
             ('Uptime', timedelta(hours=18, minutes=23, seconds=12), ''),
             ('Hardware mode', True, ''),
         ]
+
+    def set_fixed_speed(self, *args, **kwargs):
+        self.call_args['set_fixed_speed'] = CallArgs(args, kwargs)
+
+    def set_speed_profile(self, *args, **kwargs):
+        self.call_args['set_speed_profile'] = CallArgs(args, kwargs)
+
+    def set_color(self, *args, **kwargs):
+        self.call_args['set_color'] = CallArgs(args, kwargs)
 
     @property
     def description(self):

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -1,7 +1,10 @@
 import os
 from collections import deque, namedtuple
+from datetime import timedelta
+from enum import Enum, unique
 from tempfile import mkdtemp
 
+from liquidctl.driver.base import *
 from liquidctl.keyval import RuntimeStorage, _FilesystemBackend
 
 Report = namedtuple('Report', ['number', 'data'])
@@ -181,3 +184,80 @@ class VirtualSmbus:
 
     def load_eeprom(self, address):
         return self._data[address]  # hack
+
+
+@unique
+class VirtualControlMode(Enum):
+    QUIET = 0x0
+    BALANCED = 0x1
+    EXTREME = 0x2
+
+
+CallArgs = namedtuple('CallArgs', ['args', 'kwargs'])
+
+
+class VirtualBusDevice(BaseDriver):
+    def __init__(self, *args, **kwargs):
+        self.call_args = dict()
+        self.call_args['__init__'] = CallArgs(args, kwargs)
+        self.connected = False
+
+    def connect(self, *args, **kwargs):
+        self.call_args['connect'] = CallArgs(args, kwargs)
+        self.connected = True
+        return self
+
+    def disconnect(self, *args, **kwargs):
+        self.call_args['disconnect'] = CallArgs(args, kwargs)
+        self.connected = False
+
+    def initialize(self, *args, **kwargs):
+        self.call_args['initialize'] = CallArgs(args, kwargs)
+        return self.get_status(**kwargs)
+
+    def get_status(self, *args, **kwargs):
+        self.call_args['status'] = CallArgs(args, kwargs)
+        return [
+            ('Temperature', 30.4, '°C'),
+            ('Fan control mode', VirtualControlMode.QUIET, ''),
+            ('Animation', None, ''),
+            ('Uptime', timedelta(hours=18, minutes=23, seconds=12), ''),
+            ('Hardware mode', True, ''),
+        ]
+
+    @property
+    def description(self):
+        return 'Virtual Bus Device (experimental)'
+
+    @property
+    def vendor_id(self):
+        return 0x1234
+
+    @property
+    def product_id(self):
+        return 0xabcd
+
+    @property
+    def release_number(self):
+        None
+
+    @property
+    def serial_number(self):
+        raise OSError()
+
+    @property
+    def bus(self):
+        return 'virtual'
+
+    @property
+    def address(self):
+        return 'virtual_address'
+
+    @property
+    def port(self):
+        return None
+
+
+class VirtualBus(BaseBus):
+    def find_devices(self, **kwargs):
+        yield from [VirtualBusDevice()]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -20,3 +20,57 @@ def test_entering_the_runtime_context_does_not_call_connect():
         # since __enter__ takes no arguments, if __enter__ calls connect it
         # will override dev.kwargs['connect'] with {}
         assert 'marker' in dev.call_args['connect'].kwargs
+
+
+def test_modified_readme_example(capsys):
+    from liquidctl import find_liquidctl_devices
+
+    first = True
+
+    # find all connected and supported devices on pseudo bus 'virtual'
+    devices = find_liquidctl_devices(bus='virtual')
+
+    for dev in devices:
+
+        # connect to the device (here a context manager is used, but the
+        # connection can also be manually managed)
+        with dev.connect():
+            print(f'{dev.description} at {dev.bus}:{dev.address}:')
+
+            # devices should be initialized after every boot (here we assume
+            # this has not been done before)
+            init_status = dev.initialize()
+
+            # print all data returned by initialize()
+            if init_status:
+                for key, value, unit in init_status:
+                    print(f'{key}: {value} {unit}')
+
+            # get regular status information from the device
+            status = dev.get_status()
+
+            # print all data returned by get_status()
+            for key, value, unit in status:
+                print(f'{key}: {value} {unit}')
+
+            # for a particular device, set the pump LEDs to red
+            if 'Virtual Bus Device' in dev.description:
+                print('setting pump to radical red')
+                radical_red = [0xff, 0x35, 0x5e]
+                dev.set_color(channel='pump', mode='fixed', colors=[radical_red])
+
+        # the context manager took care of automatically calling disconnect();
+        # when manually managing the connection, disconnect() must be called at
+        # some point even if an exception is raised
+
+        if first:
+            first = False
+            print()  # add a blank line between each device
+
+    # end of modified example; check that it more or less did what it should
+
+    out, _ = capsys.readouterr()
+    assert 'Virtual Bus Device (experimental) at virtual:virtual_address:' in out
+    assert 'Firmware version: 3.14.16' in out
+    assert 'Temperature: 30.4 °C' in out
+    assert 'setting pump to radical red' in out

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,26 +1,9 @@
 import pytest
-
-from liquidctl.driver.base import BaseDriver
-
-
-class Virtual(BaseDriver):
-    def __init__(self, **kwargs):
-        self.kwargs = dict()
-        self.kwargs['__init__'] = kwargs
-        self.connected = False
-
-    def connect(self, **kwargs):
-        self.kwargs['connect'] = kwargs
-        self.connected = True
-        return self
-
-    def disconnect(self, **kwargs):
-        self.kwargs['disconnect'] = kwargs
-        self.connected = False
+from _testutils import VirtualBusDevice
 
 
 def test_connects_and_disconnects_with_context_manager():
-    dev = Virtual()
+    dev = VirtualBusDevice()
 
     with pytest.raises(RuntimeError):
         with dev.connect():
@@ -31,9 +14,9 @@ def test_connects_and_disconnects_with_context_manager():
 
 
 def test_entering_the_runtime_context_does_not_call_connect():
-    dev = Virtual()
+    dev = VirtualBusDevice()
 
     with dev.connect(marker=True):
         # since __enter__ takes no arguments, if __enter__ calls connect it
         # will override dev.kwargs['connect'] with {}
-        assert 'marker' in dev.kwargs['connect']
+        assert 'marker' in dev.call_args['connect'].kwargs

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -45,7 +45,28 @@ def test_json_list(main):
     assert got == exp
 
 
-def assert_json_status_like(out):
+def test_json_initialize(main):
+    code, out, _ = main('test', '--bus', 'virtual', 'initialize', '--json')
+    assert code == 0
+
+    got = json.loads(out)
+    exp = [
+        {
+            'bus': 'virtual',
+            'address': 'virtual_address',
+            'description': 'Virtual Bus Device',
+            'status': [
+                { 'key': 'Firmware version', 'value': '3.14.16', 'unit': '' },
+            ]
+        }
+    ]
+    assert got == exp
+
+
+def test_json_status(main):
+    code, out, _ = main('test', '--bus', 'virtual', 'status', '--json')
+    assert code == 0
+
     got = json.loads(out)
     exp = [
         {
@@ -62,15 +83,3 @@ def assert_json_status_like(out):
         }
     ]
     assert got == exp
-
-
-def test_json_initialize(main):
-    code, out, _ = main('test', '--bus', 'virtual', 'initialize', '--json')
-    assert code == 0
-    assert_json_status_like(out)
-
-
-def test_json_status(main):
-    code, out, _ = main('test', '--bus', 'virtual', 'status', '--json')
-    assert code == 0
-    assert_json_status_like(out)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,79 +1,10 @@
 import pytest
+from _testutils import VirtualBusDevice, VirtualControlMode
 
 import json
 import sys
-from datetime import timedelta
-from enum import Enum, unique
 
 import liquidctl.cli
-from liquidctl.driver.base import *
-
-
-@unique
-class ControlMode(Enum):
-    QUIET = 0x0
-    BALANCED = 0x1
-    EXTREME = 0x2
-
-
-class Virtual(BaseDriver):
-    def __init__(self, **kwargs):
-        pass
-
-    def connect(self, **kwargs):
-        return self
-
-    def disconnect(self, **kwargs):
-        pass
-
-    def initialize(self, **kwargs):
-        return self.get_status(**kwargs)
-
-    def get_status(self, **kwargs):
-        return [
-            ('Temperature', 30.4, '°C'),
-            ('Fan control mode', ControlMode.QUIET, ''),
-            ('Animation', None, ''),
-            ('Uptime', timedelta(hours=18, minutes=23, seconds=12), ''),
-            ('Hardware mode', True, ''),
-        ]
-
-    @property
-    def description(self):
-        return 'Virtual device (experimental)'
-
-    @property
-    def vendor_id(self):
-        return 0x1234
-
-    @property
-    def product_id(self):
-        return 0xabcd
-
-    @property
-    def release_number(self):
-        None
-
-    @property
-    def serial_number(self):
-        raise OSError()
-
-    @property
-    def bus(self):
-        return 'virtual'
-
-    @property
-    def address(self):
-        return 'virtual_address'
-
-    @property
-    def port(self):
-        return None
-
-
-class VirtualBus(BaseBus):
-    def find_devices(self, **kwargs):
-        yield from [Virtual()]
 
 
 @pytest.fixture
@@ -99,7 +30,7 @@ def test_json_list(main):
     got = json.loads(out)
     exp = [
         {
-            'description': 'Virtual device',
+            'description': 'Virtual Bus Device',
             'vendor_id': 0x1234,
             'product_id': 0xabcd,
             'release_number': None,
@@ -107,7 +38,7 @@ def test_json_list(main):
             'bus': 'virtual',
             'address': 'virtual_address',
             'port': None,
-            'driver': 'Virtual',
+            'driver': 'VirtualBusDevice',
             'experimental': True,
         }
     ]
@@ -120,10 +51,10 @@ def assert_json_status_like(out):
         {
             'bus': 'virtual',
             'address': 'virtual_address',
-            'description': 'Virtual device',
+            'description': 'Virtual Bus Device',
             'status': [
                 { 'key': 'Temperature', 'value': 30.4, 'unit': '°C' },
-                { 'key': 'Fan control mode', 'value': 'ControlMode.QUIET', 'unit': '' },
+                { 'key': 'Fan control mode', 'value': 'VirtualControlMode.QUIET', 'unit': '' },
                 { 'key': 'Animation', 'value': None, 'unit': '' },
                 { 'key': 'Uptime', 'value': 66192.0, 'unit': 's' },
                 { 'key': 'Hardware mode', 'value': True, 'unit': '' },

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,145 @@
+import pytest
+
+import json
+import sys
+from datetime import timedelta
+from enum import Enum, unique
+
+import liquidctl.cli
+from liquidctl.driver.base import *
+
+
+@unique
+class ControlMode(Enum):
+    QUIET = 0x0
+    BALANCED = 0x1
+    EXTREME = 0x2
+
+
+class Virtual(BaseDriver):
+    def __init__(self, **kwargs):
+        pass
+
+    def connect(self, **kwargs):
+        return self
+
+    def disconnect(self, **kwargs):
+        pass
+
+    def initialize(self, **kwargs):
+        return self.get_status(**kwargs)
+
+    def get_status(self, **kwargs):
+        return [
+            ('Temperature', 30.4, '°C'),
+            ('Fan control mode', ControlMode.QUIET, ''),
+            ('Animation', None, ''),
+            ('Uptime', timedelta(hours=18, minutes=23, seconds=12), ''),
+            ('Hardware mode', True, ''),
+        ]
+
+    @property
+    def description(self):
+        return 'Virtual device (experimental)'
+
+    @property
+    def vendor_id(self):
+        return 0x1234
+
+    @property
+    def product_id(self):
+        return 0xabcd
+
+    @property
+    def release_number(self):
+        None
+
+    @property
+    def serial_number(self):
+        raise OSError()
+
+    @property
+    def bus(self):
+        return 'virtual'
+
+    @property
+    def address(self):
+        return 'virtual_address'
+
+    @property
+    def port(self):
+        return None
+
+
+class VirtualBus(BaseBus):
+    def find_devices(self, **kwargs):
+        yield from [Virtual()]
+
+
+@pytest.fixture
+def main(monkeypatch, capsys):
+    """Return a function f(*args) to run main with `args` as `sys.argv`."""
+    def call_with_args(*args):
+        monkeypatch.setattr(sys, 'argv', args)
+        try:
+            liquidctl.cli.main()
+        except SystemExit as exit:
+            code = exit.code
+        else:
+            code = 0
+        out, err = capsys.readouterr()
+        return code, out, err
+    return call_with_args
+
+
+def test_json_list(main):
+    code, out, _ = main('test', '--bus', 'virtual', 'list', '--json')
+    assert code == 0
+
+    got = json.loads(out)
+    exp = [
+        {
+            'description': 'Virtual device',
+            'vendor_id': 0x1234,
+            'product_id': 0xabcd,
+            'release_number': None,
+            'serial_number': None,
+            'bus': 'virtual',
+            'address': 'virtual_address',
+            'port': None,
+            'driver': 'Virtual',
+            'experimental': True,
+        }
+    ]
+    assert got == exp
+
+
+def assert_json_status_like(out):
+    got = json.loads(out)
+    exp = [
+        {
+            'bus': 'virtual',
+            'address': 'virtual_address',
+            'description': 'Virtual device',
+            'status': [
+                { 'key': 'Temperature', 'value': 30.4, 'unit': '°C' },
+                { 'key': 'Fan control mode', 'value': 'ControlMode.QUIET', 'unit': '' },
+                { 'key': 'Animation', 'value': None, 'unit': '' },
+                { 'key': 'Uptime', 'value': 66192.0, 'unit': 's' },
+                { 'key': 'Hardware mode', 'value': True, 'unit': '' },
+            ]
+        }
+    ]
+    assert got == exp
+
+
+def test_json_initialize(main):
+    code, out, _ = main('test', '--bus', 'virtual', 'initialize', '--json')
+    assert code == 0
+    assert_json_status_like(out)
+
+
+def test_json_status(main):
+    code, out, _ = main('test', '--bus', 'virtual', 'status', '--json')
+    assert code == 0
+    assert_json_status_like(out)


### PR DESCRIPTION
Output machine readable JSON to stdout for `list`, `initialize` and `status`.

```
$ liquidctl list --match nzxt --json | jq
[
  {
    "description": "NZXT Smart Device (V1)",
    "vendor_id": 7793,
    "product_id": 5908,
    "release_number": 512,
    "serial_number": "497C47533332",
    "bus": "hid",
    "address": "/dev/hidraw4",
    "port": null,
    "driver": "SmartDevice",
    "experimental": false
  },
  {
    "description": "NZXT Kraken X (X42, X52, X62 or X72)",
    "vendor_id": 7793,
    "product_id": 5902,
    "release_number": 512,
    "serial_number": "49874481333",
    "bus": "hid",
    "address": "/dev/hidraw3",
    "port": null,
    "driver": "Kraken2",
    "experimental": false
  }
]
```

```
$ liquidctl --match kraken status --json | jq
[
  {
    "bus": "hid",
    "address": "/dev/hidraw3",
    "description": "NZXT Kraken X (X42, X52, X62 or X72)",
    "status": [
      {
        "key": "Liquid temperature",
        "value": 30.5,
        "unit": "°C"
      },
      {
        "key": "Fan speed",
        "value": 1014,
        "unit": "rpm"
      },
      {
        "key": "Pump speed",
        "value": 2345,
        "unit": "rpm"
      },
      {
        "key": "Firmware version",
        "value": "6.0.2",
        "unit": ""
      }
    ]
  }
]
```

Both examples have been prettified;<sup>1</sup> the actual output has no line breaks or indentation.

The output from `initialize`, as in the API, has the same structure as the one for `status`.

If `LANG=C` is set, non-ASCII characters will be escaped.  Otherwise, Unicode characters are used, allowing for zero-copy parsing of the output in Unicode-aware languages.

Closes: #104
Related: #89
Related: #84

---

Checklist (non-applicable items have been omitted):

- [x] Add automated tests cases
- [x] Conform to the style guide in `docs/developer/style-guide.md`
- [x] Verify that all automated tests pass
- [x] Verify that the changes work as expected ~~on~~ with real hardware
- [x] [New CLI flag?] Adjust the completion scripts in `extra/completions/`
- [ ] ~~Update (or add) applicable `docs/*guide.md` device guides~~
- [x] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [x] Update the README and other applicable documentation pages

Extra checks:

- [x] Test output encodings on Windows (with and without `LANG=C`)
- [x] Evaluate performance and usability of generated JSON in a few languages:<sup>2</sup>
    - [ ] ~~Python~~
    - [x] JS<sup>3</sup>: [gnome-shell-extension-freon@84a018469275 `.../liquidctlUtil.js`](https://github.com/jonasmalacofilho/gnome-shell-extension-freon/blob/84a018469275e36874e45724cd8c7a379e5b66cf/freon%40UshakovVasilii_Github.yahoo.com/liquidctlUtil.js)
    - [x] Rust: [rustlab@8c67ce72206d `reading-liquidctl-json`](https://github.com/jonasmalacofilho/rustlab/tree/8c67ce72206da0cd37c8fd4fdeb656b1d79f0bcc/reading-liquidctl-json), [`benches/json_from_liquidctl.rs`](https://github.com/jonasmalacofilho/rustlab/blob/8c67ce72206da0cd37c8fd4fdeb656b1d79f0bcc/benches/benches/json_from_liquidctl.rs)

---

<sup>1</sup> Piping to [`jq`](https://stedolan.github.io/jq/) or [`python -m json.tool`](https://docs.python.org/3/library/json.html#module-json.tool) can be used to prettify the output.
<sup>2</sup> Please leave comments with results in other languages.  
<sup>3</sup> Specifically, SpiderMonkey (used in GNOME JS).