### PR TITLE
Adds support for the Corsair H60i Pro XT AIO device

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The following devices are supported by this version of liquidctl.  See each guid
 | AIO liquid cooler | [Corsair Hydro H80i v2, H100i v2, H115i](docs/asetek-690lc-guide.md) | USB | <sup>_Z_</sup> |
 | AIO liquid cooler | [Corsair Hydro H100i Pro, H115i Pro, H150i Pro](docs/asetek-pro-guide.md) | USB | <sup>_Ze_</sup> |
 | AIO liquid cooler | [Corsair Hydro H100i Platinum [SE], H115i Platinum](docs/corsair-platinum-pro-xt-guide.md) | USB HID | <sup>_e_</sup> |
-| AIO liquid cooler | [Corsair Hydro H100i Pro XT, H115i Pro XT, H150i Pro XT](docs/corsair-platinum-pro-xt-guide.md) | USB HID | <sup>_e_</sup> |
+| AIO liquid cooler | [Corsair Hydro H100i Pro XT, H115i Pro XT, H150i Pro XT, H60i Pro XT](docs/corsair-platinum-pro-xt-guide.md) | USB HID | <sup>_e_</sup> |
 | AIO liquid cooler | [Corsair iCUE H100i, H115i, H150i Elite Capellix](docs/corsair-commander-core-guide.md) | USB HID | <sup>_ep_</sup> |
 | AIO liquid cooler | [EVGA CLC 120 (CL12), 240, 280, 360](docs/asetek-690lc-guide.md) | USB | <sup>_Z_</sup> |
 | AIO liquid cooler | [NZXT Kraken M22](docs/kraken-x2-m2-guide.md) | USB HID | |

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -125,6 +125,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c12", TAG+="uacc
 # Corsair Hydro H150i Pro XT
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c22", TAG+="uaccess"
 
+# Corsair Hydro H60i Pro XT
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c29", TAG+="uaccess"
+
 # Corsair Hydro H80i GT
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c02", TAG+="uaccess"
 

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -314,7 +314,7 @@ Mode	#colors
 .TE
 .
 .SS Corsair Hydro H100i Platinum, H100i Platinum SE, H115i Platinum
-.SS Corsair Hydro H100i Pro XT, H115i Pro XT , H150i Pro XT
+.SS Corsair Hydro H100i Pro XT, H115i Pro XT, H150i Pro XT, H60i Pro XT
 Fan channels: \fIfan\fR, \fIfan[1\(en2]\fR; (only H150i Pro XT:) \fIfan3\fR.
 .PP
 Pump mode (\fBinitialize \-\-pump\-mode \fImode\fR): \fIquiet\fR,

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -8,6 +8,7 @@ Supported devices:
 - Corsair Hydro H100i Pro XT
 - Corsair Hydro H115i Pro XT
 - Corsair Hydro H150i Pro XT
+- Corsair Hydro H60i Pro XT
 
 Copyright (C) 2020–2021  Jonas Malaco and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
@@ -123,6 +124,8 @@ class HydroPlatinum(UsbHidDriver):
             {'fan_count': 2, 'fan_leds': 0}),
         (0x1b1c, 0x0c22, None, 'Corsair Hydro H150i Pro XT (experimental)',
             {'fan_count': 3, 'fan_leds': 0}),
+        (0x1b1c, 0x0c29, None, 'Corsair Hydro H60i Pro XT (experimental)',
+            {'fan_count': 2, 'fan_leds': 0}),
     ]
 
     @classmethod

--- a/tests/test_backward_compatibility_15.py
+++ b/tests/test_backward_compatibility_15.py
@@ -14,6 +14,7 @@ def test_matches_platinum_and_pro_xt_coolers_regardless_of_hydro(monkeypatch):
         {'vendor_id': 0x1b1c, 'product_id': 0x0c20},  # H100i Pro XT
         {'vendor_id': 0x1b1c, 'product_id': 0x0c21},  # H115i Pro XT
         {'vendor_id': 0x1b1c, 'product_id': 0x0c22},  # H150i Pro XT
+        {'vendor_id': 0x1b1c, 'product_id': 0x0c29},  # H60i Pro XT
     ]
 
     mock_skip = [

--- a/tests/test_backward_compatibility_15.py
+++ b/tests/test_backward_compatibility_15.py
@@ -43,9 +43,9 @@ def test_matches_platinum_and_pro_xt_coolers_regardless_of_hydro(monkeypatch):
     def find(match):
         return HydroPlatinum.find_supported_devices(match=match)
 
-    assert len(find('corsair hydro')) == 6
-    assert len(find('hydro')) == 6
-    assert len(find('corsair')) == 6
+    assert len(find('corsair hydro')) == 7
+    assert len(find('hydro')) == 7
+    assert len(find('corsair')) == 7
 
     assert len(find('corsair hydro h100i')) == 3
     assert len(find('hydro h100i')) == 3


### PR DESCRIPTION
Adds support for the Corsair H60i Pro XT AIO device.

Related: #387 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update the README and other applicable documentation pages
- [x] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
