### PR TITLE
Commander core update

### DIFF
--- a/docs/developer/protocol/commander_core.md
+++ b/docs/developer/protocol/commander_core.md
@@ -83,23 +83,10 @@ Response:
 Note: the `0x01` Init/Wakeup command is exceptionally not necessary before this
 command.
 
-### `0x05` - Reset Channel
-
-Needs to be run before changing the mode on a channel if there is a chance the
-channel has already been used.
-
-Command:
-
-| Byte index | Description |
-| ---------- | ----------- |
-| 0x00 | 0x08 |
-| 0x01 | 0x05 |
-| 0x02 | 0x01 |
-| 0x03 | Channel to reset |
-
-### `0x0d` - Set Channel Mode
+### `0x0d` - Open Endpoint
 
 Sets the mode for the channel to use.
+Needs to be run **before** a read or write operation.
 
 `0x05` - Init/Wakeup will likely need to be run first.
 
@@ -111,6 +98,19 @@ Command:
 | 0x01 | 0x0d |
 | 0x02 | Channel |
 | 0x03 | New mode |
+
+### `0x05` - Close Endpoint
+
+Needs to be run **after** a read or write operation to close a previously opened endpoint.
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x05 |
+| 0x02 | 0x01 |
+| 0x03 | Channel to close |
 
 ## Mode Commands
 

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -27,8 +27,8 @@ _FAN_COUNT = 6
 _CMD_WAKE = (0x01, 0x03, 0x00, 0x02)
 _CMD_SLEEP = (0x01, 0x03, 0x00, 0x01)
 _CMD_GET_FIRMWARE = (0x02, 0x13)
-_CMD_RESET = (0x05, 0x01, 0x00)
-_CMD_SET_MODE = (0x0d, 0x00)
+_CMD_CLOSE_ENDPOINT = (0x05, 0x01, 0x00)
+_CMD_OPEN_ENDPOINT = (0x0d, 0x00)
 _CMD_READ = (0x08, 0x00)
 _CMD_WRITE = (0x06, 0x00)
 
@@ -199,9 +199,9 @@ class CommanderCore(UsbHidDriver):
         return temps
 
     def _read_data(self, mode, data_type):
-        self._send_command(_CMD_SET_MODE, mode)
+        self._send_command(_CMD_OPEN_ENDPOINT, mode)
         raw_data = self._send_command(_CMD_READ)
-        self._send_command(_CMD_RESET)
+        self._send_command(_CMD_CLOSE_ENDPOINT)
         if tuple(raw_data[3:5]) != data_type:
             raise ExpectationNotMet('device returned incorrect data type')
 
@@ -237,7 +237,6 @@ class CommanderCore(UsbHidDriver):
     def _wake_device_context(self):
         try:
             self._send_command(_CMD_WAKE)
-            self._send_command(_CMD_RESET)
             yield
         finally:
             self._send_command(_CMD_SLEEP)
@@ -245,7 +244,7 @@ class CommanderCore(UsbHidDriver):
     def _write_data(self, mode, data_type, data):
         self._read_data(mode, data_type)  # Will ensure we are writing the correct data type to avoid breakage
 
-        self._send_command(_CMD_SET_MODE, mode)
+        self._send_command(_CMD_OPEN_ENDPOINT, mode)
 
         buf = bytearray(len(data) + len(data_type) + 4)
         buf[0: 2] = int.to_bytes(len(data) + 2, length=2, byteorder="little", signed=False)
@@ -253,7 +252,7 @@ class CommanderCore(UsbHidDriver):
         buf[4 + len(data_type):] = data
 
         self._send_command(_CMD_WRITE, buf)
-        self._send_command(_CMD_RESET)
+        self._send_command(_CMD_CLOSE_ENDPOINT)
 
     def _fan_to_channel(self, fan):
         if self._has_pump:

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -237,6 +237,7 @@ class CommanderCore(UsbHidDriver):
     def _wake_device_context(self):
         try:
             self._send_command(_CMD_WAKE)
+            self._send_command(_CMD_RESET)
             yield
         finally:
             self._send_command(_CMD_SLEEP)

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -31,7 +31,6 @@ class MockCommanderCoreDevice:
 
         self._last_write = bytes()
         self._modes = {}
-        self._is_reset = False
         self._awake = False
 
         self.response_prefix = ()
@@ -111,17 +110,14 @@ class MockCommanderCoreDevice:
         self._last_write = data
         if data[0] != 0x00 or data[1] != 0x08:
             raise ValueError('Start of packets going out should be 00:08')
-
         if data[2] == 0x0d:
             channel = data[3]
-            if  (self._is_reset or not self._awake) and self._modes.get(channel) is None:
+            if  self._modes.get(channel) is None:
                 self._modes[channel] = data[4:6]
-                self._is_reset = False
             else:
                 raise ExpectationNotMet('Previous channel was not reset')
         elif data[2] == 0x05 and data[3] == 0x01:
             self._modes[data[4]] = None
-            self._is_reset = True
         elif data[2] == 0x01 and data[3] == 0x03 and data[4] == 0x00:
             self._awake = data[5] == 0x02
         elif self._awake:


### PR DESCRIPTION
Add support for the last Corsair Commander Core firmware v2.10.219.
I follow the explanation of ParkerMC to fix the issue, I changed the flow inside the _read_data and _write_data functions to follow the flow described by ParkerMC : set_mode > read / write > reset

I changed the read operation inside _send_command function to read until response starts with 0x00.

After changes to the command flow the tests failed with an "Key Error" at line 117 of file test_commander_core.py.
This is because when i delayed de reset command in read_data and when we start with a set_mode command the _modes array of the Mock device is empty. To prevent this i set in _init_ a None value inside the _modes array.


Fixes: [#464](https://github.com/liquidctl/liquidctl/issues/464)

---

Checklist:

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update the README and other applicable documentation pages
- [x] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [x] Update or add applicable `docs/*guide.md` device guides
- [x] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [x] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
