### PR TITLE
Commander Core: Cleanup and add read error checking

### DIFF
--- a/docs/developer/protocol/commander_core.md
+++ b/docs/developer/protocol/commander_core.md
@@ -8,7 +8,7 @@
 
 The Commander Core is typically shipped with the Corsair iCUE Elite Capellix
 AIOs.  The first two LED and temperature channels go to the EXT port, typically
-in use by the the AIO.
+in use by the AIO.
 
 ## Command formats
 
@@ -22,27 +22,29 @@ Host -> Device: 1024 bytes
 | Byte index | Description |
 | ---------- | ----------- |
 | 0x00 | 0x08 |
-| 0x01 | command |
-| 0x02 | channel |
-| 0x03-... | data |
+| 0x01 | Command |
+| 0x02 | Channel |
+| 0x03-... | Data |
 
 Device -> Host: 1024 bytes
 
 | Byte index | Description |
 | ---------- | ----------- |
 | 0x00 | 0x00 |
-| 0x01 | command |
+| 0x01 | Command |
 | 0x02 | 0x00 |
-| 0x03-... | data |
+| 0x03-... | Data |
 
-## Global commands
+## Global Commands
 
 Global commands should work in any mode.
 
-### `0x01` - Init/Wakeup
+### `0x01` - Wake up/Sleep
 
-Needs to be run every time the device has not been sent any data for a
-predefined number of seconds.
+Wakeup needs to be run every time the device has not been sent any data for a
+predefined number of seconds.  
+Sleep should be run when the device should return to hardware mode and
+no more data will be sent.
 
 Command:
 
@@ -52,7 +54,7 @@ Command:
 | 0x01 | 0x01 |
 | 0x02 | 0x03 |
 | 0x03 | 0x00 |
-| 0x04 | 0x02 |
+| 0x04 | 0x01 for sleep or 0x02 for wake up |
 
 ### `0x02` - Get Firmware Version
 
@@ -77,7 +79,7 @@ Response:
 Note: the `0x01` Init/Wakeup command is exceptionally not necessary before this
 command.
 
-### `0x05` - Init/Wakeup
+### `0x05` - Reset Channel
 
 Needs to be run before changing the mode on a channel if there is a chance the
 channel has already been used.
@@ -89,7 +91,7 @@ Command:
 | 0x00 | 0x08 |
 | 0x01 | 0x05 |
 | 0x02 | 0x01 |
-| 0x03 | channel to reset |
+| 0x03 | Channel to reset |
 
 ### `0x0d` - Set Channel Mode
 
@@ -103,75 +105,84 @@ Command:
 | ---------- | ----------- |
 | 0x00 | 0x08 |
 | 0x01 | 0x0d |
-| 0x02 | channel |
-| 0x03 | new mode |
+| 0x02 | Channel |
+| 0x03 | New mode |
+
+## Mode Commands
+
+These are the commands that are used in each of the modes.
+
+### `0x06` - Write
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x06 |
+| 0x02 | Channel |
+| 0x03, 0x04 | Data length  |
+| 0x05, 0x06 | 00:00 Unknown |
+| 0x07-... | Data |
+
+### `0x08` - Read
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x08 |
+| 0x02 | Channel |
+
+Response:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x00 |
+| 0x01 | 0x08 |
+| 0x02 | 0x00 |
+| 0x03, 0x04 | Data type |
+| 0x05-... | Data |
 
 ## Modes:
 
-### `0x17` - Get Speeds of Pump and Fans
+### `0x17` - Current Speeds of Pump and Fans
 
-#### `0x08` - Get Speeds of Pump and Fans
-
-Command:
+Data Type: `0x06 0x00`
 
 | Byte index | Description |
 | ---------- | ----------- |
-| 0x00 | 0x08 |
-| 0x01 | 0x08 |
-| 0x02 | channel |
+| 0x00 | Number of speed items |
+| 0x01, 0x02 | Speed of AIO/EXT port |
+| 0x03, 0x04 | Speed of Fan 1 |
+| 0x05, 0x06 | Speed of Fan 2 |
+| 0x07, 0x08 | Speed of Fan 3 |
+| 0x09, 0x0a | Speed of Fan 4 |
+| 0x0b, 0x1c | Speed of Fan 5 |
+| 0x0d, 0x1e | Speed of Fan 6 |
 
-Response:
+### `0x20` - Connected LEDs
 
-| Byte index | Description |
-| ---------- | ----------- |
-| 0x00 | 0x00 |
-| 0x01 | 0x08 |
-| 0x02 | 0x00 |
-| 0x03, 0x04 | ???????? |
-| 0x05 | Number of speed items |
-| 0x06, 0x07 | Speed of AIO/EXT port |
-| 0x08, 0x09 | Speed of Fan 1 |
-| 0x0a, 0x0b | Speed of Fan 2 |
-| 0x0c, 0x0d | Speed of Fan 3 |
-| 0x0e, 0x0f | Speed of Fan 4 |
-| 0x10, 0x11 | Speed of Fan 5 |
-| 0x12, 0x13 | Speed of Fan 6 |
-
-### `0x20` - Detect LEDs
-
-#### `0x08` - Get LED Configuration
-
-Command:
+Data Type: `0x0f 0x00`
 
 | Byte index | Description |
 | ---------- | ----------- |
-| 0x00 | 0x08 |
-| 0x01 | 0x08 |
-| 0x02 | channel |
-
-Response:
-
-| Byte index | Description |
-| ---------- | ----------- |
-| 0x00 | 0x00 |
-| 0x01 | 0x08 |
-| 0x02 | 0x00 |
-| 0x03, 0x04 | 0x0f - Number of numbers after this |
-| 0x05 | Number of RGB channels |
-| 0x06, 0x07 | EXT RGB mode |
-| 0x08, 0x09 | EXT LED count |
-| 0x0a, 0x0b | RGB Port 1 mode |
-| 0x0c, 0x0d | RGB Port 1 LED count |
-| 0x0e, 0x0f | RGB Port 2 mode |
-| 0x10, 0x11 | RGB Port 2 LED count |
-| 0x12, 0x13 | RGB Port 3 mode |
-| 0x14, 0x15 | RGB Port 3 LED count |
-| 0x16, 0x17 | RGB Port 4 mode |
-| 0x18, 0x19 | RGB Port 4 LED count |
-| 0x1a, 0x1b | RGB Port 5 mode |
-| 0x1c, 0x1d | RGB Port 5 LED count |
-| 0x1e, 0x1f | RGB Port 6 mode |
-| 0x20, 0x21 | RGB Port 6 LED count |
+| 0x00 | Number of RGB channels |
+| 0x01, 0x02 | EXT RGB mode |
+| 0x03, 0x04 | EXT LED count |
+| 0x05, 0x06 | RGB Port 1 mode |
+| 0x07, 0x08 | RGB Port 1 LED count |
+| 0x09, 0x0a | RGB Port 2 mode |
+| 0x0b, 0x0c | RGB Port 2 LED count |
+| 0x0d, 0x0e | RGB Port 3 mode |
+| 0x0f, 0x10 | RGB Port 3 LED count |
+| 0x11, 0x12 | RGB Port 4 mode |
+| 0x13, 0x14 | RGB Port 4 LED count |
+| 0x15, 0x16 | RGB Port 5 mode |
+| 0x17, 0x18 | RGB Port 5 LED count |
+| 0x19, 0x1a | RGB Port 6 mode |
+| 0x1b, 0x1c | RGB Port 6 LED count |
 
 RGB Mode:
 
@@ -182,26 +193,12 @@ RGB Mode:
 
 ### `0x21` - Get Temperatures
 
-#### `0x08` - Get Temperatures
-
-Command:
+Data Type: `0x10 0x00`
 
 | Byte index | Description |
 | ---------- | ----------- |
-| 0x00 | 0x08 |
-| 0x01 | 0x08 |
-| 0x02 | channel |
-
-Response:
-
-| Byte index | Description |
-| ---------- | ----------- |
-| 0x00 | 0x00 |
-| 0x01 | 0x08 |
-| 0x02 | 0x00 |
-| 0x03, 0x04 | ???????? |
-| 0x05 | Number of temperature sensors |
-| 0x06 | 0x00 if connected or 0x01 if not connected |
-| 0x07, 0x08 | Temperature in Celsius (needs to be divided by 10) |
-| 0x09 | 0x00 if connected or 0x01 if not connected |
-| 0x0a, 0x0b | Temperature in Celsius (needs to be divided by 10) |
+| 0x00 | Number of temperature sensors |
+| 0x01 | 0x00 if connected or 0x01 if not connected |
+| 0x02, 0x03 | Temperature in Celsius (needs to be divided by 10) |
+| 0x04 | 0x00 if connected or 0x01 if not connected |
+| 0x05, 0x06 | Temperature in Celsius (needs to be divided by 10) |

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -56,8 +56,6 @@ class CommanderCore(UsbHidDriver):
 
             status = [('Firmware version', '{}.{}.{}'.format(*fw_version), '')]
 
-            print(self._read_data((0x18,), (0x07, 0x00)).hex(':'))
-
             # Get LEDs per fan
             res = self._read_data(_MODE_LED_COUNT, _DATA_TYPE_LED_COUNT)
 

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -1,6 +1,7 @@
 import pytest
 from collections import deque
 
+from liquidctl import ExpectationNotMet
 from liquidctl.driver.commander_core import CommanderCore
 from _testutils import noop
 
@@ -29,6 +30,9 @@ class MockCommanderCoreDevice:
         self._last_write = bytes()
         self._modes = {}
 
+        self._awake = False
+
+        self.response_prefix = ()
         self.firmware_version = (0x00, 0x00, 0x00)
         self.led_counts = (None, None, None, None, None, None, None)
         self.speeds = (None, None, None, None, None, None, None)
@@ -36,40 +40,42 @@ class MockCommanderCoreDevice:
 
     def read(self, length):
         data = bytearray([0x00, self._last_write[2], 0x00])
+        data.extend(self.response_prefix)
 
         if self._last_write[2] == 0x02:  # Firmware version
             for i in range(0, 3):
                 data.append(self.firmware_version[i])
-        if self._last_write[2] == 0x08:  # Get data
-            channel = self._last_write[3]
-            mode = self._modes[channel]
-            if mode == 0x17:  # Get speeds
-                data.extend([0x06, 0x00])
-                data.append(len(self.speeds))
-                for i in self.speeds:
-                    if i is None:
-                        data.extend([0x00, 0x00])
-                    else:
-                        data.extend(int_to_le(i))
-            elif mode == 0x20:  # LED detect
-                data.extend(int_to_le(len(self.led_counts)*2+1))
-                data.append(len(self.led_counts))
-                for i in self.led_counts:
-                    if i is None:
-                        data.extend(int_to_le(3)+int_to_le(0))
-                    else:
-                        data.extend(int_to_le(2))
-                        data.extend(int_to_le(i))
-            elif mode == 0x21:  # Get temperatures
-                data.extend([0x10, 0x00])
-                data.append(len(self.temperatures))
-                for i in self.temperatures:
-                    if i is None:
-                        data.append(1)
-                        data.extend(int_to_le(0))
-                    else:
-                        data.append(0)
-                        data.extend(int_to_le(int(i*10)))
+        if self._awake:
+            if self._last_write[2] == 0x08:  # Get data
+                channel = self._last_write[3]
+                mode = self._modes[channel]
+                if mode == 0x17:  # Get speeds
+                    data.extend([0x06, 0x00])
+                    data.append(len(self.speeds))
+                    for i in self.speeds:
+                        if i is None:
+                            data.extend([0x00, 0x00])
+                        else:
+                            data.extend(int_to_le(i))
+                elif mode == 0x20:  # LED detect
+                    data.extend([0x0f, 0x00])
+                    data.append(len(self.led_counts))
+                    for i in self.led_counts:
+                        if i is None:
+                            data.extend(int_to_le(3)+int_to_le(0))
+                        else:
+                            data.extend(int_to_le(2))
+                            data.extend(int_to_le(i))
+                elif mode == 0x21:  # Get temperatures
+                    data.extend([0x10, 0x00])
+                    data.append(len(self.temperatures))
+                    for i in self.temperatures:
+                        if i is None:
+                            data.append(1)
+                            data.extend(int_to_le(0))
+                        else:
+                            data.append(0)
+                            data.extend(int_to_le(int(i*10)))
 
         return list(data)[:length]
 
@@ -83,6 +89,8 @@ class MockCommanderCoreDevice:
                 self._modes[channel] = data[4]
         elif data[2] == 0x05 and data[3] == 0x01:
             self._modes[data[4]] = None
+        elif data[2] == 0x01 and data[3] == 0x03 and data[4] == 0x00:
+            self._awake = data[5] == 0x02
 
         return len(data)
 
@@ -118,6 +126,20 @@ def test_initialize_commander_core(commander_core_device):
     assert res[8][1] is False
     assert res[9][1] is True
 
+    # Ensure device is asleep at end
+    assert not commander_core_device.device._awake
+
+
+def test_initialize_error_commander_core(commander_core_device):
+    """This tests sends invalid data to ensure the device gets set back to hardware mode on error"""
+    commander_core_device.device.response_prefix = (0x00, 0x00)
+
+    with pytest.raises(ExpectationNotMet):
+        commander_core_device.initialize()
+
+    # Ensure device is asleep at end
+    assert not commander_core_device.device._awake
+
 
 def test_status_commander_core(commander_core_device):
     commander_core_device.device.speeds = (2357, 918, 903, 501, 1104, 1824, 104)
@@ -139,3 +161,16 @@ def test_status_commander_core(commander_core_device):
     assert res[7][1] == 12.3
     assert res[8][1] == 45.6
 
+    # Ensure device is asleep at end
+    assert not commander_core_device.device._awake
+
+
+def test_status_error_commander_core(commander_core_device):
+    """This tests sends invalid data to ensure the device gets set back to hardware mode on error"""
+    commander_core_device.device.response_prefix = (0x00, 0x00)
+
+    with pytest.raises(ExpectationNotMet):
+        commander_core_device.initialize()
+
+    # Ensure device is asleep at end
+    assert not commander_core_device.device._awake


### PR DESCRIPTION
Clean up Commander Core code and documentation.

Ensure we received the right data on read.  
The first two bytes of data in response to the read command appear to be a data type so now those are being checked.

<!-- Tags (fill and keep as many as applicable): -->

Related: #218 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [x] Update or add applicable `docs/*guide.md` device guides
- [x] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
