### PR TITLE
Recognize devices with a hwmon driver

### DIFF
--- a/extra/completions/liquidctl.bash
+++ b/extra/completions/liquidctl.bash
@@ -80,6 +80,7 @@ _liquidctl_main() {
     --single-12v-ocp
     --legacy-690lc
     --non-volatile
+    --force
     "
 
     local options_with_args="

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -37,6 +37,7 @@ Other device options:
   --temperature-sensor <number>  The temperature sensor number for the Commander Pro
   --legacy-690lc                 Use Asetek 690LC in legacy mode (old Krakens)
   --non-volatile                 Store on non-volatile controller memory
+  --force                        Force a normally disabled action
   --unsafe <features>            Comma-separated bleeding-edge features to enable
 
 Other interface options:
@@ -112,6 +113,7 @@ _PARSE_ARG = {
     '--pump-mode': str.lower,
     '--legacy-690lc': bool,
     '--non-volatile': bool,
+    '--force': bool,
     '--unsafe': lambda x: x.lower().split(','),
     '--verbose': bool,
     '--debug': bool,

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -456,21 +456,21 @@ def main():
             # each backend API returns a different subtype of OSError (OSError,
             # usb.core.USBError or PermissionError) for permission issues
             if err.errno in [errno.EACCES, errno.EPERM]:
-                log_error(err, f'Error: insufficient permissions to access {dev.description}')
+                log_error(err, f'insufficient permissions to access {dev.description}')
             elif err.args == ('open failed', ):
-                log_error(err, f'Error: could not open {dev.description}, possibly due to insufficient permissions')
+                log_error(err, f'could not open {dev.description}, possibly due to insufficient permissions')
             else:
-                log_error(err, f'Unexpected OS error with {dev.description}', append_err=True)
+                log_error(err, f'unexpected OS error with {dev.description}', append_err=True)
         except NotSupportedByDevice as err:
-            log_error(err, f'Error: operation not supported by {dev.description}')
+            log_error(err, f'operation not supported by {dev.description}')
         except NotSupportedByDriver as err:
-            log_error(err, f'Error: operation not supported by driver for {dev.description}')
+            log_error(err, f'operation not supported by driver for {dev.description}')
         except UnsafeFeaturesNotEnabled as err:
             features = ','.join(err.args)
-            log_error(err, f'Error: missing --unsafe features for {dev.description}: {features!r}')
+            log_error(err, f'missing --unsafe features for {dev.description}: {features!r}')
             _LOGGER.error('More information is provided in the corresponding device guide')
         except Exception as err:
-            log_error(err, f'Unexpected error with {dev.description}', append_err=True)
+            log_error(err, f'unexpected error with {dev.description}', append_err=True)
 
     if errors:
         sys.exit(errors)

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -107,25 +107,37 @@ class CorsairHidPsu(UsbHidDriver):
         self.fpowin115 = fpowin115
         self.fpowin230 = fpowin230
 
-    def initialize(self, single_12v_ocp=False, **kwargs):
+    def initialize(self, single_12v_ocp=False, force=False, **kwargs):
         """Initialize the device.
 
         Necessary to receive non-zero value responses from the device.
-
-        Note: replies before calling this function appear to follow the
-        pattern <address> <cte 0xfe> <zero> <zero> <padding...>.
         """
 
-        self.device.clear_enqueued_reports()
-        self._write([0xfe, 0x03])  # not well understood
-        self._read()
+        # replies before calling this function appear to follow the pattern
+        # <address> <cte 0xfe> <zero> <zero> <padding...>
+
+        if self._hwmon:
+            if not force:
+                _LOGGER.warning('%s is bound to %s kernel driver, OCP and fan modes not changed',
+                                self.description, self._hwmon.module)
+                return
+            else:
+                _LOGGER.warning('forcing re-initialization of %s despite %s kernel driver',
+                                self.description, self._hwmon.module)
+
+        self._write([0xfe, 0x03])
+        _ = self._read()
+
+        # don't check current OCP and fan control modes in case we're racing
+        # with a hwmon driver and the returned values, which aren't available
+        # through hwmon, are corrupted by the race
+
         mode = OCPMode.SINGLE_RAIL if single_12v_ocp else OCPMode.MULTI_RAIL
-        if mode != self._get_12v_ocp_mode():
-            _LOGGER.info('changing +12V OCP mode to %s', mode)
-            self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, [mode.value])
-        if self._get_fan_control_mode() != FanControlMode.HARDWARE:
-            _LOGGER.info('resetting fan control to hardware mode')
-            self._set_fan_control_mode(FanControlMode.HARDWARE)
+        _LOGGER.info('setting +12V OCP mode to %s', mode)
+        self._exec(WriteBit.WRITE, _CORSAIR_12V_OCP_MODE, [mode.value])
+
+        _LOGGER.info('resetting fan control to hardware mode')
+        self._set_fan_control_mode(FanControlMode.HARDWARE)
 
     def get_status(self, **kwargs):
         """Get a status report.

--- a/liquidctl/driver/hwmon.py
+++ b/liquidctl/driver/hwmon.py
@@ -1,0 +1,53 @@
+# uses the psf/black style
+
+import logging
+import sys
+from pathlib import Path
+
+_LOGGER = logging.getLogger(__name__)
+_IS_LINUX = sys.platform == "linux"
+
+
+class HwmonDevice:
+    """Unstable API."""
+
+    __slots__ = [
+        "module",
+        "path",
+    ]
+
+    def __init__(self, module, path):
+        self.module = module
+        self.path = path
+
+    @property
+    def name(self):
+        return self.path.name
+
+    @classmethod
+    def from_hidraw(cls, path):
+        """Find the `HwmonDevice` for `path`."""
+
+        if not _IS_LINUX:
+            return None
+
+        if not path.startswith(b"/dev/hidraw"):
+            _LOGGER.debug("cannot search hwmon device for %s: unsupported path", path)
+            return None
+
+        path = path.decode()
+        name = path[5:]
+        class_path = Path("/sys/class/hidraw", name)
+
+        sys_device = class_path / "device"
+        hwmon_devices = (sys_device / "hwmon").iterdir()
+
+        hwmon_path = next(hwmon_devices)
+
+        if next(hwmon_devices, None) is not None:
+            _LOGGER.debug("cannot pick hwmon device for %s: more than one alternative", path)
+            return None
+
+        module = (sys_device / "driver" / "module").readlink().name
+
+        return HwmonDevice(module, hwmon_path)

--- a/liquidctl/driver/hwmon.py
+++ b/liquidctl/driver/hwmon.py
@@ -24,6 +24,9 @@ class HwmonDevice:
     def name(self):
         return self.path.name
 
+    def has_attribute(self, name):
+        return (self.path / name).is_file()
+
     def get_int(self, name):
         value = (self.path / name).read_text().rstrip()
         _LOGGER.debug("read %s: %s", name, value)

--- a/liquidctl/driver/hwmon.py
+++ b/liquidctl/driver/hwmon.py
@@ -24,6 +24,11 @@ class HwmonDevice:
     def name(self):
         return self.path.name
 
+    def get_int(self, name):
+        value = (self.path / name).read_text().rstrip()
+        _LOGGER.debug("read %s: %s", name, value)
+        return int(value)
+
     @classmethod
     def from_hidraw(cls, path):
         """Find the `HwmonDevice` for `path`."""

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -500,7 +500,42 @@ class SmartDevice2(_CommonSmartDeviceDriver):
         self._read_until({b'\x11\x01': parse_firm_info, b'\x21\x03': parse_led_info})
         return sorted(status)
 
-    def get_status(self, **kwargs):
+    def _get_status_directly(self):
+        status = []
+
+        def parse_fan_info(msg):
+            mode_offset = 16
+            rpm_offset = 24
+            duty_offset = 40
+            noise_offset = 56
+            raw_modes = [None, 'DC', 'PWM']
+
+            for i, _ in enumerate(self._speed_channels):
+                mode = raw_modes[msg[mode_offset + i]]
+                status.append((f'Fan {i + 1} speed', msg[rpm_offset + 1] << 8 | msg[rpm_offset], 'rpm'))
+                status.append((f'Fan {i + 1} duty', msg[duty_offset + i], '%'))
+                status.append((f'Fan {i + 1} control mode', mode, ''))
+                rpm_offset += 2
+            status.append(('Noise level', msg[noise_offset], 'dB'))
+
+        self.device.clear_enqueued_reports()
+        self._read_until({b'\x67\x02': parse_fan_info})
+        return sorted(status)
+
+    def _get_status_from_hwmon(self):
+        ret = []
+        modes = ['DC', 'PWM']
+
+        for n in range(1, len(self._speed_channels) + 1):
+            ret.append((f'Fan {n} speed', self._hwmon.get_int(f'fan{n}_input'), 'rpm')),
+            ret.append((f'Fan {n} duty', self._hwmon.get_int(f'pwm{n}_input') * 100. / 255, '%')),
+            ret.append((f'Fan {n} control mode', modes[self._hwmon.get_int(f'pwm{n}_mode')], '')),
+
+        # noise level is not available through hwmon, but also not very accurate or useful
+
+        return sorted(ret)
+
+    def get_status(self, force=False, **kwargs):
         """Get a status report.
 
         Returns a list of (key, value, unit) tuples.
@@ -508,22 +543,17 @@ class SmartDevice2(_CommonSmartDeviceDriver):
 
         if not self._speed_channels:
             return []
-        status = []
 
-        def parse_fan_info(msg):
-            rpm_offset = 24
-            duty_offset = 40
-            noise_offset = 56
-            for i, _ in enumerate(self._speed_channels):
-                if ((msg[rpm_offset] != 0x0) and (msg[rpm_offset + 1] != 0x0)):
-                    status.append((f'Fan {i + 1} speed', msg[rpm_offset + 1] << 8 | msg[rpm_offset], 'rpm'))
-                    status.append((f'Fan {i + 1} duty', msg[duty_offset + i], '%'))
-                rpm_offset += 2
-            status.append(('Noise level', msg[noise_offset], 'dB'))
+        if self._hwmon and not force:
+            _LOGGER.info('%s is bound to %s kernel driver, reading status from hwmon',
+                         self.description, self._hwmon.module)
+            return self._get_status_from_hwmon()
 
-        self.device.clear_enqueued_reports()
-        self._read_until({b'\x67\x02': parse_fan_info})
-        return sorted(status)
+        if self._hwmon:
+            _LOGGER.warning('directly reading the status from %s despite %s kernel driver',
+                            self.description, self._hwmon.module)
+
+        return self._get_status_directly()
 
     def _read_until(self, parsers):
         for _ in range(self._MAX_READ_ATTEMPTS):

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -244,12 +244,21 @@ class SmartDevice(_CommonSmartDeviceDriver):
                           for i in range(color_channel_count)}
         super().__init__(device, description, speed_channels, color_channels, **kwargs)
 
-    def initialize(self, **kwargs):
+    def initialize(self, force=False, **kwargs):
         """Initialize the device.
 
         Detects all connected fans and LED accessories, and allows subsequent
         calls to get_status.
         """
+
+        if self._hwmon and not force:
+            _LOGGER.info('%s is bound to %s kernel driver, assuming it is already initialized',
+                         self.description, self._hwmon.module)
+            return None
+
+        if self._hwmon:
+            _LOGGER.warning('forcing re-initialization of %s despite %s kernel driver',
+                            self.description, self._hwmon.module)
 
         self._write([0x1, 0x5c])  # initialize/detect connected devices and their type
         self._write([0x1, 0x5d])  # start reporting

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -101,6 +101,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 
 import itertools
 import logging
+import time
 
 from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.error import NotSupportedByDevice
@@ -254,14 +255,28 @@ class SmartDevice(_CommonSmartDeviceDriver):
         if self._hwmon and not force:
             _LOGGER.info('%s is bound to %s kernel driver, assuming it is already initialized',
                          self.description, self._hwmon.module)
-            return None
+        else:
+            if self._hwmon:
+                _LOGGER.warning('forcing re-initialization of %s despite %s kernel driver',
+                                self.description, self._hwmon.module)
+            self._write([0x1, 0x5c])  # initialize/detect connected devices and their type
+            self._write([0x1, 0x5d])  # start reporting
+            self.device.clear_enqueued_reports()
 
-        if self._hwmon:
-            _LOGGER.warning('forcing re-initialization of %s despite %s kernel driver',
-                            self.description, self._hwmon.module)
+        msg = self.device.read(self._READ_LENGTH)
 
-        self._write([0x1, 0x5c])  # initialize/detect connected devices and their type
-        self._write([0x1, 0x5d])  # start reporting
+        fw = '{}.{}.{}'.format(msg[0xb], msg[0xc] << 8 | msg[0xd], msg[0xe])
+        ret = [('Firmware version', fw, '')]
+
+        if self._color_channels:
+            lcount = msg[0x11]
+            ret.append(('LED accessories', lcount, ''))
+            if lcount > 0:
+                ltype, lsize = [('HUE+ Strip', 10), ('Aer RGB', 8)][msg[0x10] >> 3]
+                ret.append(('LED accessory type', ltype, ''))
+                ret.append(('LED count (total)', lcount*lsize, ''))
+
+        return ret
 
     def get_status(self, **kwargs):
         """Get a status report.
@@ -286,20 +301,6 @@ class SmartDevice(_CommonSmartDeviceDriver):
                 (f'Fan {num} control mode', [None, 'DC', 'PWM'][state], ''),
             ]
             noise.append(msg[1])
-
-            if i != 0:
-                continue
-
-            fw = '{}.{}.{}'.format(msg[0xb], msg[0xc] << 8 | msg[0xd], msg[0xe])
-            status.append(('Firmware version', fw, ''))
-
-            if self._color_channels:
-                lcount = msg[0x11]
-                status.append(('LED accessories', lcount, ''))
-                if lcount > 0:
-                    ltype, lsize = [('HUE+ Strip', 10), ('Aer RGB', 8)][msg[0x10] >> 3]
-                    status.append(('LED accessory type', ltype, ''))
-                    status.append(('LED count (total)', lcount*lsize, ''))
 
         status.append(('Noise level', round(sum(noise)/len(noise)), 'dB'))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pytest.ini_options]
+addopts = "--doctest-modules -ra"
+
 [tool.black]
 line-length = 100
 target-version = ["py37"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,6 @@ extend-exclude = '''
   | (^/tests/test_hydro_platinum\.py$)
   | (^/tests/test_keyval\.py$)
   | (^/tests/test_kraken2\.py$)
-  | (^/tests/test_kraken3\.py$)
   | (^/tests/test_nvidia\.py$)
   | (^/tests/test_nzxt_epsu\.py$)
   | (^/tests/test_rgb_fusion2\.py$)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,6 @@ extend-exclude = '''
   | (^/tests/test_nvidia\.py$)
   | (^/tests/test_nzxt_epsu\.py$)
   | (^/tests/test_rgb_fusion2\.py$)
-  | (^/tests/test_smart_device2\.py$)
   | (^/tests/test_smart_device\.py$)
   | (^/tests/test_smbus\.py$)
   | (^/tests/test_usb\.py$)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,0 @@
-[pytest]
-addopts = --doctest-modules -ra

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -24,13 +24,14 @@ class MockRuntimeStorage(RuntimeStorage):
 
 class MockHidapiDevice:
     def __init__(self, vendor_id=None, product_id=None, release_number=None,
-                 serial_number=None, bus=None, address=None):
+                 serial_number=None, bus=None, address=None, path=None):
         self.vendor_id = vendor_id
         self.product_id = product_id
         self.release_number = release_number
         self.serial_number = serial_number
         self.bus = bus
         self.address = address
+        self.path = path or b'<placeholder path>'
         self.port = None
 
         self.open = noop

--- a/tests/test_backward_compatibility_11.py
+++ b/tests/test_backward_compatibility_11.py
@@ -23,14 +23,14 @@ class _MockPyUsbHandle(usb.core.Device):
 
 def _mock_enumerate(vendor_id=0, product_id=0):
     return [
-        {'vendor_id': vendor_id, 'product_id': product_id, 'serial_number': '987654321'},
-        {'vendor_id': vendor_id, 'product_id': product_id, 'serial_number': '123456789'}
+        {'vendor_id': vendor_id, 'product_id': product_id, 'serial_number': '_21', 'path': b'/_21'},
+        {'vendor_id': vendor_id, 'product_id': product_id, 'serial_number': '_89', 'path': b'/_89'}
     ]
 
 
 def test_construct_with_raw_pyusb_handle(monkeypatch):
     monkeypatch.setattr(hid, 'enumerate', _mock_enumerate)
-    pyusb_handle = _MockPyUsbHandle(serial_number='123456789')
+    pyusb_handle = _MockPyUsbHandle(serial_number='_89')
     liquidctl_device = Kraken2(pyusb_handle, 'Some device')
     assert liquidctl_device.device.vendor_id == pyusb_handle.idVendor, \
         '<driver instance>.device points to incorrect physical device'

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -16,6 +16,7 @@ class MockCommanderCoreDevice:
         self.vendor_id = 0x1b1c
         self.product_id = 0x0c1c
         self.address = 'addr'
+        self.path = b'path'
         self.release_number = None
         self.serial_number = None
         self.bus = None

--- a/tests/test_hwmon.py
+++ b/tests/test_hwmon.py
@@ -25,3 +25,7 @@ def test_has_path(mock_hwmon):
 
 def test_has_name(mock_hwmon):
     assert mock_hwmon.name == "hwmon7"
+
+
+def test_gets_int(mock_hwmon):
+    assert mock_hwmon.get_int("fan1_input") == 1499

--- a/tests/test_hwmon.py
+++ b/tests/test_hwmon.py
@@ -27,5 +27,13 @@ def test_has_name(mock_hwmon):
     assert mock_hwmon.name == "hwmon7"
 
 
+def test_checks_existing_attribute(mock_hwmon):
+    assert mock_hwmon.has_attribute("fan1_input")
+
+
+def test_checks_non_existing_attribute(mock_hwmon):
+    assert not mock_hwmon.has_attribute("bubble1_input")
+
+
 def test_gets_int(mock_hwmon):
     assert mock_hwmon.get_int("fan1_input") == 1499

--- a/tests/test_hwmon.py
+++ b/tests/test_hwmon.py
@@ -1,0 +1,27 @@
+# uses the psf/black style
+
+import pytest
+
+from liquidctl.driver.hwmon import HwmonDevice
+
+
+@pytest.fixture
+def mock_hwmon(tmp_path):
+    hwmon = tmp_path / "hwmon7"
+    hwmon.mkdir()
+
+    (hwmon / "fan1_input").write_text("1499\n")
+
+    return HwmonDevice("mock_module", hwmon)
+
+
+def test_has_module(mock_hwmon):
+    assert mock_hwmon.module == "mock_module"
+
+
+def test_has_path(mock_hwmon):
+    assert mock_hwmon.path.is_dir()
+
+
+def test_has_name(mock_hwmon):
+    assert mock_hwmon.name == "hwmon7"

--- a/tests/test_keyval.py
+++ b/tests/test_keyval.py
@@ -131,9 +131,9 @@ def test_fs_backend_load_store_is_atomic(tmpdir):
     store.store('key', 42)
 
     ps = [
-        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .5)),
-        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .5)),
-        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .5)),
+        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .2)),
+        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .2)),
+        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .2)),
     ]
 
     start_time = time.monotonic()
@@ -147,7 +147,7 @@ def test_fs_backend_load_store_is_atomic(tmpdir):
     elapsed = (time.monotonic() - start_time)
 
     assert store.load('key') == 45
-    assert elapsed >= .5 * len(ps)
+    assert elapsed >= .2 * len(ps)
 
 
 def test_fs_backend_loads_honor_load_store_locking(tmpdir):
@@ -157,7 +157,7 @@ def test_fs_backend_loads_honor_load_store_locking(tmpdir):
     store.store('key', 42)
 
     ps = [
-        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .5)),
+        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .2)),
         Process(target=_fs_mp_check_key, args=(run_dir, 'prefix', 'key', 43)),
     ]
 
@@ -176,7 +176,7 @@ def test_fs_backend_stores_honor_load_store_locking(tmpdir):
     store.store('key', 42)
 
     ps = [
-        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .5)),
+        Process(target=_fs_mp_increment_key, args=(run_dir, 'prefix', 'key', .2)),
         Process(target=_fs_mp_store_key, args=(run_dir, 'prefix', 'key', -1)),
     ]
 
@@ -190,7 +190,7 @@ def test_fs_backend_stores_honor_load_store_locking(tmpdir):
     ps[1].join()
 
     elapsed = (time.monotonic() - start_time)
-    assert elapsed >= .5
+    assert elapsed >= .2
 
     ps[0].join()
     assert store.load('key') == -1

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -3,6 +3,7 @@
 import pytest
 from _testutils import MockHidapiDevice, Report
 
+from liquidctl.driver.hwmon import HwmonDevice
 from liquidctl.driver.kraken3 import KrakenX3, KrakenZ3
 from liquidctl.driver.kraken3 import (
     _COLOR_CHANNELS_KRAKENX,
@@ -71,6 +72,21 @@ class MockKraken(MockHidapiDevice):
                 reply[15 + 2 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_LOGO.value
         self.preload_read(Report(0, reply))
         return super().write(data)
+
+
+@pytest.mark.parametrize("has_hwmon,force", [(False, False), (True, True), (True, False)])
+def test_krakenx3_initializes(mock_krakenx3, has_hwmon, force, tmp_path):
+    if has_hwmon:
+        mock_krakenx3._hwmon = HwmonDevice("mock_module", tmp_path)
+
+    # TODO check the result
+    _ = mock_krakenx3.initialize(force=force)
+
+    writes = len(mock_krakenx3.device.sent)
+    if not has_hwmon or force:
+        assert writes == 4
+    else:
+        assert writes == 2
 
 
 def test_krakenx3_parses_status_fields(mock_krakenx3):

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -1,49 +1,60 @@
+# uses the psf/black style
+
 import pytest
 from _testutils import MockHidapiDevice, Report
 
 from liquidctl.driver.kraken3 import KrakenX3, KrakenZ3
-from liquidctl.driver.kraken3 import _COLOR_CHANNELS_KRAKENX
-from liquidctl.driver.kraken3 import _SPEED_CHANNELS_KRAKENX
-from liquidctl.driver.kraken3 import _SPEED_CHANNELS_KRAKENZ
+from liquidctl.driver.kraken3 import (
+    _COLOR_CHANNELS_KRAKENX,
+    _SPEED_CHANNELS_KRAKENX,
+    _COLOR_CHANNELS_KRAKENZ,
+    _SPEED_CHANNELS_KRAKENZ,
+)
 from liquidctl.util import HUE2_MAX_ACCESSORIES_IN_CHANNEL as MAX_ACCESSORIES
 from liquidctl.util import Hue2Accessory
 
 
 # https://github.com/liquidctl/liquidctl/issues/160#issuecomment-664044103
-_SAMPLE_STATUS = bytes.fromhex(
-    '7502200036000b51535834353320012101a80635350000000000000000000000'
-    '0000000000000000000000000000000000000000000000000000000000000000'
+SAMPLE_STATUS = bytes.fromhex(
+    "7502200036000B51535834353320012101A80635350000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
 )
 # https://github.com/liquidctl/liquidctl/issues/160#issue-665781804
-_FAULTY_STATUS = bytes.fromhex(
-    '7502200036000b5153583435332001ffffcc0a64640000000000000000000000'
-    '0000000000000000000000000000000000000000000000000000000000000000'
+FAULTY_STATUS = bytes.fromhex(
+    "7502200036000B5153583435332001FFFFCC0A64640000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
 )
 
 
 @pytest.fixture
-def mockKrakenXDevice():
-    device = _MockKrakenDevice(raw_led_channels=len(_COLOR_CHANNELS_KRAKENX) - 1)
-    dev = KrakenX3(device, 'Corsair Kraken X73',
-                   speed_channels=_SPEED_CHANNELS_KRAKENX,
-                   color_channels=_COLOR_CHANNELS_KRAKENX)
+def mock_krakenx3():
+    raw = MockKraken(raw_led_channels=len(_COLOR_CHANNELS_KRAKENX) - 1)
+    dev = KrakenX3(
+        raw,
+        "Mock Kraken X73",
+        speed_channels=_SPEED_CHANNELS_KRAKENX,
+        color_channels=_COLOR_CHANNELS_KRAKENX,
+    )
 
     dev.connect()
     return dev
 
 
 @pytest.fixture
-def mockKrakenZDevice():
-    device = _MockKrakenDevice(raw_led_channels=0)
-    dev = KrakenZ3(device, 'Mock Kraken Z73',
-                   speed_channels=_SPEED_CHANNELS_KRAKENZ,
-                   color_channels={})
+def mock_krakenz3():
+    raw = MockKraken(raw_led_channels=1)
+    dev = KrakenZ3(
+        raw,
+        "Mock Kraken Z73",
+        speed_channels=_SPEED_CHANNELS_KRAKENZ,
+        color_channels=_COLOR_CHANNELS_KRAKENZ,
+    )
 
     dev.connect()
     return dev
 
 
-class _MockKrakenDevice(MockHidapiDevice):
+class MockKraken(MockHidapiDevice):
     def __init__(self, raw_led_channels):
         super().__init__()
         self.raw_led_channels = raw_led_channels
@@ -59,42 +70,38 @@ class _MockKrakenDevice(MockHidapiDevice):
                 reply[15 + 1 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_RING.value
                 reply[15 + 2 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_LOGO.value
         self.preload_read(Report(0, reply))
+        return super().write(data)
 
 
-def test_kracken_x_device_parses_status_fields(mockKrakenXDevice):
-    mockKrakenXDevice.device.preload_read(Report(0, _SAMPLE_STATUS))
-    temperature, pump_speed, pump_duty = mockKrakenXDevice.get_status()
-    assert temperature == ('Liquid temperature', 33.1, '°C')
-    assert pump_speed == ('Pump speed', 1704, 'rpm')
-    assert pump_duty == ('Pump duty', 53, '%')
+def test_krakenx3_parses_status_fields(mock_krakenx3):
+    mock_krakenx3.device.preload_read(Report(0, SAMPLE_STATUS))
+
+    temperature, pump_speed, pump_duty = mock_krakenx3.get_status()
+
+    assert temperature == ("Liquid temperature", 33.1, "°C")
+    assert pump_speed == ("Pump speed", 1704, "rpm")
+    assert pump_duty == ("Pump duty", 53, "%")
 
 
-def test_kracken_x_device_warns_if_faulty_temperature(mockKrakenXDevice, caplog):
-    mockKrakenXDevice.device.preload_read(Report(0, _FAULTY_STATUS))
-    mockKrakenXDevice.get_status()
+def test_krakenx3_warns_if_faulty_temperature(mock_krakenx3, caplog):
+    mock_krakenx3.device.preload_read(Report(0, FAULTY_STATUS))
 
-    assert 'unexpected temperature reading' in caplog.text
+    _ = mock_krakenx3.get_status()
+    assert "unexpected temperature reading" in caplog.text
 
 
-def test_kracken_x_device_not_totally_broken(mockKrakenXDevice):
+def test_krakenx3_not_totally_broken(mock_krakenx3):
     """Reasonable example calls to untested APIs do not raise exceptions."""
-    dev = mockKrakenXDevice
-
-    dev.initialize()
-    dev.set_color(channel='ring', mode='fixed', colors=iter([[3, 2, 1]]),
-                  speed='fastest')
-    dev.set_speed_profile(channel='pump',
-                          profile=iter([(20, 20), (30, 50), (40, 100)]))
-    dev.set_fixed_speed(channel='pump', duty=50)
+    mock_krakenx3.initialize()
+    mock_krakenx3.set_color(channel="ring", mode="fixed", colors=iter([[3, 2, 1]]), speed="fastest")
+    mock_krakenx3.set_speed_profile(channel="pump", profile=iter([(20, 20), (30, 50), (40, 100)]))
+    mock_krakenx3.set_fixed_speed(channel="pump", duty=50)
 
 
-def test_kracken_z_device_not_totally_broken(mockKrakenZDevice):
+def test_krakenz3_not_totally_broken(mock_krakenz3):
     """Reasonable example calls to untested APIs do not raise exceptions."""
-    dev = mockKrakenZDevice
-
-    dev.initialize()
-    dev.device.preload_read(Report(0, _SAMPLE_STATUS))
-    dev.get_status()
-    dev.set_speed_profile(channel='fan',
-                          profile=iter([(20, 20), (30, 50), (40, 100)]))
-    dev.set_fixed_speed(channel='pump', duty=50)
+    mock_krakenz3.initialize()
+    mock_krakenz3.device.preload_read(Report(0, SAMPLE_STATUS))
+    _ = mock_krakenz3.get_status()
+    mock_krakenz3.set_speed_profile(channel="fan", profile=iter([(20, 20), (30, 50), (40, 100)]))
+    mock_krakenz3.set_fixed_speed(channel="pump", duty=50)

--- a/tests/test_smart_device2.py
+++ b/tests/test_smart_device2.py
@@ -1,10 +1,12 @@
+# uses the psf/black style
+
 import pytest
 from _testutils import MockHidapiDevice, Report
 
 from liquidctl.driver.smart_device import SmartDevice2
 
 
-class _MockSmartDevice2(MockHidapiDevice):
+class MockSmart2(MockHidapiDevice):
     def __init__(self, raw_speed_channels, raw_led_channels):
         super().__init__()
         self.raw_speed_channels = raw_speed_channels
@@ -24,37 +26,31 @@ class _MockSmartDevice2(MockHidapiDevice):
 
 
 @pytest.fixture
-def mockSmartDevice2():
-    device = _MockSmartDevice2(raw_speed_channels=3, raw_led_channels=2)
-    dev = SmartDevice2(device, 'mock NZXT Smart Device V2', speed_channel_count=3, color_channel_count=2)
+def mock_smart2():
+    raw = MockSmart2(raw_speed_channels=3, raw_led_channels=2)
+    dev = SmartDevice2(raw, "Mock Smart Device V2", speed_channel_count=3, color_channel_count=2)
     dev.connect()
     return dev
 
 
-# class methods
-def test_smart_device2_constructor(mockSmartDevice2):
-
-    assert mockSmartDevice2._speed_channels == {
-            'fan1': (0, 0, 100),
-            'fan2': (1, 0, 100),
-            'fan3': (2, 0, 100),
-        }
-
-    assert mockSmartDevice2._color_channels == {
-            'led1': (0b001),
-            'led2': (0b010),
-            'sync': (0b011),
-        }
+def test_constructor_sets_up_all_channels(mock_smart2):
+    assert mock_smart2._speed_channels == {
+        "fan1": (0, 0, 100),
+        "fan2": (1, 0, 100),
+        "fan3": (2, 0, 100),
+    }
+    assert mock_smart2._color_channels == {
+        "led1": (0b001),
+        "led2": (0b010),
+        "sync": (0b011),
+    }
 
 
-def test_smart_device2_not_totally_broken(mockSmartDevice2):
-    dev = mockSmartDevice2
-
-    dev.initialize()
-    dev.device.preload_read(Report(0, [0x67, 0x02] + [0] * 62))
-    dev.get_status()
-
-    dev.set_color(channel='led1', mode='breathing', colors=iter([[142, 24, 68]]),
-                  speed='fastest')
-
-    dev.set_fixed_speed(channel='fan3', duty=50)
+def test_not_totally_broken(mock_smart2):
+    _ = mock_smart2.initialize()
+    mock_smart2.device.preload_read(Report(0, [0x67, 0x02] + [0] * 62))
+    _ = mock_smart2.get_status()
+    mock_smart2.set_color(
+        channel="led1", mode="breathing", colors=iter([[142, 24, 68]]), speed="fastest"
+    )
+    mock_smart2.set_fixed_speed(channel="fan3", duty=50)

--- a/tests/test_smart_device2.py
+++ b/tests/test_smart_device2.py
@@ -6,6 +6,13 @@ from _testutils import MockHidapiDevice, Report
 from liquidctl.driver.hwmon import HwmonDevice
 from liquidctl.driver.smart_device import SmartDevice2
 
+# https://github.com/liquidctl/liquidctl/issues/292#issuecomment-786876335
+# (adapted: set control mode for connected fan to PWM)
+SAMPLE_STATUS = bytes.fromhex(
+    "67023a003f00185732533230312003000200000000000000fc03000000000000"
+    "0000000000000000322828000000000032282800000000003000000000000000"
+)
+
 
 class MockSmart2(MockHidapiDevice):
     def __init__(self, raw_speed_channels, raw_led_channels):
@@ -48,6 +55,63 @@ def test_initializes(mock_smart2, has_hwmon, force, tmp_path):
         assert writes == 4
     else:
         assert writes == 2
+
+
+@pytest.mark.parametrize("has_hwmon,force", [(False, False), (True, True)])
+def test_reads_status_directly(mock_smart2, has_hwmon, force):
+    if has_hwmon:
+        mock_smart2._hwmon = HwmonDevice(None, None)
+
+    mock_smart2.device.preload_read(Report(0, SAMPLE_STATUS))
+
+    expected = [
+        ("Fan 1 speed", 1020, "rpm"),
+        ("Fan 1 duty", 50, "%"),
+        ("Fan 1 control mode", "PWM", ""),
+        ("Fan 2 speed", 0, "rpm"),
+        ("Fan 2 duty", 40, "%"),
+        ("Fan 2 control mode", None, ""),
+        ("Fan 3 speed", 0, "rpm"),
+        ("Fan 3 duty", 40, "%"),
+        ("Fan 3 control mode", None, ""),
+        ("Noise level", 48, "dB"),
+    ]
+
+    got = mock_smart2.get_status(force=force)
+
+    assert sorted(got) == sorted(expected)
+
+
+def test_reads_status_from_hwmon(mock_smart2, tmp_path):
+    mock_smart2._hwmon = HwmonDevice("mock_module", tmp_path)
+    (tmp_path / "pwm1_enable").write_text("1\n")
+    (tmp_path / "pwm2_enable").write_text("0\n")
+    (tmp_path / "pwm3_enable").write_text("0\n")
+    (tmp_path / "pwm1_mode").write_text("1\n")
+    (tmp_path / "pwm2_mode").write_text("0\n")
+    (tmp_path / "pwm3_mode").write_text("0\n")
+    (tmp_path / "pwm1_input").write_text("127\n")
+    (tmp_path / "pwm2_input").write_text("102\n")
+    (tmp_path / "pwm3_input").write_text("102\n")
+    (tmp_path / "fan1_input").write_text("1020\n")
+    (tmp_path / "fan2_input").write_text("0\n")
+    (tmp_path / "fan3_input").write_text("0\n")
+
+    expected = [
+        ("Fan 1 speed", 1020, "rpm"),
+        ("Fan 1 duty", pytest.approx(50, rel=1.0 / 255), "%"),
+        ("Fan 1 control mode", "PWM", ""),
+        ("Fan 2 speed", 0, "rpm"),
+        ("Fan 2 duty", pytest.approx(40, rel=1.0 / 255), "%"),
+        ("Fan 2 control mode", "DC", ""),
+        ("Fan 3 speed", 0, "rpm"),
+        ("Fan 3 duty", pytest.approx(40, rel=1.0 / 255), "%"),
+        ("Fan 3 control mode", "DC", ""),
+    ]
+
+    got = mock_smart2.get_status()
+
+    assert sorted(got) == sorted(expected)
 
 
 def test_constructor_sets_up_all_channels(mock_smart2):

--- a/tests/test_smart_device2.py
+++ b/tests/test_smart_device2.py
@@ -3,6 +3,7 @@
 import pytest
 from _testutils import MockHidapiDevice, Report
 
+from liquidctl.driver.hwmon import HwmonDevice
 from liquidctl.driver.smart_device import SmartDevice2
 
 
@@ -23,6 +24,7 @@ class MockSmart2(MockHidapiDevice):
                 reply[15 + 1 * 6] = 0x10
                 reply[15 + 2 * 6] = 0x11
         self.preload_read(Report(reply[0], reply[1:]))
+        return super().write(data)
 
 
 @pytest.fixture
@@ -31,6 +33,21 @@ def mock_smart2():
     dev = SmartDevice2(raw, "Mock Smart Device V2", speed_channel_count=3, color_channel_count=2)
     dev.connect()
     return dev
+
+
+@pytest.mark.parametrize("has_hwmon,force", [(False, False), (True, True), (True, False)])
+def test_initializes(mock_smart2, has_hwmon, force, tmp_path):
+    if has_hwmon:
+        mock_smart2._hwmon = HwmonDevice("mock_module", tmp_path)
+
+    # TODO check the result
+    _ = mock_smart2.initialize(force=force)
+
+    writes = len(mock_smart2.device.sent)
+    if not has_hwmon or force:
+        assert writes == 4
+    else:
+        assert writes == 2
 
 
 def test_constructor_sets_up_all_channels(mock_smart2):


### PR DESCRIPTION
The Linux kernel has hwmon support for a few devices we also support.

Take the presence of these and future hwmon drivers into account:

- [x] detect and log when there's a kernel hwmon driver bound
- [x] don't re-initialize devices when there's a conflict with a hwmon driver
    - [x] (kernel does not initialize) NZXT Kraken X42/X52/X62/X72 (`nzxt-kraken2`)
    - [x] NZXT Kraken X53/X63/X73 (`nzxt-kraken3`)
    - [x] (liquidctl only reads) Corsair Commander Pro/Obsidian 1000D (`corsair-cpro`)
    - [x] NZXT Grid+ V3/Smart Device (V1) (`nzxt-grid3`)
    - [x] NZXT Smart Device V2/RGB & Fan Controller (`nzxt-smart2`)
    - [x] Corsair HX750i, HX850i, HX1000i, HX1200i, RM650i, RM750i, RM850i, RM1000i (`corsair-psu`)
- [x] allow _forced_ re-initialization of devices with a hwmon driver
- [ ] get status from hwmon, if possible
    - [x] NZXT Kraken X42/X52/X62/X72 (`nzxt-kraken2`)
    - [x] NZXT Kraken X53/X63/X73 (`nzxt-kraken3`)
    - [x] NZXT Grid+ V3/Smart Device (V1) (`nzxt-grid3`)
    - [x] NZXT Smart Device V2/RGB & Fan Controller (`nzxt-smart2`)
    - [ ] Corsair Commander Pro/Obsidian 1000D (`corsair-cpro`)
    - [ ] Corsair HX750i, HX850i, HX1000i, HX1200i, RM650i, RM750i, RM850i, RM1000i (`corsair-psu`)
- [ ] warn when there are significant conflicts on other APIs

Other notes/to-dos:

- [ ] revisit `--force` option name
- [ ] consider a standardized `_hwmon` property
- [ ] consider only populatating `_hwmon` in `connect()`
- [ ] for consistency, consider renaming `<Driver>.device` to `_device`, `_raw` or `_(hid|usb|<etc>)`

Left for later:

- when feasible, use the hwmon interface for `set_fixed_speed()` and/or `set_speed_profile()`

<!-- Tags (fill and keep as many as applicable): -->

Related: #403 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Adhere to the [development process]
- [ ] Conform to the [style guide] (with changes currently in `staging`: adoption of black [for new files])
- [ ] Verify that the changes work as expected on real hardware
    - [ ] NZXT Kraken X42/X52/X62/X72 (`nzxt-kraken2`)
    - [ ] NZXT Kraken X53/X63/X73 (`nzxt-kraken3`)
    - [ ] NZXT Grid+ V3/Smart Device (V1) (`nzxt-grid3`)
    - [ ] NZXT Smart Device V2/RGB & Fan Controller (`nzxt-smart2`)
    - [ ] (no changes) Corsair Commander Pro/Obsidian 1000D (`corsair-cpro`)
    - [ ] Corsair HX750i, HX850i, HX1000i, HX1200i, RM650i, RM750i, RM850i, RM1000i (`corsair-psu`)
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
