### PR TITLE
commander_core: retry commands if the device fails to produce a response

### DIFF
--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -419,7 +419,7 @@ class HidapiDevice:
             discarded += 1
         _LOGGER.debug('discarded %d previously enqueued reports', discarded)
 
-    def read(self, length):
+    def read(self, length, timeout_ms=None):
         """Read raw report from HID.
 
         The returned data follows the semantics of the Linux HIDRAW API.
@@ -430,7 +430,13 @@ class HidapiDevice:
         > reports, the report data will begin at the first byte.
         """
         self.hiddev.set_nonblocking(False)
-        data = self.hiddev.read(length)
+        if timeout_ms is not None:
+            data = self.hiddev.read(length, timeout_ms=timeout_ms)
+            if not data:
+                _LOGGER.debug('read 0 bytes, timeout')
+                raise IOError('timeout')
+        else:
+            data = self.hiddev.read(length)
         _LOGGER.debug('read %d bytes: %r', len(data), LazyHexRepr(data))
         return data
 

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -41,7 +41,7 @@ class MockCommanderCoreDevice:
         self.fixed_speeds = (0, 0, 0, 0, 0, 0, 0)
         self.temperatures = (None, None)
 
-    def read(self, length):
+    def read(self, length, timeout_ms=None):
         data = bytearray([0x00, self._last_write[2], 0x00])
         data.extend(self.response_prefix)
 


### PR DESCRIPTION
Sometimes a `_CMD_OPEN_ENDPOINT` command fails to produce a ready (`00:`) response, blocking after several non-ready (`f0:`) responses instead. If this happens, just retry the command and hope for the best...

TODO: only do this with commands known to be idempotent (is `_CMD_OPEN_ENDPOINT`?)

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: #505

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
