### PR TITLE
Rename get_int to read_int in HwmonDevice

### DIFF
--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -272,7 +272,7 @@ class Aquacomputer(UsbHidDriver):
         for idx, temp_sensor_offset in enumerate(self._device_info.get("temp_sensors", [])):
             temp_sensor_reading = (
                 self._device_info["temp_sensors_label"][idx],
-                self._hwmon.get_int(f"temp{idx + 1}_input") * 1e-3,
+                self._hwmon.read_int(f"temp{idx + 1}_input") * 1e-3,
                 "°C",
             )
             sensor_readings.append(temp_sensor_reading)
@@ -281,28 +281,28 @@ class Aquacomputer(UsbHidDriver):
         for idx, fan_sensor_offset in enumerate(self._device_info.get("fan_sensors", [])):
             fan_speed = (
                 self._device_info["fan_speed_label"][idx],
-                self._hwmon.get_int(f"fan{idx + 1}_input"),
+                self._hwmon.read_int(f"fan{idx + 1}_input"),
                 "rpm",
             )
             sensor_readings.append(fan_speed)
 
             fan_power = (
                 self._device_info["fan_power_label"][idx],
-                self._hwmon.get_int(f"power{idx + 1}_input") * 1e-6,
+                self._hwmon.read_int(f"power{idx + 1}_input") * 1e-6,
                 "W",
             )
             sensor_readings.append(fan_power)
 
             fan_voltage = (
                 self._device_info["fan_voltage_label"][idx],
-                self._hwmon.get_int(f"in{idx}_input") * 1e-3,
+                self._hwmon.read_int(f"in{idx}_input") * 1e-3,
                 "V",
             )
             sensor_readings.append(fan_voltage)
 
             fan_current = (
                 self._device_info["fan_current_label"][idx],
-                self._hwmon.get_int(f"curr{idx + 1}_input") * 1e-3,
+                self._hwmon.read_int(f"curr{idx + 1}_input") * 1e-3,
                 "A",
             )
             sensor_readings.append(fan_current)
@@ -310,12 +310,12 @@ class Aquacomputer(UsbHidDriver):
         # Special-case sensor readings
         if self._device_info["type"] == self._DEVICE_D5NEXT:
             # Read +5V voltage rail value
-            plus_5v_voltage = ("+5V voltage", self._hwmon.get_int("in2_input") * 1e-3, "V")
+            plus_5v_voltage = ("+5V voltage", self._hwmon.read_int("in2_input") * 1e-3, "V")
             sensor_readings.append(plus_5v_voltage)
 
             if self._hwmon.has_attribute("in3_input"):
                 # The driver exposes the +12V voltage of the pump (kernel v5.20+), read the value
-                plus_12v_voltage = ("+12V voltage", self._hwmon.get_int("in3_input") * 1e-3, "V")
+                plus_12v_voltage = ("+12V voltage", self._hwmon.read_int("in3_input") * 1e-3, "V")
                 sensor_readings.append(plus_12v_voltage)
             else:
                 _LOGGER.warning(
@@ -323,7 +323,7 @@ class Aquacomputer(UsbHidDriver):
                 )
         elif self._device_info["type"] == self._DEVICE_QUADRO:
             # Read flow sensor value
-            flow_sensor_value = ("Flow sensor", self._hwmon.get_int("fan5_input"), "dL/h")
+            flow_sensor_value = ("Flow sensor", self._hwmon.read_int("fan5_input"), "dL/h")
             sensor_readings.append(flow_sensor_value)
 
         return sensor_readings

--- a/liquidctl/driver/commander_pro.py
+++ b/liquidctl/driver/commander_pro.py
@@ -289,19 +289,19 @@ class CommanderPro(UsbHidDriver):
         for i, probe_enabled in enumerate(temp_probes):
             if probe_enabled:
                 n = i + 1
-                temp = self._hwmon.get_int(f'temp{n}_input') * 1e-3
+                temp = self._hwmon.read_int(f'temp{n}_input') * 1e-3
                 status.append((f'Temperature {n}', temp, '°C'))
 
         # get fan RPMs of connected fans
         for i, fan_mode in enumerate(fan_modes):
             if fan_mode == _FAN_MODE_DC or fan_mode == _FAN_MODE_PWM:
                 n = i + 1
-                speed = self._hwmon.get_int(f'fan{n}_input')
+                speed = self._hwmon.read_int(f'fan{n}_input')
                 status.append((f'Fan {n} speed', speed, 'rpm'))
 
         # get the real power supply voltages
         for i, rail in enumerate(["+12V", "+5V", "+3.3V"]):
-            voltage = self._hwmon.get_int(f'in{i}_input') * 1e-3
+            voltage = self._hwmon.read_int(f'in{i}_input') * 1e-3
             status.append((f'{rail} rail', voltage, 'V'))
 
         return status

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -192,23 +192,23 @@ class CorsairHidPsu(UsbHidDriver):
         # with a kernel driver
         _LOGGER.warning('some attributes cannot be read from %s kernel driver', self._hwmon.driver)
 
-        input_voltage = self._hwmon.get_int('in0_input') * 1e-3
+        input_voltage = self._hwmon.read_int('in0_input') * 1e-3
 
         ret = [
-            ('VRM temperature', self._hwmon.get_int('temp1_input') * 1e-3, '°C'),
-            ('Case temperature', self._hwmon.get_int('temp2_input') * 1e-3, '°C'),
-            ('Fan speed', self._hwmon.get_int('fan1_input'), 'rpm'),
+            ('VRM temperature', self._hwmon.read_int('temp1_input') * 1e-3, '°C'),
+            ('Case temperature', self._hwmon.read_int('temp2_input') * 1e-3, '°C'),
+            ('Fan speed', self._hwmon.read_int('fan1_input'), 'rpm'),
             ('Input voltage', input_voltage, 'V'),
         ]
 
         for n, rail in zip(range(2, 5), [_RAIL_12V, _RAIL_5V, _RAIL_3P3V]):
             i = n - 1
             name = _RAIL_NAMES[rail]
-            ret.append((f'{name} output voltage', self._hwmon.get_int(f'in{i}_input') * 1e-3, 'V'))
-            ret.append((f'{name} output current', self._hwmon.get_int(f'curr{n}_input') * 1e-3, 'A'))
-            ret.append((f'{name} output power', self._hwmon.get_int(f'power{n}_input') * 1e-6, 'W'))
+            ret.append((f'{name} output voltage', self._hwmon.read_int(f'in{i}_input') * 1e-3, 'V'))
+            ret.append((f'{name} output current', self._hwmon.read_int(f'curr{n}_input') * 1e-3, 'A'))
+            ret.append((f'{name} output power', self._hwmon.read_int(f'power{n}_input') * 1e-6, 'W'))
 
-        output_power = self._hwmon.get_int('power1_input') * 1e-6
+        output_power = self._hwmon.read_int('power1_input') * 1e-6
         input_power = round(self._input_power_at(input_voltage, output_power), 0)
         efficiency = round(output_power / input_power * 100, 0)
 

--- a/liquidctl/driver/hwmon.py
+++ b/liquidctl/driver/hwmon.py
@@ -32,7 +32,7 @@ class HwmonDevice:
         _LOGGER.debug("read %s: %s", name, value)
         return value
 
-    def get_int(self, name):
+    def read_int(self, name):
         return int(self.get_string(name))
 
     def write_int(self, name, value):

--- a/liquidctl/driver/kraken2.py
+++ b/liquidctl/driver/kraken2.py
@@ -153,9 +153,9 @@ class Kraken2(UsbHidDriver):
 
     def _get_status_from_hwmon(self):
         return [
-            (_STATUS_TEMPERATURE, self._hwmon.get_int('temp1_input') * 1e-3, '°C'),
-            (_STATUS_FAN_SPEED, self._hwmon.get_int('fan1_input'), 'rpm'),
-            (_STATUS_PUMP_SPEED, self._hwmon.get_int('fan2_input'), 'rpm'),
+            (_STATUS_TEMPERATURE, self._hwmon.read_int('temp1_input') * 1e-3, '°C'),
+            (_STATUS_FAN_SPEED, self._hwmon.read_int('fan1_input'), 'rpm'),
+            (_STATUS_PUMP_SPEED, self._hwmon.read_int('fan2_input'), 'rpm'),
         ]
 
     def get_status(self, direct_access=False, **kwargs):

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -291,9 +291,9 @@ class KrakenX3(UsbHidDriver):
 
     def _get_status_from_hwmon(self):
         return [
-            (_STATUS_TEMPERATURE, self._hwmon.get_int("temp1_input") * 1e-3, "°C"),
-            (_STATUS_PUMP_SPEED, self._hwmon.get_int("fan1_input"), "rpm"),
-            (_STATUS_PUMP_DUTY, self._hwmon.get_int("pwm1") * 100.0 / 255, "%"),
+            (_STATUS_TEMPERATURE, self._hwmon.read_int("temp1_input") * 1e-3, "°C"),
+            (_STATUS_PUMP_SPEED, self._hwmon.read_int("fan1_input"), "rpm"),
+            (_STATUS_PUMP_DUTY, self._hwmon.read_int("pwm1") * 100.0 / 255, "%"),
         ]
 
     def get_status(self, direct_access=False, **kwargs):

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -343,10 +343,10 @@ class SmartDevice(_BaseSmartDevice):
 
         for i in range(len(self._speed_channels)):
             n = i + 1
-            ret.append((f'Fan {n} speed', self._hwmon.get_int(f'fan{n}_input'), 'rpm')),
-            ret.append((f'Fan {n} voltage', self._hwmon.get_int(f'in{i}_input') * 1e-3, 'V')),
-            ret.append((f'Fan {n} current', self._hwmon.get_int(f'curr{n}_input') * 1e-3, 'A')),
-            ret.append((f'Fan {n} control mode', mode[self._hwmon.get_int(f'pwm{n}_mode')], '')),
+            ret.append((f'Fan {n} speed', self._hwmon.read_int(f'fan{n}_input'), 'rpm')),
+            ret.append((f'Fan {n} voltage', self._hwmon.read_int(f'in{i}_input') * 1e-3, 'V')),
+            ret.append((f'Fan {n} current', self._hwmon.read_int(f'curr{n}_input') * 1e-3, 'A')),
+            ret.append((f'Fan {n} control mode', mode[self._hwmon.read_int(f'pwm{n}_mode')], '')),
 
         # noise level is not available through hwmon, but also not very accurate or useful
 
@@ -572,9 +572,9 @@ class SmartDevice2(_BaseSmartDevice):
         modes = ['DC', 'PWM']
 
         for n in range(1, len(self._speed_channels) + 1):
-            ret.append((f'Fan {n} speed', self._hwmon.get_int(f'fan{n}_input'), 'rpm')),
-            ret.append((f'Fan {n} duty', self._hwmon.get_int(f'pwm{n}') * 100. / 255, '%')),
-            ret.append((f'Fan {n} control mode', modes[self._hwmon.get_int(f'pwm{n}_mode')], '')),
+            ret.append((f'Fan {n} speed', self._hwmon.read_int(f'fan{n}_input'), 'rpm')),
+            ret.append((f'Fan {n} duty', self._hwmon.read_int(f'pwm{n}') * 100. / 255, '%')),
+            ret.append((f'Fan {n} control mode', modes[self._hwmon.read_int(f'pwm{n}_mode')], '')),
 
         # noise level is not available through hwmon, but also not very accurate or useful
 

--- a/tests/test_hwmon.py
+++ b/tests/test_hwmon.py
@@ -41,4 +41,4 @@ def test_gets_string(mock_hwmon):
 
 
 def test_gets_int(mock_hwmon):
-    assert mock_hwmon.get_int("fan1_input") == 1499
+    assert mock_hwmon.read_int("fan1_input") == 1499


### PR DESCRIPTION
As discussed in #499, rename `get_int` to `read_int` in `HwmonDevice` to match the newly added `write_int` function.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [ ] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
