### PR TITLE
find_supported_devices doesn't take the class arg

### DIFF
--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -93,7 +93,7 @@ class _Base690Lc(UsbDriver):
         Automatically sets the appropriate value for `legacy_690lc`.
         """
 
-        return super().find_supported_devices(cls, legacy_690lc=cls._LEGACY_690LC, **kwargs)
+        return super().find_supported_devices(legacy_690lc=cls._LEGACY_690LC, **kwargs)
 
     def _configure_flow_control(self, clear_to_send):
         """Set the software clear-to-send flow control policy for device."""


### PR DESCRIPTION
Just a small fix to not give to the base class the cls argument

Without this fix, I have this error:

> File "/usr/lib/python3.9/site-packages/liquidctl/driver/asetek.py", line 97, in find_supported_devices
    return super().find_supported_devices(cls, legacy_690lc=cls._LEGACY_690LC, **kwargs)
TypeError: find_supported_devices() takes 1 positional argument but 2 were given

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Adhere to the [development process]
- [ ] Conform to the [style guide]
- [ ] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
