### PR TITLE
HydroPro: Fix duplicate use of second alert temp

### DIFF
--- a/liquidctl/driver/asetek_pro.py
+++ b/liquidctl/driver/asetek_pro.py
@@ -183,7 +183,7 @@ class HydroPro(_Base690Lc):
             # possible to combine it with other modes, but exploring that would
             # require some experimentation
             temps = (30, 40, 50)
-            self._post([0x5f, temps[0], 0x00, temps[1], 0x00, temps[1], 0x00]
+            self._post([0x5f, temps[0], 0x00, temps[1], 0x00, temps[2], 0x00]
                        + colors[0] + colors[1] + colors[2], read_length=6)
             self._post([0x5e, 0x01], read_length=3)
             self.device.release()


### PR DESCRIPTION
Somewhere between the initial proposal[1]  and the final inclusion[2] of this feature, this seems to have been changed to use the second alert temperature twice.

This is a bug that results in what I can only describe as the colour getting "stuck" at the interpolated halfway-point between color2 and color3 when temperature rises over 40 degrees.

Tested with my h100i Pro RGB, using all three temperatures results in the expected behaviour of interpolation between color1 and color2 between 30 and 40 degrees, and interpolation between color2 and color3 between 40 and 50 degrees.

[1] <https://github.com/liquidctl/liquidctl/pull/234/files#diff-6e83d451ee55e2e559f9aa43783fe2574adddb8edaf9252aca4b476b5f0821b5R212>
[2] <https://github.com/liquidctl/liquidctl/pull/264/files#diff-6e83d451ee55e2e559f9aa43783fe2574adddb8edaf9252aca4b476b5f0821b5R186>

Fixes: No issue filed, *possibly* #461 
Related: #137, #234, #264 

---

Checklist:

All unchecked items were imo non-applicable.

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

Nothing new was added, so remaining checklist items removed.

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
