### PR TITLE
changed the default number of the maximum LEDs to use for the commander node deviced

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 _Summary for the 1.7.1 release: fix a bug when colorizing the log output._
 
 Changelog since 1.7.0:
+### Changed
+ - Changed the default behavior for the default value for `maximum-leds` to be all the LED's instead of one for the Corsair Commander family of devices 
 ### Fixed
  - Fix `KeyError` when logging due to colorlog<6
  - Swap DEBUG and INFO level colors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 _Summary for the 1.7.1 release: fix a bug when colorizing the log output._
 
 Changelog since 1.7.0:
-### Changed
- - Changed the default behavior for the default value for `maximum-leds` to be all the LED's instead of one for the Corsair Commander family of devices 
 ### Fixed
  - Fix `KeyError` when logging due to colorlog<6
  - Swap DEBUG and INFO level colors

--- a/docs/corsair-commander-guide.md
+++ b/docs/corsair-commander-guide.md
@@ -136,6 +136,7 @@ _² This is not a real mode but it is fixed with RGB values of 0_
 
 To specify which LED's on the channel the effect should apply to the
 `--start-led` and `--maximum-leds` flags must be given.
+By default the effect will apply to all LED's on the channel.
 
 If you have 3 Corsair LL fans connected to channel one and you want to set
 the first and third to green and the middle to blue you can use the following

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -368,7 +368,7 @@ class CommanderPro(UsbHidDriver):
                 self._send_command(_CMD_SET_FAN_PROFILE, buf)
 
     def set_color(self, channel, mode, colors, direction='forward',
-                  speed='medium', start_led=1, maximum_leds=1, **kwargs):
+                  speed='medium', start_led=1, maximum_leds=204, **kwargs):
         """Set the color of each LED.
 
         The table bellow summarizes the available channels, modes, and their

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -67,6 +67,7 @@ _PROFILE_LENGTH = 6
 _CRITICAL_TEMPERATURE = 60
 _CRITICAL_TEMPERATURE_HIGH = 100
 _MAX_FAN_RPM = 5000             # I have no idea if this is a good value or not
+_MAX_LEDS = 204
 
 _MODES = {
     'off': 0x04,            # this is a special case of fixed
@@ -368,7 +369,7 @@ class CommanderPro(UsbHidDriver):
                 self._send_command(_CMD_SET_FAN_PROFILE, buf)
 
     def set_color(self, channel, mode, colors, direction='forward',
-                  speed='medium', start_led=1, maximum_leds=204, **kwargs):
+                  speed='medium', start_led=1, maximum_leds=_MAX_LEDS, **kwargs):
         """Set the color of each LED.
 
         The table bellow summarizes the available channels, modes, and their
@@ -402,8 +403,8 @@ class CommanderPro(UsbHidDriver):
 
         direction = map_direction(direction, _LED_DIRECTION_FORWARD, _LED_DIRECTION_BACKWARD)
         speed = _LED_SPEED_SLOW if speed == 'slow' else _LED_SPEED_FAST if speed == 'fast' else _LED_SPEED_MEDIUM
-        start_led = clamp(start_led, 1, 204) - 1
-        num_leds = clamp(maximum_leds, 1, 204 - start_led - 1)
+        start_led = clamp(start_led, 1, _MAX_LEDS) - 1
+        num_leds = clamp(maximum_leds, 1, _MAX_LEDS - start_led)
         random_colors = 0x00 if mode == 'off' or len(colors) != 0 else 0x01
         mode_val = _MODES.get(mode, -1)
 

--- a/tests/test_commander_pro.py
+++ b/tests/test_commander_pro.py
@@ -863,8 +863,8 @@ def test_set_color_hardware_default_start_end(commanderProDevice):
     assert len(sent) == 5
 
     assert sent[3].data[0] == 0x35
-    assert sent[3].data[2] == 0x00  # start led
-    assert sent[3].data[3] == 203  # num leds
+    assert sent[3].data[2] == 0  # start led
+    assert sent[3].data[3] == 204  # num leds
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 
@@ -897,8 +897,7 @@ def test_set_color_hardware_start_set(commanderProDevice, startLED, expected):
 
 
 @pytest.mark.parametrize('numLED,expected', [
-    (1, 0x01), (30, 0x1e), (96, 0x60)
-    ])
+    (1, 1), (30, 30), (96, 96), (203, 203), (204, 204), (205, 204)    ])
 def test_set_color_hardware_num_leds(commanderProDevice, numLED, expected):
     ignore = Report(0, bytes(16))
     for _ in range(6):
@@ -919,7 +918,6 @@ def test_set_color_hardware_num_leds(commanderProDevice, numLED, expected):
     assert effects is not None
     assert len(effects) == 1
 
-
 def test_set_color_hardware_too_many_leds(commanderProDevice):
     ignore = Report(0, bytes(16))
     for _ in range(6):
@@ -934,7 +932,7 @@ def test_set_color_hardware_too_many_leds(commanderProDevice):
 
     assert sent[3].data[0] == 0x35
     assert sent[3].data[2] == 0xc7  # start led
-    assert sent[3].data[3] == 0x04  # num led
+    assert sent[3].data[3] == 5  # num led
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 

--- a/tests/test_commander_pro.py
+++ b/tests/test_commander_pro.py
@@ -864,7 +864,7 @@ def test_set_color_hardware_default_start_end(commanderProDevice):
 
     assert sent[3].data[0] == 0x35
     assert sent[3].data[2] == 0x00  # start led
-    assert sent[3].data[3] == 0x01  # num leds
+    assert sent[3].data[3] == 203  # num leds
 
     effects = commanderProDevice._data.load('saved_effects', default=None)
 


### PR DESCRIPTION
Describe what the changes are meant to address.

This will change the default value for the `maximum-leds` flag to be all LED's and not just `1` LED. 

<!-- Tags (fill and keep as many as applicable): -->

Fixes: #367 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
