### PR TITLE
Aquacomputer D5 Next sensor reading support

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | USB & USB HID | <sup>_p_</sup> |
 | DDR4 DRAM          | [Corsair Vengeance RGB](docs/ddr4-guide.md) | SMBus | <sup>_Uax_</sup> |
 | DDR4 DRAM          | [Generic DDR4 temperature sensor](docs/ddr4-guide.md) | SMBus | <sup>_Uax_</sup> |
-| Fan/LED controller | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | USB HID | <sup>_ehn_</sup> |
+| Fan/pump controller | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | USB HID | <sup>_ehn_</sup> |
 | Fan/LED controller | [Corsair Commander Pro](docs/corsair-commander-guide.md) | USB HID | <sup>_h_</sup> |
 | Fan/LED controller | [Corsair Commander Core](docs/corsair-commander-core-guide.md) | USB HID | <sup>_ep_</sup> |
 | Fan/LED controller | [Corsair Commander Core XT](docs/corsair-commander-core-guide.md) | USB HID | <sup>_enp_</sup> |
@@ -136,7 +136,7 @@ The notes are sorted alphabetically, major (upper case) notes before minor
 | Fan/LED controller | [NZXT RGB & Fan Controller](docs/nzxt-hue2-guide.md) | USB HID | <sup>_h_</sup> |
 | Fan/LED controller | [NZXT Smart Device](docs/nzxt-smart-device-v1-guide.md) | USB HID | <sup>_h_</sup> |
 | Fan/LED controller | [NZXT Smart Device V2](docs/nzxt-hue2-guide.md) | USB HID | <sup>_h_</sup> |
-| Fan/AIO controller | [NZXT H1 V2](docs/nzxt-hue2-guide.md) | USB HID | <sup>_e_</sup> |
+| Fan/pump controller | [NZXT H1 V2](docs/nzxt-hue2-guide.md) | USB HID | <sup>_e_</sup> |
 | Graphics card RGB  | [Select ASUS GTX and RTX cards](docs/nvidia-guide.md) | I²C | <sup>_Ux_</sup> |
 | Graphics card RGB  | [Select EVGA GTX 1070, 1070 Ti and 1080 cards](docs/nvidia-guide.md) | I²C | <sup>_Ux_</sup> |
 | Motherboard        | [ASUS Aura LED motherboards](docs/asus-aura-led-guide.md) | USB HID | <sup>_e_</sup> |

--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ The notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | USB & USB HID | <sup>_p_</sup> |
 | DDR4 DRAM          | [Corsair Vengeance RGB](docs/ddr4-guide.md) | SMBus | <sup>_Uax_</sup> |
 | DDR4 DRAM          | [Generic DDR4 temperature sensor](docs/ddr4-guide.md) | SMBus | <sup>_Uax_</sup> |
+| Fan/LED controller | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | USB HID | <sup>_hn_</sup> |
 | Fan/LED controller | [Corsair Commander Pro](docs/corsair-commander-guide.md) | USB HID | <sup>_h_</sup> |
 | Fan/LED controller | [Corsair Commander Core](docs/corsair-commander-core-guide.md) | USB HID | <sup>_ep_</sup> |
 | Fan/LED controller | [Corsair Commander Core XT](docs/corsair-commander-core-guide.md) | USB HID | <sup>_enp_</sup> |

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | USB & USB HID | <sup>_p_</sup> |
 | DDR4 DRAM          | [Corsair Vengeance RGB](docs/ddr4-guide.md) | SMBus | <sup>_Uax_</sup> |
 | DDR4 DRAM          | [Generic DDR4 temperature sensor](docs/ddr4-guide.md) | SMBus | <sup>_Uax_</sup> |
-| Fan/LED controller | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | USB HID | <sup>_hn_</sup> |
+| Fan/LED controller | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | USB HID | <sup>_ehn_</sup> |
 | Fan/LED controller | [Corsair Commander Pro](docs/corsair-commander-guide.md) | USB HID | <sup>_h_</sup> |
 | Fan/LED controller | [Corsair Commander Core](docs/corsair-commander-core-guide.md) | USB HID | <sup>_ep_</sup> |
 | Fan/LED controller | [Corsair Commander Core XT](docs/corsair-commander-core-guide.md) | USB HID | <sup>_enp_</sup> |

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,7 @@ Device guides
 
 <!-- sort -->
 
+- [Aquacomputer D5 Next watercooling pump](aquacomputer-d5next-guide.md)
 - [Asetek 690LC liquid coolers](asetek-690lc-guide.md)
 - [Asetek Pro liquid coolers](asetek-pro-guide.md)
 - [Corsair Commander Code](corsair-commander-core-guide.md)

--- a/docs/aquacomputer-d5next-guide.md
+++ b/docs/aquacomputer-d5next-guide.md
@@ -3,12 +3,18 @@ _Driver API and source code available in [`liquidctl.driver.aquacomputer`](../li
 
 ## Initialization
 
-Initialization is not required. The pump sends a status HID report every second as soon as it's connected.
+Initialization is _currently_ not required, but is recommended. It outputs the firmware version:
+
+```
+Aquacomputer D5 Next
+└── Firmware version    1023
+```
+
+The pump automatically sends a status HID report every second as soon as it's connected.
 
 ## Monitoring
 
-The D5 Next exposes sensor values such as liquid temperature and two groups of fan sensors, for the pump and the optionally connected fan. These groups provide RPM speed, voltage, current and power readings. The
-pump additionally exposes +5V and +12V voltage rail readings.
+The D5 Next exposes sensor values such as liquid temperature and two groups of fan sensors, for the pump and the optionally connected fan. These groups provide RPM speed, voltage, current and power readings. The pump additionally exposes +5V and +12V voltage rail readings:
 
 ```
 # liquidctl status

--- a/docs/aquacomputer-d5next-guide.md
+++ b/docs/aquacomputer-d5next-guide.md
@@ -7,7 +7,8 @@ Initialization is _currently_ not required, but is recommended. It outputs the f
 
 ```
 Aquacomputer D5 Next
-└── Firmware version    1023
+├── Firmware version           1023
+└── Serial number       03500-24905
 ```
 
 The pump automatically sends a status HID report every second as soon as it's connected.

--- a/docs/aquacomputer-d5next-guide.md
+++ b/docs/aquacomputer-d5next-guide.md
@@ -1,0 +1,27 @@
+# Aquacomputer D5 Next watercooling pump
+_Driver API and source code available in [`liquidctl.driver.aquacomputer`](../liquidctl/driver/aquacomputer.py)._
+
+## Initialization
+
+Initialization is not required. The pump sends a status HID report every second as soon as it's connected.
+
+## Monitoring
+
+The D5 Next exposes sensor values such as liquid temperature and two groups of fan sensors, for the pump and the optionally connected fan. These groups provide RPM speed, voltage, current and power readings. The
+pump additionally exposes +5V and +12V voltage rail readings.
+
+```
+# liquidctl status
+Aquacomputer D5 Next
+├── Liquid temperature     26.9  °C
+├── Pump speed             1968  rpm
+├── Pump power             2.56  W
+├── Pump voltage          12.04  V
+├── Pump current           0.21  A
+├── Fan speed               373  rpm
+├── Fan power              0.38  W
+├── Fan voltage           12.06  V
+├── Fan current            0.03  A
+├── +5V voltage            5.01  V
+└── +12V voltage          12.06  V
+```

--- a/docs/developer/protocol/aquacomputer.md
+++ b/docs/developer/protocol/aquacomputer.md
@@ -1,0 +1,51 @@
+# Aquacomputer protocols
+
+Aquacomputer devices share the same HID report philosophy:
+
+* A sensor report with ID `0x01` is sent every second to the host, detailing current sensor readings
+* A control/configuration report that can be requested and sent back to the device, controlling its settings and mode of operation. Contains a CRC-16/USB checksum in the last two bytes
+* A save report, which is always constant and is sent after a configuration report (the devices seem to work fine without it, but the official software always sends it)
+
+These devices also share some substructures in their reports. All listed values are two bytes long and in big endian, unless noted otherwise.
+
+### Sensor report details & substructures
+
+There's one important substructure that keeps recurring in sensor reports, and it concerns fan info. The definition of fan here also includes pumps, not only 3/4 pin fans in the literal sense. Here's what it's known to contain:
+
+| What               | Where (relative offset) |
+| ------------------ | ----------------------- |
+| Fan speed (0-100%) | 0x00                    |
+| Fan voltage        | 0x02                    |
+| Fan current        | 0x04                    |
+| Fan power          | 0x06                    |
+| Fan speed (RPM)    | 0x08                    |
+
+Temperature sensors, if not connected, will report `0x7FFF` as their value.
+
+## D5 Next pump
+
+The D5 Next pump can, aside from itself, control and monitor an optionally connected fan.
+
+### Sensor report
+
+An example sensor report of the D5 Next looks like this:
+
+```
+01 00 03 0B B8 4E 20 00 01 00 00 00 64 03 FB 00 00 00 51 00 00 00 0E A4 00 00 00 45 00 10 42 C4 00 00 00 00 30 C9 00 00 00 A8 9C C2 B9 00 00 01 49 18 87 A1 3C 5C AB 04 BA 01 F8 00 00 00 52 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 00 00 00 00 00 00 00 00 0A 31 7F FF 00 00 7F FF 00 00 00 00 00 00 00 00 00 00 00 00 00 1B DC 04 B9 00 C5 00 EE 0B A8 00 00 00 1B DC 09 AA 08 4C 09 A9 08 4A 00 03 00 06 00 00 00 00 00 00 00 00 00 00 00 00 01 08 E5 00 E7 27 10 27 10 7F 7F
+```
+
+Its ID is `0x01` and its length is `0x9e`.
+
+Here is what it's currently known to contain:
+
+| What                               | Where/starts at (offset) |
+| ---------------------------------- | ------------------------ |
+| Serial number (first part)         | 0x03                     |
+| Serial number (second part)        | 0x05                     |
+| Firmware version                   | 0xD                      |
+| Number of power cycles *[4 bytes]* | 0x18                     |
+| Liquid (water) temperature         | 0x57                     |
+| Pump info substructure             | 0x74                     |
+| Fan info substructure              | 0x67                     |
+| +5V voltage                        | 0x39                     |
+| +12V voltage                       | 0x37                     |

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -325,6 +325,9 @@ KERNEL=="i2c-*", ATTR{name}=="NVIDIA i2c adapter 1 *", ATTRS{vendor}=="0x10de", 
 
 # Section: USB devices and USB HIDs
 
+# Aquacomputer D5 Next
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0c70", ATTRS{idProduct}=="f00e", TAG+="uaccess"
+
 # Asetek 690LC (assuming EVGA CLC)
 # Asetek 690LC (assuming NZXT Kraken X)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2433", ATTRS{idProduct}=="b200", TAG+="uaccess"

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -26,6 +26,7 @@ from liquidctl.driver.base import BaseBus, find_all_subclasses
 from liquidctl.driver import asetek
 from liquidctl.driver import asetek_pro
 from liquidctl.driver import aura_led
+from liquidctl.driver import aquacomputer
 from liquidctl.driver import commander_core
 from liquidctl.driver import commander_pro
 from liquidctl.driver import corsair_hid_psu

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -101,14 +101,12 @@ class Aquacomputer(UsbHidDriver):
         sensor_readings = []
 
         # Read temp sensor values
-        for label, offset in zip(
-            self._device_info["temp_sensors_label"], self._device_info["temp_sensors"]
-        ):
-            temp_sensor_value = u16be_from(msg, offset)
+        for idx, temp_sensor_offset in enumerate(self._device_info["temp_sensors"]):
+            temp_sensor_value = u16be_from(msg, temp_sensor_offset)
 
             if temp_sensor_value != _AQC_TEMP_SENSOR_DISCONNECTED:
                 temp_sensor_reading = (
-                    label,
+                    self._device_info["temp_sensors_label"][idx],
                     temp_sensor_value * 1e-2,
                     "°C",
                 )

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -254,5 +254,5 @@ class Aquacomputer(UsbHidDriver):
         if clear_first:
             self.device.clear_enqueued_reports()
         msg = self.device.read(self._device_info["status_report_length"])
-        self._firmware_version = tuple(msg[0xD:0xE])
+        self._firmware_version = get_unaligned_be16(msg, 0xD)
         return msg

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -26,7 +26,7 @@ SPDX-License-Identifier: GPL-3.0-or-later
 import logging
 
 from liquidctl.driver.usb import UsbHidDriver
-from liquidctl.error import NotSupportedByDevice
+from liquidctl.error import NotSupportedByDriver
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -222,15 +222,15 @@ class Aquacomputer(UsbHidDriver):
 
     def set_speed_profile(self, channel, profile, **kwargs):
         # Not yet reverse engineered / implemented
-        raise NotSupportedByDevice()
+        raise NotSupportedByDriver()
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         # Not yet implemented
-        raise NotSupportedByDevice()
+        raise NotSupportedByDriver()
 
     def set_color(self, channel, mode, colors, **kwargs):
         # Not yet reverse engineered / implemented
-        raise NotSupportedByDevice()
+        raise NotSupportedByDriver()
 
     @property
     def firmware_version(self):

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -1,0 +1,246 @@
+"""liquidctl driver for Aquacomputer family of watercooling devices.
+
+Aquacomputer D5 Next watercooling pump
+--------------------------------------
+The pump sends a status HID report every second with no initialization
+being required.
+
+The status HID report exposes sensor values such as liquid temperature and
+two groups of fan sensors, for the pump and the optionally connected fan.
+These groups provide RPM speed, voltage, current and power readings. The
+pump additionally exposes a +5V voltage sensor reading.
+
+Driver
+------
+Linux has the aquacomputer_d5next driver available since v5.15. Subsequent
+releases have more functionality and support a wider range of devices. If
+present, it's used instead of reading the status reports directly.
+
+Copyright (C) 2022 - Aleksa Savic
+
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+# uses the psf/black style
+
+import logging
+
+from liquidctl.driver.usb import UsbHidDriver
+from liquidctl.error import NotSupportedByDevice
+
+_LOGGER = logging.getLogger(__name__)
+
+_AQC_TEMP_SENSOR_DISCONNECTED = 0x7FFF
+_AQC_FAN_VOLTAGE_OFFSET = 0x02
+_AQC_FAN_CURRENT_OFFSET = 0x04
+_AQC_FAN_POWER_OFFSET = 0x06
+_AQC_FAN_SPEED_OFFSET = 0x08
+
+_AQC_STATUS_READ_ENDPOINT = 0x01
+
+
+def get_unaligned_be16(msg, offset):
+    return msg[offset] << 8 | msg[offset + 1]
+
+
+class Aquacomputer(UsbHidDriver):
+    # Support for hwmon: aquacomputer_d5next, sensors - 5.15+
+
+    SUPPORTED_DEVICES = [
+        (
+            0x0C70,
+            0xF00E,
+            None,
+            "Aquacomputer D5 Next",
+            {
+                "device_info": {
+                    "type": "D5 Next",
+                    "fan_sensors": [0x6C, 0x5F],
+                    "temp_sensors": [0x57],
+                    "plus_5v_voltage": 0x39,
+                    "temp_sensors_label": ["Liquid temperature"],
+                    "fan_speed_label": ["Pump speed", "Fan speed"],
+                    "fan_power_label": ["Pump power", "Fan power"],
+                    "fan_voltage_label": ["Pump voltage", "Fan voltage"],
+                    "fan_current_label": ["Pump current", "Fan current"],
+                    "status_report_length": 0x9E,
+                }
+            },
+        ),
+    ]
+
+    def __init__(self, device, description, device_info, **kwargs):
+        super().__init__(device, description)
+
+        # Read when necessary
+        self._firmware_version = None
+
+        self._device_info = device_info
+
+    def initialize(self, **kwargs):
+        """Initialize the device and the driver.
+
+        This method should be called every time the system boots, resumes from
+        a suspended state, or if the device has just been (re)connected.  In
+        those scenarios, no other method, except `connect()` or `disconnect()`,
+        should be called until the device and driver has been (re-)initialized.
+
+        Returns None or a list of `(property, value, unit)` tuples, similarly
+        to `get_status()`.
+        """
+
+        fw = self.firmware_version
+        _LOGGER.debug("raw firmware version: %r", fw)
+
+        return [("Firmware version", fw, "")]
+
+    def _get_status_directly(self):
+        msg = self._read()
+
+        sensor_readings = []
+
+        # Read temp sensor values
+        for idx, temp_sensor_offset in enumerate(self._device_info["temp_sensors"]):
+            temp_sensor_value = get_unaligned_be16(msg, temp_sensor_offset)
+
+            if temp_sensor_value != _AQC_TEMP_SENSOR_DISCONNECTED:
+                temp_sensor_reading = (
+                    self._device_info["temp_sensors_label"][idx],
+                    temp_sensor_value * 1e-2,
+                    "°C",
+                )
+                sensor_readings.append(temp_sensor_reading)
+
+        # Read fan speed and related values
+        for idx, fan_sensor_offset in enumerate(self._device_info["fan_sensors"]):
+            fan_speed = (
+                self._device_info["fan_speed_label"][idx],
+                get_unaligned_be16(msg, fan_sensor_offset + _AQC_FAN_SPEED_OFFSET),
+                "rpm",
+            )
+            sensor_readings.append(fan_speed)
+
+            fan_power = (
+                self._device_info["fan_power_label"][idx],
+                get_unaligned_be16(msg, fan_sensor_offset + _AQC_FAN_POWER_OFFSET) * 1e-2,
+                "W",
+            )
+            sensor_readings.append(fan_power)
+
+            fan_voltage = (
+                self._device_info["fan_voltage_label"][idx],
+                get_unaligned_be16(msg, fan_sensor_offset + _AQC_FAN_VOLTAGE_OFFSET) * 1e-2,
+                "V",
+            )
+            sensor_readings.append(fan_voltage)
+
+            fan_current = (
+                self._device_info["fan_current_label"][idx],
+                get_unaligned_be16(msg, fan_sensor_offset + _AQC_FAN_CURRENT_OFFSET) * 1e-3,
+                "A",
+            )
+            sensor_readings.append(fan_current)
+
+        # Special-case sensor readings
+        if self._device_info["type"] == "D5 Next":
+            # Read +5V voltage rail value
+            plus_5v_voltage = (
+                "+5V voltage",
+                get_unaligned_be16(msg, self._device_info["plus_5v_voltage"]) * 1e-2,
+                "V",
+            )
+            sensor_readings.append(plus_5v_voltage)
+
+        return sensor_readings
+
+    def _get_status_from_hwmon(self):
+        sensor_readings = []
+
+        # Read temp sensor values
+        for idx, temp_sensor_offset in enumerate(self._device_info["temp_sensors"]):
+            temp_sensor_reading = (
+                self._device_info["temp_sensors_label"][idx],
+                self._hwmon.get_int(f"temp{idx + 1}_input") * 1e-3,
+                "°C",
+            )
+            sensor_readings.append(temp_sensor_reading)
+
+        # Read fan speed and related values
+        for idx, fan_sensor_offset in enumerate(self._device_info["fan_sensors"]):
+            fan_speed = (
+                self._device_info["fan_speed_label"][idx],
+                self._hwmon.get_int(f"fan{idx + 1}_input"),
+                "rpm",
+            )
+            sensor_readings.append(fan_speed)
+
+            fan_power = (
+                self._device_info["fan_power_label"][idx],
+                self._hwmon.get_int(f"power{idx + 1}_input") * 1e-6,
+                "W",
+            )
+            sensor_readings.append(fan_power)
+
+            fan_voltage = (
+                self._device_info["fan_voltage_label"][idx],
+                self._hwmon.get_int(f"in{idx}_input") * 1e-3,
+                "V",
+            )
+            sensor_readings.append(fan_voltage)
+
+            fan_current = (
+                self._device_info["fan_current_label"][idx],
+                self._hwmon.get_int(f"curr{idx + 1}_input") * 1e-3,
+                "A",
+            )
+            sensor_readings.append(fan_current)
+
+        # Special-case sensor readings
+        if self._device_info["type"] == "D5 Next":
+            # Read +5V voltage rail value
+            plus_5v_voltage = ("+5V voltage", self._hwmon.get_int(f"in2_input") * 1e-3, "V")
+            sensor_readings.append(plus_5v_voltage)
+
+        return sensor_readings
+
+    def get_status(self, direct_access=False, **kwargs):
+        """Get a status report.
+
+        Returns a list of `(property, value, unit)` tuples.
+        """
+
+        if self._hwmon and not direct_access:
+            _LOGGER.info("bound to %s kernel driver, reading status from hwmon", self._hwmon.module)
+            return self._get_status_from_hwmon()
+
+        if self._hwmon:
+            _LOGGER.warning(
+                "directly reading the status despite %s kernel driver", self._hwmon.module
+            )
+
+        return self._get_status_directly()
+
+    def set_speed_profile(self, channel, profile, **kwargs):
+        # Not yet reverse engineered / implemented
+        raise NotSupportedByDevice()
+
+    def set_fixed_speed(self, channel, duty, **kwargs):
+        # Not yet implemented
+        raise NotSupportedByDevice()
+
+    def set_color(self, channel, mode, colors, **kwargs):
+        # Not yet reverse engineered / implemented
+        raise NotSupportedByDevice()
+
+    @property
+    def firmware_version(self):
+        if self._firmware_version is None:
+            _ = self._read(clear_first=False)
+        return self._firmware_version
+
+    def _read(self, clear_first=True):
+        if clear_first:
+            self.device.clear_enqueued_reports()
+        msg = self.device.read(self._device_info["status_report_length"])
+        self._firmware_version = tuple(msg[0xD:0xE])
+        return msg

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -58,6 +58,7 @@ class Aquacomputer(UsbHidDriver):
                     "fan_sensors": [0x6C, 0x5F],
                     "temp_sensors": [0x57],
                     "plus_5v_voltage": 0x39,
+                    "plus_12v_voltage": 0x37,
                     "temp_sensors_label": ["Liquid temperature"],
                     "fan_speed_label": ["Pump speed", "Fan speed"],
                     "fan_power_label": ["Pump power", "Fan power"],
@@ -150,6 +151,14 @@ class Aquacomputer(UsbHidDriver):
                 "V",
             )
             sensor_readings.append(plus_5v_voltage)
+
+            # Read +12V voltage rail value
+            plus_12v_voltage = (
+                "+12V voltage",
+                get_unaligned_be16(msg, self._device_info["plus_12v_voltage"]) * 1e-2,
+                "V",
+            )
+            sensor_readings.append(plus_12v_voltage)
 
         return sensor_readings
 

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -43,11 +43,11 @@ _AQC_STATUS_READ_ENDPOINT = 0x01
 class Aquacomputer(UsbHidDriver):
     # Support for hwmon: aquacomputer_d5next, sensors - 5.15+
 
-    DEVICE_D5NEXT = "D5 Next"
+    _DEVICE_D5NEXT = "D5 Next"
 
-    DEVICE_INFO = {
-        DEVICE_D5NEXT: {
-            "type": DEVICE_D5NEXT,
+    _DEVICE_INFO = {
+        _DEVICE_D5NEXT: {
+            "type": _DEVICE_D5NEXT,
             "fan_sensors": [0x6C, 0x5F],
             "temp_sensors": [0x57],
             "plus_5v_voltage": 0x39,
@@ -62,7 +62,7 @@ class Aquacomputer(UsbHidDriver):
     }
 
     SUPPORTED_DEVICES = [
-        (0x0C70, 0xF00E, None, "Aquacomputer D5 Next", {"device_info": DEVICE_INFO[DEVICE_D5NEXT]}),
+        (0x0C70, 0xF00E, None, "Aquacomputer D5 Next", {"device_info": _DEVICE_INFO[_DEVICE_D5NEXT]}),
     ]
 
     def __init__(self, device, description, device_info, **kwargs):
@@ -137,7 +137,7 @@ class Aquacomputer(UsbHidDriver):
             sensor_readings.append(fan_current)
 
         # Special-case sensor readings
-        if self._device_info["type"] == self.DEVICE_D5NEXT:
+        if self._device_info["type"] == self._DEVICE_D5NEXT:
             # Read +5V voltage rail value
             plus_5v_voltage = (
                 "+5V voltage",
@@ -199,7 +199,7 @@ class Aquacomputer(UsbHidDriver):
             sensor_readings.append(fan_current)
 
         # Special-case sensor readings
-        if self._device_info["type"] == self.DEVICE_D5NEXT:
+        if self._device_info["type"] == self._DEVICE_D5NEXT:
             # Read +5V voltage rail value
             plus_5v_voltage = ("+5V voltage", self._hwmon.get_int("in2_input") * 1e-3, "V")
             sensor_readings.append(plus_5v_voltage)

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -86,7 +86,6 @@ class Aquacomputer(UsbHidDriver):
         """
 
         fw = self.firmware_version
-        _LOGGER.debug("raw firmware version: %r", fw)
 
         return [("Firmware version", fw, "")]
 

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -8,7 +8,7 @@ being required.
 The status HID report exposes sensor values such as liquid temperature and
 two groups of fan sensors, for the pump and the optionally connected fan.
 These groups provide RPM speed, voltage, current and power readings. The
-pump additionally exposes a +5V voltage sensor reading.
+pump additionally exposes +5V and +12V voltage rail readings.
 
 Driver
 ------

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -95,12 +95,12 @@ class Aquacomputer(UsbHidDriver):
         sensor_readings = []
 
         # Read temp sensor values
-        for idx, temp_sensor_offset in enumerate(self._device_info["temp_sensors"]):
-            temp_sensor_value = u16be_from(msg, temp_sensor_offset)
+        for label, offset in zip(self._device_info["temp_sensors_label"], self._device_info["temp_sensors"]):
+            temp_sensor_value = u16be_from(msg, offset)
 
             if temp_sensor_value != _AQC_TEMP_SENSOR_DISCONNECTED:
                 temp_sensor_reading = (
-                    self._device_info["temp_sensors_label"][idx],
+                    label,
                     temp_sensor_value * 1e-2,
                     "°C",
                 )

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -62,7 +62,13 @@ class Aquacomputer(UsbHidDriver):
     }
 
     SUPPORTED_DEVICES = [
-        (0x0C70, 0xF00E, None, "Aquacomputer D5 Next", {"device_info": _DEVICE_INFO[_DEVICE_D5NEXT]}),
+        (
+            0x0C70,
+            0xF00E,
+            None,
+            "Aquacomputer D5 Next",
+            {"device_info": _DEVICE_INFO[_DEVICE_D5NEXT]},
+        ),
     ]
 
     def __init__(self, device, description, device_info, **kwargs):
@@ -95,7 +101,9 @@ class Aquacomputer(UsbHidDriver):
         sensor_readings = []
 
         # Read temp sensor values
-        for label, offset in zip(self._device_info["temp_sensors_label"], self._device_info["temp_sensors"]):
+        for label, offset in zip(
+            self._device_info["temp_sensors_label"], self._device_info["temp_sensors"]
+        ):
             temp_sensor_value = u16be_from(msg, offset)
 
             if temp_sensor_value != _AQC_TEMP_SENSOR_DISCONNECTED:

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -212,6 +212,10 @@ class Aquacomputer(UsbHidDriver):
                 # The driver exposes the +12V voltage of the pump (kernel v5.20+), read the value
                 plus_12v_voltage = ("+12V voltage", self._hwmon.get_int("in3_input") * 1e-3, "V")
                 sensor_readings.append(plus_12v_voltage)
+            else:
+                _LOGGER.warning(
+                    "some attributes cannot be read from %s kernel driver", self._hwmon.module
+                )
 
         return sensor_readings
 

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -76,6 +76,7 @@ class Aquacomputer(UsbHidDriver):
 
         # Read when necessary
         self._firmware_version = None
+        self._serial_number = None
 
         self._device_info = device_info
 
@@ -92,8 +93,9 @@ class Aquacomputer(UsbHidDriver):
         """
 
         fw = self.firmware_version
+        serial_number = self.serial_number
 
-        return [("Firmware version", fw, "")]
+        return [("Firmware version", fw, ""), ("Serial number", serial_number, "")]
 
     def _get_status_directly(self):
         msg = self._read()
@@ -256,9 +258,16 @@ class Aquacomputer(UsbHidDriver):
             _ = self._read(clear_first=False)
         return self._firmware_version
 
+    @property
+    def serial_number(self):
+        if self._serial_number is None:
+            _ = self._read(clear_first=False)
+        return self._serial_number
+
     def _read(self, clear_first=True):
         if clear_first:
             self.device.clear_enqueued_reports()
         msg = self.device.read(self._device_info["status_report_length"])
         self._firmware_version = u16be_from(msg, 0xD)
+        self._serial_number = f"{u16be_from(msg, 0x3):05}-{u16be_from(msg, 0x5):05}"
         return msg

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -111,8 +111,8 @@ def test_d5next_set_fixed_speeds_not_supported(mockD5NextDevice):
     with pytest.raises(NotSupportedByDriver):
         mockD5NextDevice.set_fixed_speed("fan", 42)
 
-        with pytest.raises(NotSupportedByDriver):
-            mockD5NextDevice.set_fixed_speed("pump", 84)
+    with pytest.raises(NotSupportedByDriver):
+        mockD5NextDevice.set_fixed_speed("pump", 84)
 
 
 def test_kraken_speed_profiles_not_supported(mockD5NextDevice):

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -60,6 +60,9 @@ def test_d5next_initialize(mockD5NextDevice):
     # Verify firmware version
     assert init_result[0][1] == 1023
 
+    # Verify serial number
+    assert init_result[1][1] == "03531-22908"
+
 
 @pytest.mark.parametrize("has_hwmon,direct_access", [(False, False), (True, True)])
 def test_d5next_get_status_directly(mockD5NextDevice, has_hwmon, direct_access):

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -6,17 +6,17 @@ from liquidctl.driver.aquacomputer import Aquacomputer
 from liquidctl.error import NotSupportedByDriver
 
 D5NEXT_SAMPLE_STATUS_REPORT = bytes.fromhex(
-    "00030DCB597C00010000006403FF00000051000004DC14000001E0007A98AF0"
-    "0000000FFFF000041A803C169000001481ACAA3465CB804B401F4000000527FFF"
-    "7FFF7FFF7FFF7FFF7FFF7FFF7FFF000000000000000009D27FFF00007FFF01F40"
-    "4B400200026016D006300000004B200D7010207B80000000000098D083A098A08"
-    "3A00060001000000000000000000000000011A24015E27101D4CFFBF"
+    "00030DCB597C00010000006403FF00000051000004DC14000001E0007A98AF000"
+    "00000FFFF000041A803C169000001481ACAA3465CB804B401F4000000527FFF7F"
+    "FF7FFF7FFF7FFF7FFF7FFF7FFF000000000000000009D27FFF00007FFF01F404B"
+    "400200026016D006300000004B200D7010207B80000000000098D083A098A083A"
+    "00060001000000000000000000000000011A24015E27101D4CFFBF"
 )
 
 
 @pytest.fixture
 def mockD5NextDevice():
-    device = _MockD5NextDevice(fw_version=1023)
+    device = _MockD5NextDevice()
     dev = Aquacomputer(
         device,
         "Mock Aquacomputer D5 Next",
@@ -28,9 +28,8 @@ def mockD5NextDevice():
 
 
 class _MockD5NextDevice(MockHidapiDevice):
-    def __init__(self, fw_version):
+    def __init__(self):
         super().__init__(vendor_id=0x0C70, product_id=0xF00E)
-        self.fw_version = fw_version
 
         self.preload_read(Report(1, D5NEXT_SAMPLE_STATUS_REPORT))
 
@@ -87,19 +86,34 @@ def test_d5next_get_status_directly(mockD5NextDevice, has_hwmon, direct_access):
 
 
 def test_d5next_get_status_from_hwmon(mockD5NextDevice, tmp_path):
-    # TODO
 
     mockD5NextDevice._hwmon = HwmonDevice("mock_module", tmp_path)
-    (tmp_path / "temp1_input").write_text("20900\n")
-    (tmp_path / "fan1_input").write_text("2499\n")
-    (tmp_path / "fan2_input").write_text("1702\n")
+    (tmp_path / "temp1_input").write_text("25100\n")  # Liquid temperature
+    (tmp_path / "fan1_input").write_text("1976\n")  # Pump speed
+    (tmp_path / "power1_input").write_text("2580000\n")  # Pump power
+    (tmp_path / "in0_input").write_text("12020\n")  # Pump voltage
+    (tmp_path / "curr1_input").write_text("215\n")  # Pump current
+    (tmp_path / "fan2_input").write_text("365\n")  # Fan speed
+    (tmp_path / "power2_input").write_text("380000\n")  # Fan power
+    (tmp_path / "in1_input").write_text("12040\n")  # Fan voltage
+    (tmp_path / "curr2_input").write_text("31\n")  # Fan current
+    (tmp_path / "in2_input").write_text("4990\n")  # +5V voltage
+    (tmp_path / "in3_input").write_text("12040\n")  # +12V voltage
 
     got = mockD5NextDevice.get_status()
 
     expected = [
-        ("Liquid temperature", pytest.approx(20.9), "°C"),
-        ("Fan speed", 2499, "rpm"),
-        ("Pump speed", 1702, "rpm"),
+        ("Liquid temperature", pytest.approx(25.1, 0.1), "°C"),
+        ("Pump speed", 1976, "rpm"),
+        ("Pump power", pytest.approx(2.58, 0.1), "W"),
+        ("Pump voltage", pytest.approx(12.02, 0.1), "V"),
+        ("Pump current", pytest.approx(0.21, 0.1), "A"),
+        ("Fan speed", 365, "rpm"),
+        ("Fan power", pytest.approx(0.38, 0.1), "W"),
+        ("Fan voltage", pytest.approx(12.04, 0.1), "V"),
+        ("Fan current", pytest.approx(0.03, 0.1), "A"),
+        ("+5V voltage", pytest.approx(5.00, 0.1), "V"),
+        ("+12V voltage", pytest.approx(12.04, 0.1), "V"),
     ]
 
     assert sorted(got) == sorted(expected)

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -1,0 +1,123 @@
+import pytest
+from _testutils import MockHidapiDevice, Report
+
+from liquidctl.driver.hwmon import HwmonDevice
+from liquidctl.driver.aquacomputer import Aquacomputer
+from liquidctl.error import NotSupportedByDriver
+
+D5NEXT_SAMPLE_STATUS_REPORT = bytes.fromhex(
+    "00030DCB597C00010000006403FF00000051000004DC14000001E0007A98AF0"
+    "0000000FFFF000041A803C169000001481ACAA3465CB804B401F4000000527FFF"
+    "7FFF7FFF7FFF7FFF7FFF7FFF7FFF000000000000000009D27FFF00007FFF01F40"
+    "4B400200026016D006300000004B200D7010207B80000000000098D083A098A08"
+    "3A00060001000000000000000000000000011A24015E27101D4CFFBF"
+)
+
+
+@pytest.fixture
+def mockD5NextDevice():
+    device = _MockD5NextDevice(fw_version=1023)
+    dev = Aquacomputer(
+        device,
+        "Mock Aquacomputer D5 Next",
+        device_info=Aquacomputer.DEVICE_INFO[Aquacomputer.DEVICE_D5NEXT],
+    )
+
+    dev.connect()
+    return dev
+
+
+class _MockD5NextDevice(MockHidapiDevice):
+    def __init__(self, fw_version):
+        super().__init__(vendor_id=0x0C70, product_id=0xF00E)
+        self.fw_version = fw_version
+
+        self.preload_read(Report(1, D5NEXT_SAMPLE_STATUS_REPORT))
+
+    def read(self, length):
+        pre = super().read(length)
+        if pre:
+            return pre
+
+        return Report(1, D5NEXT_SAMPLE_STATUS_REPORT)
+
+
+def test_d5next_connect(mockD5NextDevice):
+    def mock_open():
+        nonlocal opened
+        opened = True
+
+    mockD5NextDevice.device.open = mock_open
+    opened = False
+
+    with mockD5NextDevice.connect() as cm:
+        assert cm == mockD5NextDevice
+        assert opened
+
+
+def test_d5next_initialize(mockD5NextDevice):
+    init_result = mockD5NextDevice.initialize()
+
+    # Verify firmware version
+    assert init_result[0][1] == 1023
+
+
+@pytest.mark.parametrize("has_hwmon,direct_access", [(False, False), (True, True)])
+def test_d5next_get_status_directly(mockD5NextDevice, has_hwmon, direct_access):
+    if has_hwmon:
+        mockD5NextDevice._hwmon = HwmonDevice(None, None)
+
+    mockD5NextDevice.device.preload_read(Report(1, D5NEXT_SAMPLE_STATUS_REPORT))
+
+    got = mockD5NextDevice.get_status(direct_access=direct_access)
+
+    expected = [
+        ("Liquid temperature", pytest.approx(25.1, 0.1), "°C"),
+        ("Pump speed", 1976, "rpm"),
+        ("Pump power", pytest.approx(2.58, 0.1), "W"),
+        ("Pump voltage", pytest.approx(12.02, 0.1), "V"),
+        ("Pump current", pytest.approx(0.21, 0.1), "A"),
+        ("Fan speed", 365, "rpm"),
+        ("Fan power", pytest.approx(0.38, 0.1), "W"),
+        ("Fan voltage", pytest.approx(12.04, 0.1), "V"),
+        ("Fan current", pytest.approx(0.03, 0.1), "A"),
+        ("+5V voltage", pytest.approx(5.00, 0.1), "V"),
+        ("+12V voltage", pytest.approx(12.04, 0.1), "V"),
+    ]
+
+    assert sorted(got) == sorted(expected)
+
+
+def test_d5next_get_status_from_hwmon(mockD5NextDevice, tmp_path):
+    # TODO
+
+    mockD5NextDevice._hwmon = HwmonDevice("mock_module", tmp_path)
+    (tmp_path / "temp1_input").write_text("20900\n")
+    (tmp_path / "fan1_input").write_text("2499\n")
+    (tmp_path / "fan2_input").write_text("1702\n")
+
+    got = mockD5NextDevice.get_status()
+
+    expected = [
+        ("Liquid temperature", pytest.approx(20.9), "°C"),
+        ("Fan speed", 2499, "rpm"),
+        ("Pump speed", 1702, "rpm"),
+    ]
+
+    assert sorted(got) == sorted(expected)
+
+
+def test_d5next_set_fixed_speeds_not_supported(mockD5NextDevice):
+    with pytest.raises(NotSupportedByDriver):
+        mockD5NextDevice.set_fixed_speed("fan", 42)
+
+        with pytest.raises(NotSupportedByDriver):
+            mockD5NextDevice.set_fixed_speed("pump", 84)
+
+
+def test_kraken_speed_profiles_not_supported(mockD5NextDevice):
+    with pytest.raises(NotSupportedByDriver):
+        mockD5NextDevice.set_speed_profile("fan", 1)
+
+    with pytest.raises(NotSupportedByDriver):
+        mockD5NextDevice.set_speed_profile("pump", 1)

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -67,8 +67,6 @@ def test_d5next_get_status_directly(mockD5NextDevice, has_hwmon, direct_access):
     if has_hwmon:
         mockD5NextDevice._hwmon = HwmonDevice(None, None)
 
-    mockD5NextDevice.device.preload_read(Report(1, D5NEXT_SAMPLE_STATUS_REPORT))
-
     got = mockD5NextDevice.get_status(direct_access=direct_access)
 
     expected = [

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -20,7 +20,7 @@ def mockD5NextDevice():
     dev = Aquacomputer(
         device,
         "Mock Aquacomputer D5 Next",
-        device_info=Aquacomputer.DEVICE_INFO[Aquacomputer.DEVICE_D5NEXT],
+        device_info=Aquacomputer._DEVICE_INFO[Aquacomputer._DEVICE_D5NEXT],
     )
 
     dev.connect()

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -129,7 +129,7 @@ def test_d5next_set_fixed_speeds_not_supported(mockD5NextDevice):
 
 def test_kraken_speed_profiles_not_supported(mockD5NextDevice):
     with pytest.raises(NotSupportedByDriver):
-        mockD5NextDevice.set_speed_profile("fan", 1)
+        mockD5NextDevice.set_speed_profile("fan", None)
 
     with pytest.raises(NotSupportedByDriver):
-        mockD5NextDevice.set_speed_profile("pump", 1)
+        mockD5NextDevice.set_speed_profile("pump", None)


### PR DESCRIPTION
As promised in #438, here is the first PR for adding support for Aquacomputer devices to liquidctl. This PR adds a new driver called `aquacomputer`, and it currently supports reading sensor values of the D5 Next watercooling pump.

Aquacomputer devices share same layouts of sensor substructures/groups in their HID reports, so adding sensor reading support for other devices, such as Octo, Quadro, Farbwerk, Farbwerk 360 should be trivial. (Just need to specify the offsets in device specific data and write some cases for non-general sensors.) They are all supported by the [partially mainlined driver](https://github.com/aleksamagicka/aquacomputer_d5next-hwmon) that I maintain.

Some advanced features of the devices are still being investigated and reverse engineered, and additionally as far as I know nobody has looked at the RGB controls yet. The kernel driver supports sensor reading and directly controlling the PWM inputs, where available.

Marking this PR as draft for now, as I have to check more boxes down below. I've formatted the code using black (haven't used it before), so hopefully it looks as it should.

And a question for the future: the kernel driver support for devices varies between kernel versions. Is there a clean way to get the kernel version from liquidctl already?

Related: #439 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [x] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [x] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
