### PR TITLE
Add support for reading virtual temp sensors on Aquacomputer D5 Next

### DIFF
--- a/docs/aquacomputer-d5next-guide.md
+++ b/docs/aquacomputer-d5next-guide.md
@@ -19,9 +19,9 @@ The pump automatically sends a status HID report every second as soon as it's co
 ## Monitoring
 
 The D5 Next exposes sensor values such as liquid temperature and two groups of fan sensors, for the pump and the
-optionally connected fan. These groups provide RPM speed, voltage, current and power readings. It also supports virtual
-temperature sensors, which are user assigned. Currently, they can only be read from the device. The pump additionally
-exposes +5V and +12V voltage rail readings:
+optionally connected fan. These groups provide RPM speed, voltage, current and power readings. It also supports eight
+virtual temperature sensors, which are user assigned. Currently, they can only be read from the device. The pump
+additionally exposes +5V and +12V voltage rail readings:
 
 ```
 # liquidctl status

--- a/docs/aquacomputer-d5next-guide.md
+++ b/docs/aquacomputer-d5next-guide.md
@@ -19,13 +19,15 @@ The pump automatically sends a status HID report every second as soon as it's co
 ## Monitoring
 
 The D5 Next exposes sensor values such as liquid temperature and two groups of fan sensors, for the pump and the
-optionally connected fan. These groups provide RPM speed, voltage, current and power readings. The pump additionally
+optionally connected fan. These groups provide RPM speed, voltage, current and power readings. It also supports virtual
+temperature sensors, which are user assigned. Currently, they can only be read from the device. The pump additionally
 exposes +5V and +12V voltage rail readings:
 
 ```
 # liquidctl status
 Aquacomputer D5 Next
 ├── Liquid temperature     26.9  °C
+├── Soft. Sensor 1         50.0  °C
 ├── Pump speed             1968  rpm
 ├── Pump power             2.56  W
 ├── Pump voltage          12.04  V

--- a/docs/developer/protocol/aquacomputer.md
+++ b/docs/developer/protocol/aquacomputer.md
@@ -62,7 +62,7 @@ Its ID is `0x01` and its length is `0x9e`.
 Here is what it's currently known to contain:
 
 | What                               | Where/starts at (offset) |
-| ---------------------------------- | ------------------------ |
+|------------------------------------|--------------------------|
 | Serial number (first part)         | 0x03                     |
 | Serial number (second part)        | 0x05                     |
 | Firmware version                   | 0xD                      |
@@ -72,6 +72,14 @@ Here is what it's currently known to contain:
 | Fan info substructure              | 0x67                     |
 | +5V voltage                        | 0x39                     |
 | +12V voltage                       | 0x37                     |
+| Virtual temp sensor 1              | 0x3F                     |
+| Virtual temp sensor 2              | 0x41                     |
+| Virtual temp sensor 3              | 0x43                     |
+| Virtual temp sensor 4              | 0x45                     |
+| Virtual temp sensor 5              | 0x47                     |
+| Virtual temp sensor 6              | 0x49                     |
+| Virtual temp sensor 7              | 0x4B                     |
+| Virtual temp sensor 8              | 0x4D                     |
 
 ### Control report
 

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -92,11 +92,11 @@ class Aquacomputer(UsbHidDriver):
             "type": _DEVICE_D5NEXT,
             "fan_sensors": [0x6C, 0x5F],
             "temp_sensors": [0x57],
-            "virt_temp_sensors": [0x3F + offset for offset in range(0, 8+1, 2)],
+            "virt_temp_sensors": [0x3F + offset for offset in range(0, 8 + 1, 2)],
             "plus_5v_voltage": 0x39,
             "plus_12v_voltage": 0x37,
             "temp_sensors_label": ["Liquid temperature"],
-            "virt_temp_sensors_label": [f"Soft. Sensor {num}" for num in range(1, 8+1)],
+            "virt_temp_sensors_label": [f"Soft. Sensor {num}" for num in range(1, 8 + 1)],
             "fan_speed_label": ["Pump speed", "Fan speed"],
             "fan_power_label": ["Pump power", "Fan power"],
             "fan_voltage_label": ["Pump voltage", "Fan voltage"],
@@ -336,7 +336,7 @@ class Aquacomputer(UsbHidDriver):
             sensor_readings.append(plus_5v_voltage)
 
             if self._hwmon.has_attribute("in3_input"):
-                # The driver exposes the +12V voltage of the pump (kernel v5.20+), read the value
+                # The driver exposes the +12V voltage of the pump (kernel v6.0+), read the value
                 plus_12v_voltage = ("+12V voltage", self._hwmon.read_int("in3_input") * 1e-3, "V")
                 sensor_readings.append(plus_12v_voltage)
             else:

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -7,7 +7,7 @@ from liquidctl.error import NotSupportedByDriver, NotSupportedByDevice
 
 D5NEXT_SAMPLE_STATUS_REPORT = bytes.fromhex(
     "00030DCB597C00010000006403FF00000051000004DC14000001E0007A98AF000"
-    "00000FFFF000041A803C169000001481ACAA3465CB804B401F4000000527FFF7F"
+    "00000FFFF000041A803C169000001481ACAA3465CB804B401F40000005213887F"
     "FF7FFF7FFF7FFF7FFF7FFF7FFF000000000000000009D27FFF00007FFF01F404B"
     "400200026016D006300000004B200D7010207B80000000000098D083A098A083A"
     "00060001000000000000000000000000011A24015E27101D4CFFBF"
@@ -223,6 +223,7 @@ def test_d5next_get_status_directly(mockD5NextDevice, has_hwmon, direct_access):
 
     expected = [
         ("Liquid temperature", pytest.approx(25.1, 0.1), "°C"),
+        ("Soft. Sensor 1", pytest.approx(50, 0.1), "°C"),
         ("Pump speed", 1976, "rpm"),
         ("Pump power", pytest.approx(2.58, 0.1), "W"),
         ("Pump voltage", pytest.approx(12.02, 0.1), "V"),

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -252,11 +252,27 @@ def test_d5next_get_status_from_hwmon(mockD5NextDevice, tmp_path):
     (tmp_path / "curr2_input").write_text("31\n")  # Fan current
     (tmp_path / "in2_input").write_text("4990\n")  # +5V voltage
     (tmp_path / "in3_input").write_text("12040\n")  # +12V voltage
+    (tmp_path / "temp2_input").write_text("50000\n")  # Soft. Sensor 1 temperature
+    (tmp_path / "temp3_input").write_text("60000\n")  # Soft. Sensor 2 temperature
+    (tmp_path / "temp4_input").write_text("50000\n")  # Soft. Sensor 3 temperature
+    (tmp_path / "temp5_input").write_text("50000\n")  # Soft. Sensor 4 temperature
+    (tmp_path / "temp6_input").write_text("50000\n")  # Soft. Sensor 5 temperature
+    (tmp_path / "temp7_input").write_text("50000\n")  # Soft. Sensor 6 temperature
+    (tmp_path / "temp8_input").write_text("50000\n")  # Soft. Sensor 7 temperature
+    (tmp_path / "temp9_input").write_text("50000\n")  # Soft. Sensor 8 temperature
 
     got = mockD5NextDevice.get_status()
 
     expected = [
         ("Liquid temperature", pytest.approx(25.1, 0.1), "°C"),
+        ("Soft. Sensor 1", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 2", pytest.approx(60, 0.1), "°C"),
+        ("Soft. Sensor 3", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 4", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 5", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 6", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 7", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 8", pytest.approx(50, 0.1), "°C"),
         ("Pump speed", 1976, "rpm"),
         ("Pump power", pytest.approx(2.58, 0.1), "W"),
         ("Pump voltage", pytest.approx(12.02, 0.1), "V"),


### PR DESCRIPTION
Add support for reading eight virtual temperature sensors on the Aquacomputer D5 Next. Virtual temperature sensors can be set by the user, but that is not yet reverse engineered.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [x] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [x] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
