### PR TITLE
317 log colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ Neumaier, Kristóf Jakab, Sean Nelson, Chris Griffith, notaz, realies and Thomas
 Pircher.
 
 Depending on how it is packaged, it might also bundle copies of python, hidapi,
-libusb, cython-hidapi, pyusb and docopt.
+libusb, cython-hidapi, pyusb, docopt, colorlog and colorama.
 
 This program is free software: you can redistribute it and/or modify it under
 the terms of the GNU General Public License as published by the Free Software

--- a/README.md
+++ b/README.md
@@ -131,10 +131,11 @@ The following dependencies are required at runtime (common package names are lis
 - Python 3.6+ _(python3, python)_
 - pkg_resources Python package _(python3-setuptools, python3-pkg-resources, python-setuptools)_
 - docopt _(python3-docopt, python-docopt)_
+- colorlog _(python3-colorlog, python-colorlog)_
 - cython-hidapi _(python3-hidapi, python3-hid, python-hidapi)_
 - PyUSB _(python3-pyusb, python3-usb, python-pyusb)_
-- LibUSB 1.0 _(libusb-1.0, libusb-1.0-0, libusbx)_
 - smbus Python package _(python3-i2c-tools, python3-smbus, i2c-tools)_
+- LibUSB 1.0 _(libusb-1.0, libusb-1.0-0, libusbx)_
 
 To locally test and manually install, a few more dependencies are needed:
 

--- a/extra/windows/redist-notices.txt
+++ b/extra/windows/redist-notices.txt
@@ -4,6 +4,8 @@ liquidctl executables for Windows bundle the following projects:
  - pyinstaller (bootloader)
  - python
  - docopt
+ - colorlog
+ - colorama
  - pyusb
  - libusb-1.0
  - cython-hidapi
@@ -139,6 +141,61 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
 OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+===============================================================================
+
+colorlog – https://github.com/borntyping/python-colorlog
+
+Copyright (c) 2018 Sam Clements <sam@borntyping.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+===============================================================================
+
+colorama – https://github.com/tartley/colorama
+
+Copyright (c) 2010 Jonathan Hartley
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holders, nor those of its contributors
+  may be used to endorse or promote products derived from this software without
+  specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ===============================================================================
 

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -71,12 +71,8 @@ import os
 import sys
 from traceback import format_exception
 
+import colorlog
 from docopt import docopt
-try:
-    import colorlog
-    use_color_log=True
-except ImportError:
-    use_color_log=False
 
 from liquidctl.driver import *
 from liquidctl.error import NotSupportedByDevice, NotSupportedByDriver, UnsafeFeaturesNotEnabled
@@ -269,26 +265,20 @@ def main():
 
     if args['--debug']:
         args['--verbose'] = True
-        format_color='%(log_color)s[%(levelname)s]%(name)s%(reset)s: %(message)s'
-        format_basic='[%(levelname)s] %(name)s: %(message)s'
-        level=logging.DEBUG
+        format_color = '%(log_color)s[%(levelname)s] %(name)s%(reset)s: %(message)s'
+        level = logging.DEBUG
     elif args['--verbose']:
-        format_color='%(log_color)s%(levelname)s%(reset)s: %(message)s'
-        format_basic='%(levelname)s: %(message)s'  
-        level=logging.INFO
+        format_color = '%(log_color)s%(levelname)s%(reset)s: %(message)s'
+        level = logging.INFO
     else:
-        format_color='%(log_color)s%(levelname)s%(reset)s: %(message)s'
-        format_basic='%(levelname)s: %(message)s'
-        level=logging.WARNING
+        format_color = '%(log_color)s%(levelname)s%(reset)s: %(message)s'
+        level = logging.WARNING
         sys.tracebacklimit = 0
-   
-    if use_color_log:
-        formatter = colorlog.ColoredFormatter(format_color)
-        handler = logging.StreamHandler()
-        handler.setFormatter(formatter)
-        logging.basicConfig(level=level, handlers=[handler])
-    else:
-        logging.basicConfig(level=level, format=format_basic)  
+
+    formatter = colorlog.TTYColoredFormatter(fmt=format_color, stream=sys.stdout)
+    handler = logging.StreamHandler()
+    handler.setFormatter(formatter)
+    logging.basicConfig(level=level, handlers=[handler])
 
     _LOGGER.debug('running %s', _gen_version())
 

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -72,6 +72,11 @@ import sys
 from traceback import format_exception
 
 from docopt import docopt
+try:
+    import colorlog
+    use_color_log=True
+except ImportError:
+    use_color_log=False
 
 from liquidctl.driver import *
 from liquidctl.error import NotSupportedByDevice, NotSupportedByDriver, UnsafeFeaturesNotEnabled
@@ -264,13 +269,28 @@ def main():
 
     if args['--debug']:
         args['--verbose'] = True
-        logging.basicConfig(level=logging.DEBUG, format='[%(levelname)s] %(name)s: %(message)s')
-        _LOGGER.debug('running %s', _gen_version())
+        format_color='%(log_color)s[%(levelname)s]%(name)s%(reset)s: %(message)s'
+        format_basic='[%(levelname)s] %(name)s: %(message)s'
+        level=logging.DEBUG
     elif args['--verbose']:
-        logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+        format_color='%(log_color)s%(levelname)s%(reset)s: %(message)s'
+        format_basic='%(levelname)s: %(message)s'  
+        level=logging.INFO
     else:
-        logging.basicConfig(level=logging.WARNING, format='%(levelname)s: %(message)s')
+        format_color='%(log_color)s%(levelname)s%(reset)s: %(message)s'
+        format_basic='%(levelname)s: %(message)s'
+        level=logging.WARNING
         sys.tracebacklimit = 0
+   
+    if use_color_log:
+        formatter = colorlog.ColoredFormatter(format_color)
+        handler = logging.StreamHandler()
+        handler.setFormatter(formatter)
+        logging.basicConfig(level=level, handlers=[handler])
+    else:
+        logging.basicConfig(level=level, format=format_basic)  
+
+    _LOGGER.debug('running %s', _gen_version())
 
     opts = _make_opts(args)
     filter_count = sum(1 for opt in opts if opt in _FILTER_OPTIONS)

--- a/setup.py
+++ b/setup.py
@@ -70,7 +70,7 @@ CHANGES_URL = '{}/blob/v{}/CHANGELOG.md'.format(HOME, VERSION)
 
 make_extraversion()
 
-install_requires = ['docopt', 'pyusb', 'hidapi']
+install_requires = ['docopt', 'pyusb', 'hidapi', 'colorlog']
 
 if sys.platform == 'linux':
     install_requires.append('smbus')


### PR DESCRIPTION
Closes #317 

Logging now prints with pretty colors yay. This adds an optional module dependancy of  [colorlog](https://pypi.org/project/colorlog/).

The log format is the same, except the log level is now printed in a color.
---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Add automated tests cases
- [ ] Conform to the style guide in `docs/developer/style-guide.md`
- [x] Verify that all automated tests pass
- [x] Verify that the changes work as expected on real hardware
- [ ] [New CLI flag?] Adjust the completion scripts in `extra/completions/`
- [ ] [New device?] Regenerate `extra/linux/71-liquidctl.rules` (see file header)
- [ ] [New device?] Add entry to the README's supported device list with applicable notes (at least `EN`)
- [ ] [New driver?] Document the protocol in `docs/developer/protocol/`
- [ ] Update (or add) applicable `docs/*guide.md` device guides
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update the README and other applicable documentation pages
- [ ] Submit relevant device data to https://github.com/liquidctl/collected-device-data
