### PR TITLE
Aquacomputer driver enhancements

### DIFF
--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -76,7 +76,7 @@ class Aquacomputer(UsbHidDriver):
 
         # Read when necessary
         self._firmware_version = None
-        self._serial_number = None
+        self._serial = None
 
         self._device_info = device_info
 
@@ -93,7 +93,7 @@ class Aquacomputer(UsbHidDriver):
         """
 
         fw = self.firmware_version
-        serial_number = self.serial_number
+        serial_number = self._serial_number
 
         return [("Firmware version", fw, ""), ("Serial number", serial_number, "")]
 
@@ -259,15 +259,15 @@ class Aquacomputer(UsbHidDriver):
         return self._firmware_version
 
     @property
-    def serial_number(self):
-        if self._serial_number is None:
-            _ = self._read(clear_first=False)
-        return self._serial_number
+    def _serial_number(self):
+        if self._serial is None:
+            msg = self._read(clear_first=False)
+            self._serial = f"{u16be_from(msg, 0x3):05}-{u16be_from(msg, 0x5):05}"
+        return self._serial
 
     def _read(self, clear_first=True):
         if clear_first:
             self.device.clear_enqueued_reports()
         msg = self.device.read(self._device_info["status_report_length"])
         self._firmware_version = u16be_from(msg, 0xD)
-        self._serial_number = f"{u16be_from(msg, 0x3):05}-{u16be_from(msg, 0x5):05}"
         return msg

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -255,7 +255,8 @@ class Aquacomputer(UsbHidDriver):
     @property
     def firmware_version(self):
         if self._firmware_version is None:
-            _ = self._read(clear_first=False)
+            msg = self._read(clear_first=False)
+            self._firmware_version = u16be_from(msg, 0xD)
         return self._firmware_version
 
     @property
@@ -269,5 +270,4 @@ class Aquacomputer(UsbHidDriver):
         if clear_first:
             self.device.clear_enqueued_reports()
         msg = self.device.read(self._device_info["status_report_length"])
-        self._firmware_version = u16be_from(msg, 0xD)
         return msg

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -252,18 +252,21 @@ class Aquacomputer(UsbHidDriver):
         # Not yet reverse engineered / implemented
         raise NotSupportedByDriver()
 
+    def _read_device_statics(self):
+        if self._firmware_version is None or self._serial is None:
+            msg = self._read(clear_first=False)
+
+            self._firmware_version = u16be_from(msg, 0xD)
+            self._serial = f"{u16be_from(msg, 0x3):05}-{u16be_from(msg, 0x5):05}"
+
     @property
     def firmware_version(self):
-        if self._firmware_version is None:
-            msg = self._read(clear_first=False)
-            self._firmware_version = u16be_from(msg, 0xD)
+        self._read_device_statics()
         return self._firmware_version
 
     @property
     def _serial_number(self):
-        if self._serial is None:
-            msg = self._read(clear_first=False)
-            self._serial = f"{u16be_from(msg, 0x3):05}-{u16be_from(msg, 0x5):05}"
+        self._read_device_statics()
         return self._serial
 
     def _read(self, clear_first=True):

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -32,7 +32,6 @@ class _MockD5NextDevice(MockHidapiDevice):
         super().__init__(vendor_id=0x0C70, product_id=0xF00E)
 
         self.preload_read(Report(1, D5NEXT_SAMPLE_STATUS_REPORT))
-        self.preload_read(Report(1, D5NEXT_SAMPLE_STATUS_REPORT))
 
     def read(self, length):
         pre = super().read(length)

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -32,6 +32,7 @@ class _MockD5NextDevice(MockHidapiDevice):
         super().__init__(vendor_id=0x0C70, product_id=0xF00E)
 
         self.preload_read(Report(1, D5NEXT_SAMPLE_STATUS_REPORT))
+        self.preload_read(Report(1, D5NEXT_SAMPLE_STATUS_REPORT))
 
     def read(self, length):
         pre = super().read(length)


### PR DESCRIPTION
For `aquacomputer.py`, make serial number property private and read that and firmware version only when they are requested, but not already cached.

Related: #482

---
Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
