### PR TITLE
Fix small bug in hwmon.py with Python <3.9

### DIFF
--- a/liquidctl/driver/hwmon.py
+++ b/liquidctl/driver/hwmon.py
@@ -63,6 +63,7 @@ class HwmonDevice:
             _LOGGER.debug("cannot pick hwmon device for %s: more than one alternative", path)
             return None
 
-        module = (sys_device / "driver" / "module").readlink().name
+        # use resolve() to be compatible with Python <3.9
+        module = (sys_device / "driver" / "module").resolve().name
 
         return HwmonDevice(module, path)


### PR DESCRIPTION
Change PosixPath.readlink() to PosixPath.resolve() for compatibility with Python <3.9

The .readlink() function is not available in the pathlib library prior to Python 3.9. Replacing it with a call to .resolve() for the same result.

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: <!-- #number of issue (implies Closes tag) or commit SHA -->
Closes: #481
Related:  

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
