### PR TITLE
Add Start of Commander Core Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The following devices are supported by this version of liquidctl.  See each guid
 | AIO liquid cooler | [Corsair Hydro H100i Pro, H115i Pro, H150i Pro](docs/asetek-pro-guide.md) | USB | <sup>_Ze_</sup> |
 | AIO liquid cooler | [Corsair Hydro H100i Platinum [SE], H115i Platinum](docs/corsair-platinum-pro-xt-guide.md) | USB HID | <sup>_e_</sup> |
 | AIO liquid cooler | [Corsair Hydro H100i Pro XT, H115i Pro XT, H150i Pro XT](docs/corsair-platinum-pro-xt-guide.md) | USB HID | <sup>_e_</sup> |
+| AIO liquid cooler | [Corsair iCUE H100i, H115i, H150i ELITE CAPELLIX](docs/corsair-commander-core-guide.md) | USB HID | <sup>_en_</sup> |
 | AIO liquid cooler | [EVGA CLC 120 (CL12), 240, 280, 360](docs/asetek-690lc-guide.md) | USB | <sup>_Z_</sup> |
 | AIO liquid cooler | [NZXT Kraken M22](docs/kraken-x2-m2-guide.md) | USB HID | |
 | AIO liquid cooler | [NZXT Kraken X40, X60](docs/asetek-690lc-guide.md) | USB | <sup>_LZe_</sup> |
@@ -97,6 +98,7 @@ The following devices are supported by this version of liquidctl.  See each guid
 | AIO liquid cooler | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | USB & USB HID | <sup>_e_</sup> |
 | DDR4 DRAM | [Corsair Vengeance RGB](docs/ddr4-guide.md) | SMBus | <sup>_Uex_</sup> |
 | DDR4 DRAM | [DIMMs with a standard temperature sensor](docs/ddr4-guide.md) | SMBus | <sup>_Uex_</sup> |
+| Fan/LED controller | [Corsair Commander Core](docs/corsair-commander-core-guide.md) | USB HID | <sup>_en_</sup> |
 | Fan/LED controller | [Corsair Commander Pro](docs/corsair-commander-guide.md) | USB HID | <sup>_e_</sup> |
 | Fan/LED controller | [Corsair Lighting Node Core, Pro](docs/corsair-commander-guide.md) | USB HID | <sup>_e_</sup> |
 | Fan/LED controller | [NZXT Grid+ V3](docs/nzxt-smart-device-v1-guide.md) | USB HID | |

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ The following devices are supported by this version of liquidctl.  See each guid
 | AIO liquid cooler | [Corsair Hydro H100i Pro, H115i Pro, H150i Pro](docs/asetek-pro-guide.md) | USB | <sup>_Ze_</sup> |
 | AIO liquid cooler | [Corsair Hydro H100i Platinum [SE], H115i Platinum](docs/corsair-platinum-pro-xt-guide.md) | USB HID | <sup>_e_</sup> |
 | AIO liquid cooler | [Corsair Hydro H100i Pro XT, H115i Pro XT, H150i Pro XT](docs/corsair-platinum-pro-xt-guide.md) | USB HID | <sup>_e_</sup> |
-| AIO liquid cooler | [Corsair iCUE H100i, H115i, H150i ELITE CAPELLIX](docs/corsair-commander-core-guide.md) | USB HID | <sup>_en_</sup> |
+| AIO liquid cooler | [Corsair iCUE H100i, H115i, H150i Elite Capellix](docs/corsair-commander-core-guide.md) | USB HID | <sup>_en_</sup> |
 | AIO liquid cooler | [EVGA CLC 120 (CL12), 240, 280, 360](docs/asetek-690lc-guide.md) | USB | <sup>_Z_</sup> |
 | AIO liquid cooler | [NZXT Kraken M22](docs/kraken-x2-m2-guide.md) | USB HID | |
 | AIO liquid cooler | [NZXT Kraken X40, X60](docs/asetek-690lc-guide.md) | USB | <sup>_LZe_</sup> |

--- a/docs/corsair-commander-core-guide.md
+++ b/docs/corsair-commander-core-guide.md
@@ -1,0 +1,42 @@
+# Corsair Commander Core
+_Driver API and source code available in [`liquidctl.driver.commander_core`](../liquidctl/driver/commander_core.py)._
+
+Currently, functionality implemented is listed here. More is planned to be added.
+
+## Initializing the device
+
+The device should be initialized every time it is powered on.
+
+```
+# liquidctl initialize
+Corsair Commander Core (experimental)
+├── Firmware version                 1.6.135  
+├── AIO RGB                               29  LEDs
+├── RGB port 1                             8  LEDs
+├── RGB port 2                             8  LEDs
+├── RGB port 3                  Disconnected  
+├── RGB port 4                  Disconnected  
+├── RGB port 5                  Disconnected  
+├── RGB port 6                  Disconnected  
+├── Water Temperature Sensor       Connected  
+└── Temperature Sensor 1        Disconnected  
+```
+
+## Retrieving the pump speed, fan speeds, and temperatures
+
+
+The Commander Core currently can retrieve the pump speed, fan speeds, temperature of the water, and
+the temperature measured by the probe.
+
+```
+# liquidctl status
+Corsair Commander Core (experimental)
+├── Pump Speed           2342  rpm
+├── Fan Speed 1           872  rpm
+├── Fan Speed 2           851  rpm
+├── Fan Speed 3             0  rpm
+├── Fan Speed 4             0  rpm
+├── Fan Speed 5             0  rpm
+├── Fan Speed 6             0  rpm
+└── Water Temperature    36.9  °C
+```

--- a/docs/corsair-commander-core-guide.md
+++ b/docs/corsair-commander-core-guide.md
@@ -25,18 +25,18 @@ Corsair Commander Core (experimental)
 ## Retrieving the pump speed, fan speeds, and temperatures
 
 
-The Commander Core currently can retrieve the pump speed, fan speeds, temperature of the water, and
+The commander core currently can retrieve the pump speed, fan speeds, temperature of the water, and
 the temperature measured by the probe.
 
 ```
 # liquidctl status
 Corsair Commander Core (experimental)
-├── Pump Speed           2342  rpm
-├── Fan Speed 1           872  rpm
-├── Fan Speed 2           851  rpm
-├── Fan Speed 3             0  rpm
-├── Fan Speed 4             0  rpm
-├── Fan Speed 5             0  rpm
-├── Fan Speed 6             0  rpm
-└── Water Temperature    36.9  °C
+├── Pump speed           2356  rpm
+├── Fan speed 1           810  rpm
+├── Fan speed 2           791  rpm
+├── Fan speed 3             0  rpm
+├── Fan speed 4             0  rpm
+├── Fan speed 5             0  rpm
+├── Fan speed 6             0  rpm
+└── Water temperature    35.8  °C
 ```

--- a/docs/corsair-commander-core-guide.md
+++ b/docs/corsair-commander-core-guide.md
@@ -10,16 +10,16 @@ The device should be initialized every time it is powered on.
 ```
 # liquidctl initialize
 Corsair Commander Core (experimental)
-├── Firmware version                 1.6.135  
-├── AIO RGB                               29  LEDs
-├── RGB port 1                             8  LEDs
-├── RGB port 2                             8  LEDs
-├── RGB port 3                  Disconnected  
-├── RGB port 4                  Disconnected  
-├── RGB port 5                  Disconnected  
-├── RGB port 6                  Disconnected  
-├── Water Temperature Sensor       Connected  
-└── Temperature Sensor 1        Disconnected  
+├── Firmware version            1.6.135  
+├── AIO LED count                    29  
+├── RGB port 1 LED count              8  
+├── RGB port 2 LED count              8  
+├── RGB port 3 LED count            N/A  
+├── RGB port 4 LED count            N/A  
+├── RGB port 5 LED count            N/A  
+├── RGB port 6 LED count            N/A  
+├── Water temperature sensor        Yes  
+└── Temperature sensor 1             No   
 ```
 
 ## Retrieving the pump speed, fan speeds, and temperatures

--- a/docs/developer/protocol/commander_core.md
+++ b/docs/developer/protocol/commander_core.md
@@ -1,0 +1,206 @@
+# Corsair Commander Core Protocol
+
+### Compatible devices
+
+| Device Name | USB ID | LED channels | Fan channels | Temperature channels | 
+|:-----------:|:------:|:------------:|:------------:|:--------------------:|
+| Commander Pro | `1B1C:0C1C` | 7 | 6 | 2 |
+**NOTE: The first two LED and temperature channels go to the EXT port and potentially the AIO**
+
+### Command formats
+
+**NOTES:**
+ - The commander core works in different modes so ensure the proper mode has been sent for each command
+ - Unless stated otherwise all multi-byte numbers used little endian
+
+Host -> Device: 1024 bytes
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | command |
+| 0x02 | channel |
+| 0x03-... | data |
+
+Device -> Host: 1024 bytes
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x00 |
+| 0x01 | command |
+| 0x02 | 0x00 |
+| 0x03-... | data |
+
+___
+## Global Commands
+
+Global commander should work in any mode.
+
+### `0x01` - Init/Wakeup
+
+Needs to be run every time the device has not been sent any data for a predefined number of seconds.
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x01 |
+| 0x02 | 0x03 |
+| 0x03 | 0x00 |
+| 0x04 | 0x02 |
+
+### `0x02` - Get Firmware Version
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x02 |
+| 0x02 | 0x13 |
+
+Response:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x00 |
+| 0x01 | 0x00 |
+| 0x02 | Major |
+| 0x03 | Minor |
+| 0x04 | Patch |
+
+### `0x05` - Init/Wakeup
+
+Needs to be run before changing the mode on a channel if there is a chance the channel has already been used.
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x05 |
+| 0x02 | 0x01 |
+| 0x03 | channel to reset |
+
+### `0x0d` - Set Channel Mode
+
+Sets the mode for the channel to use  
+`0x05` - Init/Wakeup will likely need to be run first.
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x0d |
+| 0x02 | channel |
+| 0x03 | new mode |
+
+___
+
+## Modes:
+
+### `0x17` - Get Speeds of Pump and Fans
+
+#### `0x08` - Get Speeds of Pump and Fans
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x08 |
+| 0x02 | channel |
+
+Response:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x00 |
+| 0x01 | 0x08 |
+| 0x02 | 0x00 |
+| 0x03, 0x04 | ???????? |
+| 0x05 | Number of speed items |
+| 0x06, 0x07 | Speed of AIO/EXT port |
+| 0x08, 0x09 | Speed of Fan 1 |
+| 0x0a, 0x0b | Speed of Fan 2 |
+| 0x0c, 0x0d | Speed of Fan 3 |
+| 0x0e, 0x0f | Speed of Fan 4 |
+| 0x10, 0x11 | Speed of Fan 5 |
+| 0x12, 0x13 | Speed of Fan 6 |
+
+___
+
+### `0x20` - Detect LEDs
+
+#### `0x08` - Get LED Configuration
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x08 |
+| 0x02 | channel |
+
+Response:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x00 |
+| 0x01 | 0x08 |
+| 0x02 | 0x00 |
+| 0x03, 0x04 | 0x0f - Number of numbers after this |
+| 0x05 | Number of RGB channels |
+| 0x06, 0x07 | EXT RGB mode |
+| 0x08, 0x09 | EXT LED count |
+| 0x0a, 0x0b | RGB Port 1 mode |
+| 0x0c, 0x0d | RGB Port 1 LED count |
+| 0x0e, 0x0f | RGB Port 2 mode |
+| 0x10, 0x11 | RGB Port 2 LED count |
+| 0x12, 0x13 | RGB Port 3 mode |
+| 0x14, 0x15 | RGB Port 3 LED count |
+| 0x16, 0x17 | RGB Port 4 mode |
+| 0x18, 0x19 | RGB Port 4 LED count |
+| 0x1a, 0x1b | RGB Port 5 mode |
+| 0x1c, 0x1d | RGB Port 5 LED count |
+| 0x1e, 0x1f | RGB Port 6 mode |
+| 0x20, 0x21 | RGB Port 6 LED count |
+
+RGB Mode:
+
+| Fan Mode     | Value |
+| ------------ | ----- |
+| Connected    | 0x02  |
+| Disconnected | 0x03  |
+
+___
+
+### `0x21` - Get Temperatures
+
+#### `0x08` - Get Temperatures
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x08 |
+| 0x02 | channel |
+
+Response:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x00 |
+| 0x01 | 0x08 |
+| 0x02 | 0x00 |
+| 0x03, 0x04 | ???????? |
+| 0x05 | Number of temperature sensors |
+| 0x06 | 0x00 if connected or 0x01 if not connected |
+| 0x07, 0x08 | Temperature in Celsius (needs to be divided by 10) |
+| 0x09 | 0x00 if connected or 0x01 if not connected |
+| 0x0a, 0x0b | Temperature in Celsius (needs to be divided by 10) |
+
+___

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -63,6 +63,9 @@ KERNEL=="i2c-*", ATTR{name}=="NVIDIA i2c adapter 1 *", ATTRS{vendor}=="0x10de", 
 # Asetek 690LC (assuming NZXT Kraken X)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2433", ATTRS{idProduct}=="b200", TAG+="uaccess"
 
+# Corsair Commander Core
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c1c", TAG+="uaccess"
+
 # Corsair Commander Pro
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c10", TAG+="uaccess"
 

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -25,6 +25,7 @@ from liquidctl.driver.base import BaseBus, find_all_subclasses
 # automatically enabled drivers
 from liquidctl.driver import asetek
 from liquidctl.driver import asetek_pro
+from liquidctl.driver import commander_core
 from liquidctl.driver import commander_pro
 from liquidctl.driver import corsair_hid_psu
 from liquidctl.driver import hydro_platinum

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -1,0 +1,176 @@
+"""liquidctl drivers for Corsair Commander Core.
+
+Supported devices:
+
+- Corsair Commander Core
+
+
+Copyright (C)2021  ParkerMc and contributors
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import logging
+
+from liquidctl.driver.usb import UsbHidDriver
+from liquidctl.util import u16le_from
+
+_LOGGER = logging.getLogger(__name__)
+
+_REPORT_LENGTH = 1024
+_RESPONSE_LENGTH = 1024
+
+_INTERFACE_NUMBER = 1
+
+_CMD_GET_FIRMWARE = (0x02, 0x13)
+_CMD_INIT = (0x01, 0x03, 0x00, 0x02)
+_CMD_RESET = (0x05, 0x01, 0x00)
+_CMD_SET_MODE = (0x0d, 0x00)
+_CMD_GET = (0x08, 0x00)
+
+_MODE_DETECT_RGB = 0x20
+_MODE_GET_SPEEDS = 0x17
+_MODE_GET_TEMPS = 0x21
+
+
+class CommanderCore(UsbHidDriver):
+    """Corsair Commander Core"""
+
+    SUPPORTED_DEVICES = [
+        (0x1b1c, 0x0c1c, None, 'Corsair Commander Core (experimental)', {})
+    ]
+
+    def __init__(self, device, description, **kwargs):
+        super().__init__(device, description, **kwargs)
+
+    def connect(self, runtime_storage=None, **kwargs):
+        """Connect to the device."""
+        return super().connect(**kwargs)
+
+    def initialize(self, **kwargs):
+        """Initialize the device and get the fan modes."""
+
+        res = self._send_command(_CMD_GET_FIRMWARE)
+        fw_version = (res[3], res[4], res[5])
+
+        status = [('Firmware version', '{}.{}.{}'.format(*fw_version), '')]
+
+        # INIT
+        self._send_command(_CMD_INIT)
+
+        # Get LEDs per fan
+        self._send_command(_CMD_RESET)
+        self._send_command(_CMD_SET_MODE, [_MODE_DETECT_RGB])
+        res = self._send_command(_CMD_GET)
+        num_rgb = res[5]
+        for i in range(0, num_rgb):
+            connected = u16le_from(res, offset=6+i*4) == 2
+            num_leds = u16le_from(res, offset=8+i*4)
+            if i == 0:
+                status += [(f'AIO RGB', num_leds if connected else 'Disconnected', 'LEDs' if connected else '')]
+            else:
+                status += [(f'RGB port {i}', num_leds if connected else 'Disconnected', 'LEDs' if connected else '')]
+
+        # Get what temp sensors are connected
+        for i, temp in self._get_temps().items():
+            connected = temp is not None
+            if i == 0:
+                status += [(f'Water Temperature Sensor', 'Connected' if connected else 'Disconnected', '')]
+            else:
+                status += [(f'Temperature Sensor {i}', 'Connected' if connected else 'Disconnected', '')]
+
+        return status
+
+    def get_status(self, **kwargs):
+        """Get all the fan speeds and temps"""
+        status = []
+
+        # INIT in case it hasn't been accesses in a while
+        self._send_command(_CMD_INIT)
+
+        for i, speed in self._get_speeds().items():
+            if i == 0:
+                status += [(f'Pump Speed', speed, 'rpm')]
+            else:
+                status += [(f'Fan Speed {i}', speed, 'rpm')]
+
+        for i, temp in self._get_temps().items():
+            if temp is None:
+                continue
+            if i == 0:
+                status += [(f'Water Temperature', temp, '°C')]
+            else:
+                status += [(f'Temperature {i}', temp, '°C')]
+
+        return status
+
+    def set_color(self, channel, mode, colors, **kwargs):
+        raise NotImplementedError
+
+    def set_speed_profile(self, channel, profile, **kwargs):
+        raise NotImplementedError
+
+    def set_fixed_speed(self, channel, duty, **kwargs):
+        raise NotImplementedError
+
+    @classmethod
+    def probe(cls, handle, **kwargs):
+        """Ensure we get the right interface"""
+
+        if handle.hidinfo['interface_number'] == _INTERFACE_NUMBER:
+            return
+
+        yield from super().probe(handle, **kwargs)
+
+    def _get_speeds(self):
+        speeds = {}
+
+        self._send_command(_CMD_RESET)
+        self._send_command(_CMD_SET_MODE, [_MODE_GET_SPEEDS])
+        res = self._send_command(_CMD_GET)
+
+        num_speeds = res[5]
+        speeds_data = res[6:6 + num_speeds*2]
+        for i in range(0, num_speeds):
+            speeds[i] = u16le_from(speeds_data, offset=i*2)
+
+        return speeds
+
+    def _get_temps(self):
+        temps = {}
+
+        self._send_command(_CMD_RESET)
+        self._send_command(_CMD_SET_MODE, [_MODE_GET_TEMPS])
+        res = self._send_command(_CMD_GET)
+
+        num_temps = res[5]
+        temp_data = res[6:6 + num_temps*3]
+        for i in range(0, num_temps):
+            connected = temp_data[i*3] == 0x00
+            if connected:
+                temps[i] = u16le_from(temp_data, offset=i*3+1)/10
+            else:
+                temps[i] = None
+
+        return temps
+
+    def _send_command(self, command, data=()):
+        # self.device.write expects buf[0] to be the report number or 0 if not used
+        buf = bytearray(_REPORT_LENGTH + 1)
+
+        # buf[1] when going out is always 08
+        buf[1] = 0x08
+
+        # Indexes for the buffer
+        cmd_start = 2
+        data_start = cmd_start + len(command)
+        data_end = data_start + len(data)
+
+        # Fill in the buffer
+        buf[cmd_start: data_start] = command
+        buf[data_start:data_end] = data
+
+        self.device.clear_enqueued_reports()
+        self.device.write(buf)
+
+        buf = bytes(self.device.read(_RESPONSE_LENGTH))
+        return buf

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -1,0 +1,141 @@
+import pytest
+
+from _testutils import noop
+from collections import deque
+from liquidctl.driver.commander_core import CommanderCore
+
+
+def int_to_le(num, length=2, byteorder='little', signed=False):
+    return int(num).to_bytes(length=length, byteorder=byteorder, signed=signed)
+
+
+class MockCommanderCoreDevice:
+    def __init__(self):
+        self.vendor_id = 0x1b1c
+        self.product_id = 0x0c1c
+        self.address = "addr"
+        self.release_number = None
+        self.serial_number = None
+        self.bus = None
+        self.port = None
+
+        self.open = noop
+        self.close = noop
+        self.clear_enqueued_reports = noop
+
+        self._read = deque()
+        self.sent = list()
+
+        self._last_write = bytes()
+        self._modes = {}
+
+        self.firmware_version = (0x00, 0x00, 0x00)
+        self.led_counts = (None, None, None, None, None, None, None)
+        self.speeds = (None, None, None, None, None, None, None)
+        self.temperatures = (None, None)
+
+    def read(self, length):
+        data = bytearray([0x00, self._last_write[2], 0x00])
+
+        if self._last_write[2] == 0x02:  # Firmware version
+            for i in range(0, 3):
+                data.append(self.firmware_version[i])
+        if self._last_write[2] == 0x08:  # Get data
+            channel = self._last_write[3]
+            mode = self._modes[channel]
+            if mode == 0x17:  # Get speeds
+                data.extend([0x06, 0x00])
+                data.append(len(self.speeds))
+                for i in self.speeds:
+                    if i is None:
+                        data.extend([0x00, 0x00])
+                    else:
+                        data.extend(int_to_le(i))
+            elif mode == 0x20:  # LED detect
+                data.extend(int_to_le(len(self.led_counts)*2+1))
+                data.append(len(self.led_counts))
+                for i in self.led_counts:
+                    if i is None:
+                        data.extend(int_to_le(3)+int_to_le(0))
+                    else:
+                        data.extend(int_to_le(2))
+                        data.extend(int_to_le(i))
+            elif mode == 0x21:  # Get temperatures
+                data.extend([0x10, 0x00])
+                data.append(len(self.temperatures))
+                for i in self.temperatures:
+                    if i is None:
+                        data.append(1)
+                        data.extend(int_to_le(0))
+                    else:
+                        data.append(0)
+                        data.extend(int_to_le(int(i*10)))
+
+        return list(data)[:length]
+
+    def write(self, data):
+        data = bytes(data)  # ensure data is convertible to bytes
+        self._last_write = data
+
+        if data[2] == 0x0d:
+            channel = data[3]
+            if self._modes[channel] is None:
+                self._modes[channel] = data[4]
+        elif data[2] == 0x05 and data[3] == 0x01:
+            self._modes[data[4]] = None
+
+        return len(data)
+
+
+@pytest.fixture
+def commander_core_device():
+    device = MockCommanderCoreDevice()
+    core = CommanderCore(device, 'Corsair Commander Core (experimental)')
+    core.connect()
+    return core
+
+
+def test_initialize_commander_core(commander_core_device):
+    commander_core_device.device.firmware_version = (0x01, 0x02, 0x21)
+    commander_core_device.device.led_counts = (27, None, 1, 2, 4, 8, 16)
+    commander_core_device.device.temperatures = (None, 45.6)
+    res = commander_core_device.initialize()
+
+    assert len(res) == 10
+
+    assert res[0][1] == '1.2.33'  # Firmware
+
+    # LED counts
+    assert res[1][1] == 27
+    assert res[2][1] == 'Disconnected'
+    assert res[3][1] == 1
+    assert res[4][1] == 2
+    assert res[5][1] == 4
+    assert res[6][1] == 8
+    assert res[7][1] == 16
+
+    # Temperature sensors connected
+    assert res[8][1] == 'Disconnected'
+    assert res[9][1] == 'Connected'
+
+
+def test_status_commander_core(commander_core_device):
+    commander_core_device.device.speeds = (2357, 918, 903, 501, 1104, 1824, 104)
+    commander_core_device.device.temperatures = (12.3, 45.6)
+    res = commander_core_device.get_status()
+
+    assert len(res) == 9
+
+    # Speeds of pump and fans
+    assert res[0][1] == 2357
+    assert res[1][1] == 918
+    assert res[2][1] == 903
+    assert res[3][1] == 501
+    assert res[4][1] == 1104
+    assert res[5][1] == 1824
+    assert res[6][1] == 104
+
+    # Temperatures
+    assert res[7][1] == 12.3
+    assert res[8][1] == 45.6
+

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -107,7 +107,7 @@ def test_initialize_commander_core(commander_core_device):
 
     # LED counts
     assert res[1][1] == 27
-    assert res[2][1] == 'Disconnected'
+    assert res[2][1] is None
     assert res[3][1] == 1
     assert res[4][1] == 2
     assert res[5][1] == 4
@@ -115,8 +115,8 @@ def test_initialize_commander_core(commander_core_device):
     assert res[7][1] == 16
 
     # Temperature sensors connected
-    assert res[8][1] == 'Disconnected'
-    assert res[9][1] == 'Connected'
+    assert res[8][1] is False
+    assert res[9][1] is True
 
 
 def test_status_commander_core(commander_core_device):

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -1,8 +1,8 @@
 import pytest
-
-from _testutils import noop
 from collections import deque
+
 from liquidctl.driver.commander_core import CommanderCore
+from _testutils import noop
 
 
 def int_to_le(num, length=2, byteorder='little', signed=False):


### PR DESCRIPTION
This is the first part of support for the Commander Core. 
To initialize it adds getting the firmware version, number of LEDs per RGB port, and what tempature sensors are conencted.
To status it adds getting pump speed, fan speed, and temperatures.

<!-- Tags (fill and keep as many as applicable): -->

Related: #218

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [x] Update or add applicable `docs/*guide.md` device guides
- [x] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [x] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
