### PR TITLE
made log colors look even better

### DIFF
--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -268,17 +268,28 @@ def main():
 
     if args['--debug']:
         args['--verbose'] = True
-        format_color = '%(log_color)s[%(levelname)s] %(name)s%(reset)s: %(message)s'
+        format_color = '%(log_color)s[%(levelname)s] %(name)s%(reset)s: %(message_log_color)s%(message)s'
         level = logging.DEBUG
     elif args['--verbose']:
-        format_color = '%(log_color)s%(levelname)s%(reset)s: %(message)s'
+        format_color = '%(log_color)s%(levelname)s%(reset)s: %(message_log_color)s%(message)s'
         level = logging.INFO
     else:
-        format_color = '%(log_color)s%(levelname)s%(reset)s: %(message)s'
+        format_color = '%(log_color)s%(levelname)s%(reset)s: %(message_log_color)s%(message)s'
         level = logging.WARNING
         sys.tracebacklimit = 0
+    
+    log_colors = colorlog.default_log_colors
+    log_colors['WARNING'] = 'bold_yellow'
+    log_colors['DEBUG'] = 'blue'
+    secondary_log_colors={
+		'message': {
+			'WARNING': 'yellow',
+            'ERROR': 'red',
+			'CRITICAL': 'bold_red'
+		}
+	}
 
-    formatter = colorlog.TTYColoredFormatter(fmt=format_color, stream=sys.stdout)
+    formatter = colorlog.TTYColoredFormatter(fmt=format_color, stream=sys.stdout, log_colors=log_colors, secondary_log_colors=secondary_log_colors)
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     logging.basicConfig(level=level, handlers=[handler])


### PR DESCRIPTION
This does exactly what the title says. The log colors now look up to 1000000000 times better[¹]()

As per the discussion on discord:
- debug logs are now blue
- warning, error, critical now have the entire line colored
- warning is now `bold_yellow` instead of normal `yellow`

¹  = some people may disagree, but don't listen to them


---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Add automated tests cases
- [ ] Conform to the style guide in `docs/developer/style-guide.md`
- [ ] Verify that all automated tests pass
- [ ] Verify that the changes work as expected on real hardware
- [ ] [New CLI flag?] Adjust the completion scripts in `extra/completions/`
- [ ] [New device?] Regenerate `extra/linux/71-liquidctl.rules` (see file header)
- [ ] [New device?] Add entry to the README's supported device list with applicable notes (at least `EN`)
- [ ] [New driver?] Document the protocol in `docs/developer/protocol/`
- [ ] Update (or add) applicable `docs/*guide.md` device guides
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update the README and other applicable documentation pages
- [ ] Submit relevant device data to https://github.com/liquidctl/collected-device-data
