### PR TITLE
added nzxt smart device 2 model 2010

### DIFF
--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -194,3 +194,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2006", TAG+="uacc
 
 # NZXT Smart Device V2
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="200d", TAG+="uaccess"
+
+# NZXT Smart Device V2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2010", TAG+="uaccess"

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -186,6 +186,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2009", TAG+="uacc
 # NZXT RGB & Fan Controller
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="200e", TAG+="uaccess"
 
+# NZXT RGB & Fan Controller
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2010", TAG+="uaccess"
+
 # NZXT Smart Device (V1)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="1714", TAG+="uaccess"
 
@@ -194,6 +197,3 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2006", TAG+="uacc
 
 # NZXT Smart Device V2
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="200d", TAG+="uaccess"
-
-# NZXT Smart Device V2
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2010", TAG+="uaccess"

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -347,6 +347,10 @@ class SmartDevice2(_CommonSmartDeviceDriver):
             'speed_channel_count': 3,
             'color_channel_count': 2
         }),
+        (0x1e71, 0x2010, None, 'NZXT RGB & Fan Controller', {
+            'speed_channel_count': 3,
+            'color_channel_count': 2
+        }),
     ]
 
     _MAX_READ_ATTEMPTS = 12


### PR DESCRIPTION
I found yet another model of the nzxt led and fan controller.
After adding the device ID everything seems to work just fine.

This is basically the same as  f19913c just with the id 2010

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
