### PR TITLE
Commander core fix hang

### DIFF
--- a/docs/developer/protocol/commander_core.md
+++ b/docs/developer/protocol/commander_core.md
@@ -21,7 +21,7 @@ sent for each command.
 
 Unless stated otherwise all multi-byte numbers used little endian.
 
-Host -> Device: 1024 bytes
+Host -> Device: 96 bytes for firmware v2.x.x | 1024 bytes for firmware v1.x.x
 
 | Byte index | Description |
 | ---------- | ----------- |
@@ -30,7 +30,7 @@ Host -> Device: 1024 bytes
 | 0x02 | Channel |
 | 0x03-... | Data |
 
-Device -> Host: 1024 bytes
+Device -> Host: 96 bytes for firmware v2.x.x | 1024 bytes for firmware v1.x.x
 
 | Byte index | Description |
 | ---------- | ----------- |

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -17,8 +17,8 @@ from liquidctl.util import clamp, u16le_from
 
 _LOGGER = logging.getLogger(__name__)
 
-_REPORT_LENGTH = 1024
-_RESPONSE_LENGTH = 1024
+_REPORT_LENGTH = 96
+_RESPONSE_LENGTH = 96
 
 _INTERFACE_NUMBER = 0
 


### PR DESCRIPTION
Reduce the _REPORT_LENGTH and _RESPONSE_LENGTH from 1024 to 96 to fix hang when loop over liquidctl status command according to @ParkerMc [comment](https://github.com/liquidctl/liquidctl/issues/505#issuecomment-1260311397) on issue #505 

Fixes:  #505

---

Checklist:

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update the README and other applicable documentation pages
- [ ] Update the `liquidctl.8` Linux/Unix/Mac OS man page
- [ ] Update or add applicable `docs/*guide.md` device guides
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `en`)

New driver?

- [x] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
