### PR TITLE
Remove temporary warning about HIDAPI for FreeBSD 

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,6 @@ By default, root privileges (`doas` or `sudo`) are required to run liquidctl.
 
 To gain full access as a normal user without `doas` or `sudo`, see devd(8). Also, you might consider manually changing the permission of the file of the USB device for an individual session with `chown`, e.g. `sudo chown [user] /dev/ugen[#.#]`.
 
-Note: as of March 20, 2021, HIDAPI (`comms/hidapi`), which is required for `comms/py-hidapi` (and, thus, liquidctl), must be built from the latest port rather than installed as a package, as the latest package is out of date. Make sure that you have HIDAPI version 0.10.1 or later installed prior to installing `comms/py-hidapi` and liquidctl. Then, liquidctl will work as expected.
-
 ### DragonFly BSD
 
 The port is also available in DragonFly Ports.


### PR DESCRIPTION
FreeBSD's `hidapi` package has been updated to 0.10.1 for x86 and amd64 in both latest and quarterly branches for all supported FreeBSD versions (11.4, 12.2, 13.0, & 14-CURRENT).

As I am assuming that nobody is using liquidctl on another architecture (ARM, RISC-V, PowerPC, etc.), I have simply removed the whole warning message that we had in place temporarily before.

All is well now :smile:

Describe what the changes are meant to address.

If the implementation is non trivial, please also include a short overview.

<!-- Tags (fill and keep as many as applicable): -->

Fixes: #number of issue (implies Closes tag) or commit SHA
Closes: #number of issue or pull request
Related: #number of issue/pull request, or link to external discussion

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Add automated tests cases
- [ ] Conform to the style guide in `docs/developer/style-guide.md`
- [ ] Verify that all automated tests pass
- [ ] Verify that the changes work as expected on real hardware
- [ ] [New CLI flag?] Adjust the completion scripts in `extra/completions/`
- [ ] [New device?] Regenerate `extra/linux/71-liquidctl.rules` (see file header)
- [ ] [New device?] Add entry to the README's supported device list with applicable notes (at least `EN`)
- [ ] [New driver?] Document the protocol in `docs/developer/protocol/`
- [ ] Update (or add) applicable `docs/*guide.md` device guides
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update the README and other applicable documentation pages
- [ ] Submit relevant device data to https://github.com/liquidctl/collected-device-data
