### PR TITLE
Commander Core: Add fixed speed support

### DIFF
--- a/docs/corsair-commander-core-guide.md
+++ b/docs/corsair-commander-core-guide.md
@@ -18,13 +18,13 @@ Corsair Commander Core (experimental)
 ├── RGB port 4 LED count            N/A  
 ├── RGB port 5 LED count            N/A  
 ├── RGB port 6 LED count            N/A  
-├── AIO Pump                        Yes  
-├── Fan port 1                      Yes  
-├── Fan port 2                      Yes  
-├── Fan port 3                       No  
-├── Fan port 4                       No  
-├── Fan port 5                       No  
-├── Fan port 6                       No
+├── AIO port connected              Yes  
+├── Fan port 1 connected            Yes  
+├── Fan port 2 connected            Yes  
+├── Fan port 3 connected             No  
+├── Fan port 4 connected             No  
+├── Fan port 5 connected             No  
+├── Fan port 6 connected             No  
 ├── Water temperature sensor        Yes  
 └── Temperature sensor 1             No   
 ```
@@ -60,5 +60,8 @@ Currently, the pump and each fan can be set to a fixed duty cycle.
 Valid channel values are `pump`, `fanN`, where 1 <= N <= 6 is the fan number, and
 `fans`, to simultaneously configure all fans.
 
-Note: There is a hardware minimum speed when setting a fixed duty cycle. Anything below that point just runs at the minimum.
-This means that 0 is not stopped and a lot of the lower speeds mean the same speed. 
+In iCUE the pump can be set to different modes that correspond to a fixed percent that can be used in liquidctl.
+Quiet is 75%, Balanced is 85% and Extreme is 100%. 
+
+Note: The pump and some fans have a limit to how slow they can go and will not stop when set to zero.
+This is a hardware limitation that cannot be changed.

--- a/docs/corsair-commander-core-guide.md
+++ b/docs/corsair-commander-core-guide.md
@@ -10,7 +10,7 @@ The device should be initialized every time it is powered on.
 ```
 # liquidctl initialize
 Corsair Commander Core (experimental)
-├── Firmware version            1.6.135  
+├── Firmware version            2.6.201  
 ├── AIO LED count                    29  
 ├── RGB port 1 LED count              8  
 ├── RGB port 2 LED count              8  
@@ -18,6 +18,13 @@ Corsair Commander Core (experimental)
 ├── RGB port 4 LED count            N/A  
 ├── RGB port 5 LED count            N/A  
 ├── RGB port 6 LED count            N/A  
+├── AIO Pump                        Yes  
+├── Fan port 1                      Yes  
+├── Fan port 2                      Yes  
+├── Fan port 3                       No  
+├── Fan port 4                       No  
+├── Fan port 5                       No  
+├── Fan port 6                       No
 ├── Water temperature sensor        Yes  
 └── Temperature sensor 1             No   
 ```
@@ -39,3 +46,17 @@ Corsair Commander Core (experimental)
 ├── Fan speed 6             0  rpm
 └── Water temperature    35.8  °C
 ```
+
+## Programming the pump and fan speeds
+
+Currently, the pump and each fan can be set to a fixed duty cycle. 
+
+```
+# liquidctl set fan1 speed 70
+                ^^^^       ^^
+               channel    duty
+```
+
+Valid channel values are `pump`, `fanN`, where 1 <= N <= 6 is the fan number, and
+`fans`, to simultaneously configure all fans.
+

--- a/docs/corsair-commander-core-guide.md
+++ b/docs/corsair-commander-core-guide.md
@@ -60,3 +60,5 @@ Currently, the pump and each fan can be set to a fixed duty cycle.
 Valid channel values are `pump`, `fanN`, where 1 <= N <= 6 is the fan number, and
 `fans`, to simultaneously configure all fans.
 
+Note: There is a hardware minimum speed when setting a fixed duty cycle. Anything below that point just runs at the minimum.
+This means that 0 is not stopped and a lot of the lower speeds mean the same speed. 

--- a/docs/developer/protocol/commander_core.md
+++ b/docs/developer/protocol/commander_core.md
@@ -122,8 +122,9 @@ Command:
 | 0x01 | 0x06 |
 | 0x02 | Channel |
 | 0x03, 0x04 | Data length  |
-| 0x05, 0x06 | 00:00 Unknown |
-| 0x07-... | Data |
+| 0x05, 0x06 | 00:00 Unknown (Before data length starts) |
+| 0x07, 0x08 | Data Type (Included in data length) |
+| 0x09-... | Data |
 
 ### `0x08` - Read
 
@@ -159,8 +160,26 @@ Data Type: `0x06 0x00`
 | 0x05, 0x06 | Speed of Fan 2 |
 | 0x07, 0x08 | Speed of Fan 3 |
 | 0x09, 0x0a | Speed of Fan 4 |
-| 0x0b, 0x1c | Speed of Fan 5 |
-| 0x0d, 0x1e | Speed of Fan 6 |
+| 0x0b, 0x0c | Speed of Fan 5 |
+| 0x0d, 0x0e | Speed of Fan 6 |
+
+### `0x1a` - Connected Speed Devices
+
+Data Type: `0x09 0x00`
+
+Connection State: 0x07 if connected or 0x01 if not connected
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | Number of Ports |
+| 0x01 | AIO/EXT Connection State|
+| 0x02 | Fan 1 Connection State |
+| 0x03 | Fan 2 Connection State |
+| 0x04 | Fan 3 Connection State |
+| 0x05 | Fan 4 Connection State |
+| 0x06 | Fan 5 Connection State |
+| 0x07 | Fan 6 Connection State |
+
 
 ### `0x20` - Connected LEDs
 
@@ -202,3 +221,42 @@ Data Type: `0x10 0x00`
 | 0x02, 0x03 | Temperature in Celsius (needs to be divided by 10) |
 | 0x04 | 0x00 if connected or 0x01 if not connected |
 | 0x05, 0x06 | Temperature in Celsius (needs to be divided by 10) |
+
+### `0x60 0x6d` - Hardware Speed Device Mode
+
+Data Type: `0x03 0x00`
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | Number of Ports |
+| 0x01 | AIO/EXT Speed Mode |
+| 0x02 | Fan 1 Speed Mode |
+| 0x03 | Fan 2 Speed Mode |
+| 0x04 | Fan 3 Speed Mode |
+| 0x05 | Fan 4 Speed Mode |
+| 0x06 | Fan 5 Speed Mode |
+| 0x07 | Fan 6 Speed Mode |
+
+Speed Modes:
+
+| Mode | Description |
+| ---- | ----------- |
+| 0x00 | Fixed percentage |
+| 0x02 | Fan percentage fan curve |
+
+Note: This list is not complete and currently only contains what has been confirmed so far
+
+### `0x61 0x6d` - Hardware Fixed Speed (Percentage)
+
+Data Type: `0x04 0x00`
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | Number of Ports |
+| 0x01, 0x02 | Speed as percentage for AIO/EXT port |
+| 0x03, 0x04 | Speed as percentage for Fan 1 |
+| 0x05, 0x06 | Speed as percentage for Fan 2 |
+| 0x07, 0x08 | Speed as percentage for Fan 3 |
+| 0x09, 0x0a | Speed as percentage for Fan 4 |
+| 0x0b, 0x0c | Speed as percentage for Fan 5 |
+| 0x0d, 0x0e | Speed as percentage for Fan 6 |

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -218,6 +218,8 @@ Internal data used by some drivers.
 .
 .SH DEVICE SPECIFICS
 .
+.SS Corsair Commander Core
+Cooling channels: \fIpump\fR, \fIfans\fR, \fIfan[1\-6]\fR.
 .SS Corsair Commander Pro
 .SS Corsair Lighting Node Pro
 .SS Corsair Lighting Node Core

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -225,7 +225,7 @@ class CommanderCore(UsbHidDriver):
         buf[4: 4 + len(data_type)] = data_type
         buf[4 + len(data_type):] = data
 
-        self._send_command(_CMD_WRITE, buf).hex(":")
+        self._send_command(_CMD_WRITE, buf)
 
     @staticmethod
     def _parse_channels(channel):

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -79,7 +79,7 @@ class CommanderCore(UsbHidDriver):
             res = self._read_data(_MODE_CONNECTED_SPEEDS, _DATA_TYPE_CONNECTED_SPEEDS)
             num_devices = res[0]
             for i in range(0, num_devices):
-                label = 'AIO Pump' if i == 0 else f'Fan port {i}'
+                label = 'AIO port connected' if i == 0 else f'Fan port {i} connected'
                 status += [(label, res[i + 1] == 0x07, '')]
 
             # Get what temp sensors are connected

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -14,7 +14,7 @@ from contextlib import contextmanager
 
 from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.error import ExpectationNotMet, NotSupportedByDriver
-from liquidctl.util import u16le_from
+from liquidctl.util import clamp, u16le_from
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -23,20 +23,29 @@ _RESPONSE_LENGTH = 1024
 
 _INTERFACE_NUMBER = 0
 
+_FAN_COUNT = 6
+
 _CMD_WAKE = (0x01, 0x03, 0x00, 0x02)
 _CMD_SLEEP = (0x01, 0x03, 0x00, 0x01)
 _CMD_GET_FIRMWARE = (0x02, 0x13)
 _CMD_RESET = (0x05, 0x01, 0x00)
 _CMD_SET_MODE = (0x0d, 0x00)
-_CMD_GET = (0x08, 0x00)
+_CMD_READ = (0x08, 0x00)
+_CMD_WRITE = (0x06, 0x00)
 
 _MODE_LED_COUNT = (0x20,)
 _MODE_GET_SPEEDS = (0x17,)
 _MODE_GET_TEMPS = (0x21,)
+_MODE_CONNECTED_SPEEDS = (0x1a,)
+_MODE_HW_SPEED_MODE = (0x60, 0x6d)
+_MODE_HW_FIXED_PERCENT = (0x61, 0x6d)
 
 _DATA_TYPE_SPEEDS = (0x06, 0x00)
 _DATA_TYPE_LED_COUNT = (0x0f, 0x00)
 _DATA_TYPE_TEMPS = (0x10, 0x00)
+_DATA_TYPE_CONNECTED_SPEEDS = (0x09, 0x00)
+_DATA_TYPE_HW_SPEED_MODE = (0x03, 0x00)
+_DATA_TYPE_HW_FIXED_PERCENT = (0x04, 0x00)
 
 
 class CommanderCore(UsbHidDriver):
@@ -58,14 +67,20 @@ class CommanderCore(UsbHidDriver):
 
             # Get LEDs per fan
             res = self._read_data(_MODE_LED_COUNT, _DATA_TYPE_LED_COUNT)
-
             num_devices = res[0]
             led_data = res[1:1 + num_devices * 4]
             for i in range(0, num_devices):
-                connected = u16le_from(led_data, offset=i*4) == 2
-                num_leds = u16le_from(led_data, offset=i*4+2)
+                connected = u16le_from(led_data, offset=i * 4) == 2
+                num_leds = u16le_from(led_data, offset=i * 4 + 2)
                 label = 'AIO LED count' if i == 0 else f'RGB port {i} LED count'
                 status += [(label, num_leds if connected else None, '')]
+
+            # Get what fans are connected
+            res = self._read_data(_MODE_CONNECTED_SPEEDS, _DATA_TYPE_CONNECTED_SPEEDS)
+            num_devices = res[0]
+            for i in range(0, num_devices):
+                label = 'AIO Pump' if i == 0 else f'Fan port {i}'
+                status += [(label, res[i + 1] == 0x07, '')]
 
             # Get what temp sensors are connected
             for i, temp in enumerate(self._get_temps()):
@@ -99,7 +114,36 @@ class CommanderCore(UsbHidDriver):
         raise NotSupportedByDriver
 
     def set_fixed_speed(self, channel, duty, **kwargs):
-        raise NotSupportedByDriver
+        if channel == 'pump':
+            channels = [0]
+        elif channel == "fans":
+            channels = range(1, _FAN_COUNT + 1)
+        elif channel.startswith("fan") and channel.isnumeric() and 0 < int(channel[3:]) <= _FAN_COUNT:
+            channels = [int(channel[3:])]
+        else:
+            fan_names = ['fan' + str(i) for i in range(1, _FAN_COUNT + 1)]
+            fan_names_part = '", "'.join(fan_names)
+            raise ValueError(f'unknown channel, should be one of: "pump", "{fan_names_part}" or "fans"')
+
+        with self._wake_device_context():
+            # Set hardware speed mode
+            res = self._read_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE)
+            device_count = res[0]
+
+            data = bytearray(res[0:device_count + 1])
+            for chan in channels:
+                data[chan + 1] = 0x00  # Set the device's hardware mode to fixed percent
+            self._write_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE, data)
+
+            # Set speed
+            res = self._read_data(_MODE_HW_FIXED_PERCENT, _DATA_TYPE_HW_FIXED_PERCENT)
+            device_count = res[0]
+            data = bytearray(res[0:device_count * 2 + 1])
+            duty_le = int.to_bytes(clamp(duty, 0, 100), length=2, byteorder="little", signed=False)
+            for chan in channels:
+                i = chan * 2 + 1
+                data[i: i + 2] = duty_le  # Update the device speed
+            self._write_data(_MODE_HW_FIXED_PERCENT, _DATA_TYPE_HW_FIXED_PERCENT, data)
 
     @classmethod
     def probe(cls, handle, **kwargs):
@@ -116,9 +160,9 @@ class CommanderCore(UsbHidDriver):
         res = self._read_data(_MODE_GET_SPEEDS, _DATA_TYPE_SPEEDS)
 
         num_speeds = res[0]
-        speeds_data = res[1:1 + num_speeds*2]
+        speeds_data = res[1:1 + num_speeds * 2]
         for i in range(0, num_speeds):
-            speeds.append(u16le_from(speeds_data, offset=i*2))
+            speeds.append(u16le_from(speeds_data, offset=i * 2))
 
         return speeds
 
@@ -128,11 +172,11 @@ class CommanderCore(UsbHidDriver):
         res = self._read_data(_MODE_GET_TEMPS, _DATA_TYPE_TEMPS)
 
         num_temps = res[0]
-        temp_data = res[1:1 + num_temps*3]
+        temp_data = res[1:1 + num_temps * 3]
         for i in range(0, num_temps):
-            connected = temp_data[i*3] == 0x00
+            connected = temp_data[i * 3] == 0x00
             if connected:
-                temps.append(u16le_from(temp_data, offset=i*3+1)/10)
+                temps.append(u16le_from(temp_data, offset=i * 3 + 1) / 10)
             else:
                 temps.append(None)
 
@@ -141,7 +185,7 @@ class CommanderCore(UsbHidDriver):
     def _read_data(self, mode, data_type):
         self._send_command(_CMD_RESET)
         self._send_command(_CMD_SET_MODE, mode)
-        raw_data = self._send_command(_CMD_GET)
+        raw_data = self._send_command(_CMD_READ)
 
         if tuple(raw_data[3:5]) != data_type:
             raise ExpectationNotMet('device returned incorrect data type')
@@ -178,3 +222,16 @@ class CommanderCore(UsbHidDriver):
             yield
         finally:
             self._send_command(_CMD_SLEEP)
+
+    def _write_data(self, mode, data_type, data):
+        self._read_data(mode, data_type)  # Will ensure we are writing the correct data type to avoid breakage
+
+        self._send_command(_CMD_RESET)
+        self._send_command(_CMD_SET_MODE, mode)
+
+        buf = bytearray(len(data) + len(data_type) + 4)
+        buf[0: 2] = int.to_bytes(len(data) + 2, length=2, byteorder="little", signed=False)
+        buf[4: 4 + len(data_type)] = data_type
+        buf[4 + len(data_type):] = data
+
+        self._send_command(_CMD_WRITE, buf).hex(":")

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -4,6 +4,7 @@ from collections import deque
 from liquidctl import ExpectationNotMet
 from liquidctl.driver.commander_core import CommanderCore
 from _testutils import noop
+from liquidctl.util import u16le_from
 
 
 def int_to_le(num, length=2, byteorder='little', signed=False):
@@ -14,7 +15,7 @@ class MockCommanderCoreDevice:
     def __init__(self):
         self.vendor_id = 0x1b1c
         self.product_id = 0x0c1c
-        self.address = "addr"
+        self.address = 'addr'
         self.release_number = None
         self.serial_number = None
         self.bus = None
@@ -35,7 +36,9 @@ class MockCommanderCoreDevice:
         self.response_prefix = ()
         self.firmware_version = (0x00, 0x00, 0x00)
         self.led_counts = (None, None, None, None, None, None, None)
+        self.speeds_mode = (0, 0, 0, 0, 0, 0, 0)
         self.speeds = (None, None, None, None, None, None, None)
+        self.fixed_speeds = (0, 0, 0, 0, 0, 0, 0)
         self.temperatures = (None, None)
 
     def read(self, length):
@@ -49,48 +52,89 @@ class MockCommanderCoreDevice:
             if self._last_write[2] == 0x08:  # Get data
                 channel = self._last_write[3]
                 mode = self._modes[channel]
-                if mode == 0x17:  # Get speeds
-                    data.extend([0x06, 0x00])
-                    data.append(len(self.speeds))
-                    for i in self.speeds:
-                        if i is None:
-                            data.extend([0x00, 0x00])
-                        else:
+                if mode[1] == 0x00:
+                    if mode[0] == 0x17:  # Get speeds
+                        data.extend([0x06, 0x00])
+                        data.append(len(self.speeds))
+                        for i in self.speeds:
+                            if i is None:
+                                data.extend([0x00, 0x00])
+                            else:
+                                data.extend(int_to_le(i))
+                    elif mode[0] == 0x1a:  # Speed devices connected
+                        data.extend([0x09, 0x00])
+                        data.append(len(self.speeds))
+                        for i in self.speeds:
+                            data.extend([0x01 if i is None else 0x07])
+                    elif mode[0] == 0x20:  # LED detect
+                        data.extend([0x0f, 0x00])
+                        data.append(len(self.led_counts))
+                        for i in self.led_counts:
+                            if i is None:
+                                data.extend(int_to_le(3)+int_to_le(0))
+                            else:
+                                data.extend(int_to_le(2))
+                                data.extend(int_to_le(i))
+                    elif mode[0] == 0x21:  # Get temperatures
+                        data.extend([0x10, 0x00])
+                        data.append(len(self.temperatures))
+                        for i in self.temperatures:
+                            if i is None:
+                                data.append(1)
+                                data.extend(int_to_le(0))
+                            else:
+                                data.append(0)
+                                data.extend(int_to_le(int(i*10)))
+                    else:
+                        raise NotImplementedError(f'Read for {mode.hex(":")}')
+                elif mode[1] == 0x6d:
+                    if mode[0] == 0x60:
+                        data.extend([0x03, 0x00])
+                        data.append(len(self.speeds_mode))
+                        for i in self.speeds_mode:
+                            data.append(i)
+                    elif mode[0] == 0x61:
+                        data.extend([0x04, 0x00])
+                        data.append(len(self.fixed_speeds))
+                        for i in self.fixed_speeds:
                             data.extend(int_to_le(i))
-                elif mode == 0x20:  # LED detect
-                    data.extend([0x0f, 0x00])
-                    data.append(len(self.led_counts))
-                    for i in self.led_counts:
-                        if i is None:
-                            data.extend(int_to_le(3)+int_to_le(0))
-                        else:
-                            data.extend(int_to_le(2))
-                            data.extend(int_to_le(i))
-                elif mode == 0x21:  # Get temperatures
-                    data.extend([0x10, 0x00])
-                    data.append(len(self.temperatures))
-                    for i in self.temperatures:
-                        if i is None:
-                            data.append(1)
-                            data.extend(int_to_le(0))
-                        else:
-                            data.append(0)
-                            data.extend(int_to_le(int(i*10)))
+                    else:
+                        raise NotImplementedError(f'Read for {mode.hex(":")}')
+                else:
+                    raise NotImplementedError(f'Read for {mode.hex(":")}')
 
         return list(data)[:length]
 
     def write(self, data):
         data = bytes(data)  # ensure data is convertible to bytes
         self._last_write = data
+        if data[0] != 0x00 or data[1] != 0x08:
+            raise ValueError('Start of packets going out should be 00:08')
 
         if data[2] == 0x0d:
             channel = data[3]
             if self._modes[channel] is None:
-                self._modes[channel] = data[4]
+                self._modes[channel] = data[4:6]
         elif data[2] == 0x05 and data[3] == 0x01:
             self._modes[data[4]] = None
         elif data[2] == 0x01 and data[3] == 0x03 and data[4] == 0x00:
             self._awake = data[5] == 0x02
+        elif self._awake:
+            if data[2] == 0x06:  # Write command
+                channel = data[3]
+                mode = self._modes[channel]
+                length = u16le_from(data[4:6])
+                data_type = data[8:10]
+                written_data = data[10:8+length]
+                if mode[1] == 0x6d:
+                    if mode[0] == 0x60 and list(data_type) == [0x03, 0x00]:
+                        self.speeds_mode = tuple(written_data[i+1] for i in range(0, written_data[0]))
+                    elif mode[0] == 0x61 and list(data_type) == [0x04, 0x00]:
+                        self.fixed_speeds = tuple(u16le_from(written_data[i*2+1:i*2+3]) for i in range(0, written_data[0]))
+                    else:
+                        raise NotImplementedError('Invalid Write command')
+                else:
+                    raise NotImplementedError('Invalid Write command')
 
         return len(data)
 
@@ -105,11 +149,12 @@ def commander_core_device():
 
 def test_initialize_commander_core(commander_core_device):
     commander_core_device.device.firmware_version = (0x01, 0x02, 0x21)
+    commander_core_device.device.speeds = (None, 104, None, None, None, None, 918)
     commander_core_device.device.led_counts = (27, None, 1, 2, 4, 8, 16)
     commander_core_device.device.temperatures = (None, 45.6)
     res = commander_core_device.initialize()
 
-    assert len(res) == 10
+    assert len(res) == 17
 
     assert res[0][1] == '1.2.33'  # Firmware
 
@@ -122,9 +167,18 @@ def test_initialize_commander_core(commander_core_device):
     assert res[6][1] == 8
     assert res[7][1] == 16
 
+    # Speed devices connected
+    assert not res[8][1]
+    assert res[9][1]
+    assert not res[10][1]
+    assert not res[11][1]
+    assert not res[12][1]
+    assert not res[13][1]
+    assert res[14][1]
+
     # Temperature sensors connected
-    assert res[8][1] is False
-    assert res[9][1] is True
+    assert not res[15][1]
+    assert res[16][1]
 
     # Ensure device is asleep at end
     assert not commander_core_device.device._awake
@@ -174,3 +228,57 @@ def test_status_error_commander_core(commander_core_device):
 
     # Ensure device is asleep at end
     assert not commander_core_device.device._awake
+
+
+def test_set_fixed_speed_fan2_commander_core(commander_core_device):
+    """This tests setting the speed of a single channel"""
+    commander_core_device.device.speeds_mode = (1, 2, 3, 4, 5, 6, 7)
+    commander_core_device.device.fixed_speeds = (8, 9, 10, 11, 12, 13, 14)
+
+    commander_core_device.set_fixed_speed('fan2', 95)
+
+    assert commander_core_device.device.speeds_mode == (1, 2, 0, 4, 5, 6, 7)
+    assert commander_core_device.device.fixed_speeds == (8, 9, 95, 11, 12, 13, 14)
+    # Ensure device is asleep at end
+    assert not commander_core_device.device._awake
+
+
+def test_set_fixed_speed_fans_commander_core(commander_core_device):
+    """This tests setting the speed of all the fans"""
+    commander_core_device.device.speeds_mode = (1, 2, 3, 4, 5, 6, 7)
+    commander_core_device.device.fixed_speeds = (8, 9, 10, 11, 12, 13, 14)
+
+    commander_core_device.set_fixed_speed('fans', 61)
+
+    assert commander_core_device.device.speeds_mode == (1, 0, 0, 0, 0, 0, 0)
+    assert commander_core_device.device.fixed_speeds == (8, 61, 61, 61, 61, 61, 61)
+    # Ensure device is asleep at end
+    assert not commander_core_device.device._awake
+
+
+def test_set_fixed_speed_error_commander_core(commander_core_device):
+    """This tests sends invalid data to ensure the device gets set back to hardware mode on error"""
+    commander_core_device.device.response_prefix = (0x00, 0x00)
+
+    with pytest.raises(ExpectationNotMet):
+        commander_core_device.set_fixed_speed('fan1', 95)
+
+    # Ensure device is asleep at end
+    assert not commander_core_device.device._awake
+
+
+def test_parse_channels_commander_core():
+    """This test will go through and thoroughly test CommanderCore._parse_channels so we don't have to in other tests"""
+    tests = [
+        ('pump', [0]), ('fans', [1, 2, 3, 4, 5, 6]),
+        ('fan1', [1]), ('fan2', [2]), ('fan3', [3]), ('fan4', [4]), ('fan5', [5]), ('fan6', [6])
+             ]
+
+    for (val, answer) in tests:
+        assert list(CommanderCore._parse_channels(val)) == answer
+
+
+def test_parse_channels_error_commander_core():
+    """This tests to make sure we get an error with an invalid channel"""
+    with pytest.raises(ValueError):
+        CommanderCore._parse_channels('fan')


### PR DESCRIPTION
Adds pump and fan detection to initialize.
Adds support for setting a fixed percentage as the speed to the pump and each fan.

<!-- Tags (fill and keep as many as applicable): -->

Related: #218 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [X] Adhere to the [development process]
- [X] Conform to the [style guide]
- [X] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update the README and other applicable documentation pages
- [x] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [x] Update or add applicable `docs/*guide.md` device guides
- [x] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [x] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
