### PR TITLE
445 remove _input suffix for pwm hwmon duty sources

### DIFF
--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -245,7 +245,7 @@ class KrakenX3(UsbHidDriver):
         return [
             (_STATUS_TEMPERATURE, self._hwmon.get_int('temp1_input') * 1e-3, '°C'),
             (_STATUS_PUMP_SPEED, self._hwmon.get_int('fan1_input'), 'rpm'),
-            (_STATUS_PUMP_DUTY, self._hwmon.get_int('pwm1_input') * 100. / 255, '%'),
+            (_STATUS_PUMP_DUTY, self._hwmon.get_int('pwm1') * 100. / 255, '%'),
         ]
 
     def get_status(self, direct_access=False, **kwargs):
@@ -254,11 +254,11 @@ class KrakenX3(UsbHidDriver):
         Returns a list of `(property, value, unit)` tuples.
         """
 
-        # no driver currently supports pwm1_input, so silently fallback to
+        # no driver currently supports pwm1, so silently fallback to
         # direct mode if it isn't available; for the same reason, also don't
         # yet issue a warning when directly accessing the device
 
-        if self._hwmon and not direct_access and self._hwmon.has_attribute('pwm1_input'):
+        if self._hwmon and not direct_access and self._hwmon.has_attribute('pwm1'):
             _LOGGER.info('bound to %s kernel driver, reading status from hwmon', self._hwmon.module)
             return self._get_status_from_hwmon()
 

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -549,7 +549,7 @@ class SmartDevice2(_BaseSmartDevice):
 
         for n in range(1, len(self._speed_channels) + 1):
             ret.append((f'Fan {n} speed', self._hwmon.get_int(f'fan{n}_input'), 'rpm')),
-            ret.append((f'Fan {n} duty', self._hwmon.get_int(f'pwm{n}_input') * 100. / 255, '%')),
+            ret.append((f'Fan {n} duty', self._hwmon.get_int(f'pwm{n}') * 100. / 255, '%')),
             ret.append((f'Fan {n} control mode', modes[self._hwmon.get_int(f'pwm{n}_mode')], '')),
 
         # noise level is not available through hwmon, but also not very accurate or useful


### PR DESCRIPTION

Fixes: #445 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data


[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
