### PR TITLE
315 hydro platinum fan channel

### DIFF
--- a/docs/corsair-platinum-pro-xt-guide.md
+++ b/docs/corsair-platinum-pro-xt-guide.md
@@ -63,7 +63,7 @@ omitted; in the latter case the fan will be set to max out at 60°C.
 ```
 
 Valid channel values are `fanN`, where N >= 1 is the fan number, and
-`fan`, to simultaneously configure all fans.
+`sync`, to simultaneously configure all fans.
 
 As mentioned before, unconfigured fan channels may default to 100% duty.
 

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -306,7 +306,7 @@ Mode	#colors
 .
 .SS Corsair Hydro H100i Platinum, H100i Platinum SE, H115i Platinum
 .SS Corsair Hydro H100i Pro XT, H115i Pro XT , H150i Pro XT
-Fan channels: \fIfan\fR, \fIfan[1\(en2]\fR; (only H150i Pro XT:) \fIfan3\fR.
+Fan channels: \fIsync\fR, \fIfan[1\(en2]\fR; (only H150i Pro XT:) \fIfan3\fR.
 .PP
 Pump mode (\fBinitialize \-\-pump\-mode \fImode\fR): \fIquiet\fR,
 \fIbalanced\fR (default), \fIextreme\fR.

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -352,10 +352,13 @@ class HydroPlatinum(UsbHidDriver):
 
     def _get_hw_fan_channels(self, channel):
         if channel == 'fan':
+            _LOGGER.warning('`fan` channel is deprecated, prefer `sync`')
             return self._fan_names
-        if channel in self._fan_names:
+        elif channel == 'sync':
+            return self._fan_names
+        elif channel in self._fan_names:
             return [channel]
-        raise ValueError(f'unknown channel, should be one of: {_quoted("fan", *self._fan_names)}')
+        raise ValueError(f'unknown channel, should be one of: {_quoted("sync", *self._fan_names)}')
 
     def _send_command(self, feature, command, data=None):
         # self.device.write expects buf[0] to be the report number or 0 if not used


### PR DESCRIPTION
Closes: #315 

This is meant to add consistency between different drivers and make the hydro platinum family use the channel `sync` instead of `fan` to specify that all the fans should be set to the same speed. 

Also added a depreciation notice. 

(side note about the checklist, added the man pages in there was a good call, I forgot about the manpage file at first)

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Add automated tests cases
- [ ] Conform to the style guide in `docs/developer/style-guide.md`
- [ ] Verify that all automated tests pass
- [ ] Verify that the changes work as expected on real hardware
- [ ] [New CLI flag?] Adjust the completion scripts in `extra/completions/`
- [ ] [New device?] Regenerate `extra/linux/71-liquidctl.rules` (see file header)
- [ ] [New device?] Add entry to the README's supported device list with applicable notes (at least `EN`)
- [ ] [New driver?] Document the protocol in `docs/developer/protocol/`
- [ ] Update (or add) applicable `docs/*guide.md` device guides
- [x] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [x] Update the README and other applicable documentation pages
- [ ] Submit relevant device data to https://github.com/liquidctl/collected-device-data
