### PR TITLE
smart_device: enable new variant of Smart Device V2

### DIFF
--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -200,3 +200,6 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2006", TAG+="uacc
 
 # NZXT Smart Device V2
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="200d", TAG+="uaccess"
+
+# NZXT Smart Device V2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="200f", TAG+="uaccess"

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -331,6 +331,10 @@ class SmartDevice2(_CommonSmartDeviceDriver):
             'speed_channel_count': 3,
             'color_channel_count': 2
         }),
+        (0x1e71, 0x200f, None, 'NZXT Smart Device V2', {
+            'speed_channel_count': 3,
+            'color_channel_count': 2
+        }),
         (0x1e71, 0x2001, None, 'NZXT HUE 2', {
             'speed_channel_count': 0,
             'color_channel_count': 4


### PR DESCRIPTION
Adds support for a new Smart Device V2 as recently found in the NZXT H210i 
