### PR TITLE
Add support for reading virtual temp sensors on Aquacomputer Farbwerk 360

### DIFF
--- a/docs/aquacomputer-farbwerk360-guide.md
+++ b/docs/aquacomputer-farbwerk360-guide.md
@@ -18,16 +18,19 @@ The controller automatically sends a status HID report every second as soon as i
 
 ## Monitoring
 
-The Farbwerk 360 exposes four temperature sensors.
+The Farbwerk 360 exposes four physical and sixteen virtual temperature sensors.
 
 ```
 # liquidctl status
 Aquacomputer Farbwerk 360 (experimental)
-├── Sensor 1    24.1  °C
-├── Sensor 2    25.7  °C
-├── Sensor 3    25.2  °C
-└── Sensor 4    25.6  °C
+├── Sensor 1          24.1  °C
+├── Sensor 2          25.7  °C
+├── Sensor 3          25.2  °C
+├── Sensor 4          25.6  °C
+└── Soft. Sensor 1    52.0  °C
 ```
+
+_Changed in git: read virtual temperature sensors as well._<br>
 
 ## Interaction with Linux hwmon drivers
 [Linux hwmon]: #interaction-with-linux-hwmon-drivers

--- a/docs/developer/protocol/aquacomputer.md
+++ b/docs/developer/protocol/aquacomputer.md
@@ -110,7 +110,32 @@ An example sensor report of the Farbwerk 360 looks like this:
 01 00 01 41 BB DE 92 03 E8 00 00 00 64 03 FE 00 00 00 11 00 00 00 09 D3 00 00 00 5E 00 08 A4 DD 00 00 00 24 BF E6 C0 34 A2 B4 FF D7 FF D5 FF D6 5A EC 0A 1F 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 7F FF 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 FA 01 FB 00 07 00 00 00 03 00 00 00 0B 00 00 00 00 00 15 20 1A 00 00 00 00 00 00 00 00 27 10 27 10 27 10 27 10 27 10 03 E8 00 00 03 E8 00 00 03 E8 00 00 03 E8 00 00 00 00 00 00 00 00 00 00 00 06 00 06 00 05 00 06 01 17 00 06
 ```
 
-Its ID is `0x01` and its length is `0xb6`. The four temp sensor values are located in succession at `0x32`, `0x34`, `0x36`, `0x38`.
+Its ID is `0x01` and its length is `0xb6`.
+
+Here is what it's currently known to contain:
+
+| What                   | Where/starts at (offset) |
+|------------------------|--------------------------|
+| Temp sensor 1          | 0x32                     |
+| Temp sensor 2          | 0x34                     |
+| Temp sensor 3          | 0x36                     |
+| Temp sensor 4          | 0x38                     |
+| Virtual temp sensor 1  | 0x3A                     |
+| Virtual temp sensor 2  | 0x3C                     |
+| Virtual temp sensor 3  | 0x3E                     |
+| Virtual temp sensor 4  | 0x40                     |
+| Virtual temp sensor 5  | 0x42                     |
+| Virtual temp sensor 6  | 0x44                     |
+| Virtual temp sensor 7  | 0x46                     |
+| Virtual temp sensor 8  | 0x48                     |
+| Virtual temp sensor 9  | 0x4A                     |
+| Virtual temp sensor 10 | 0x4C                     |
+| Virtual temp sensor 11 | 0x4E                     |
+| Virtual temp sensor 12 | 0x50                     |
+| Virtual temp sensor 13 | 0x52                     |
+| Virtual temp sensor 14 | 0x54                     |
+| Virtual temp sensor 15 | 0x56                     |
+| Virtual temp sensor 16 | 0x58                     |
 
 ## Octo
 

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -18,7 +18,8 @@ Aquacomputer Farbwerk 360
 Farbwerk 360 is an RGB controller and sends a status HID report every second
 with no initialization being required.
 
-The status HID report exposes four temperature sensor values.
+The status HID report exposes four physical and sixteen virtual temperature
+sensor values.
 
 Aquacomputer Octo
 -------------------------
@@ -112,7 +113,9 @@ class Aquacomputer(UsbHidDriver):
         _DEVICE_FARBWERK360: {
             "type": _DEVICE_FARBWERK360,
             "temp_sensors": [0x32, 0x34, 0x36, 0x38],
+            "virt_temp_sensors": [0x3A + offset * 2 for offset in range(0, 16)],
             "temp_sensors_label": ["Sensor 1", "Sensor 2", "Sensor 3", "Sensor 4"],
+            "virt_temp_sensors_label": [f"Soft. Sensor {num}" for num in range(1, 16 + 1)],
             "status_report_length": 0xB6,
         },
         _DEVICE_OCTO: {

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -43,7 +43,7 @@ D5NEXT_SAMPLE_CONTROL_REPORT = bytes.fromhex(
 
 FARBWERK360_SAMPLE_STATUS_REPORT = bytes.fromhex(
     "000141BBDE9203E80000006403FE000000110000001A150000005F0008AE3E000"
-    "00023BFC8C01AA20EFFD6A0E8A3915AEC0A3C0A470A6F09F87FFF7FFF7FFF7FFF"
+    "00023BFC8C01AA20EFFD6A0E8A3915AEC0A3C0A470A6F09F814507FFF7FFF7FFF"
     "7FFF7FFF7FFF7FFF7FFF7FFF7FFF7FFF7FFF7FFF7FFF7FFF00000000000000000"
     "00000000000000001F901FA0006000000030000004300000000000A0324000000"
     "00000000002710271027102710271003E8000003E8000003E8000003E80000000"
@@ -415,6 +415,7 @@ def test_farbwerk360_get_status_directly(mockFarbwerk360Device, has_hwmon, direc
         ("Sensor 2", pytest.approx(26.3, 0.1), "°C"),
         ("Sensor 3", pytest.approx(26.7, 0.1), "°C"),
         ("Sensor 4", pytest.approx(25.5, 0.1), "°C"),
+        ("Soft. Sensor 1", pytest.approx(52.00, 0.1), "°C"),
     ]
 
     assert sorted(got) == sorted(expected)
@@ -426,6 +427,22 @@ def test_farbwerk360_get_status_from_hwmon(mockFarbwerk360Device, tmp_path):
     (tmp_path / "temp2_input").write_text("26310\n")
     (tmp_path / "temp3_input").write_text("26710\n")
     (tmp_path / "temp4_input").write_text("25520\n")
+    (tmp_path / "temp5_input").write_text("50000\n")  # Soft. Sensor 1 temperature
+    (tmp_path / "temp6_input").write_text("60000\n")  # Soft. Sensor 2 temperature
+    (tmp_path / "temp7_input").write_text("50000\n")  # Soft. Sensor 3 temperature
+    (tmp_path / "temp8_input").write_text("50000\n")  # Soft. Sensor 4 temperature
+    (tmp_path / "temp9_input").write_text("50000\n")  # Soft. Sensor 5 temperature
+    (tmp_path / "temp10_input").write_text("50000\n")  # Soft. Sensor 6 temperature
+    (tmp_path / "temp11_input").write_text("50000\n")  # Soft. Sensor 7 temperature
+    (tmp_path / "temp12_input").write_text("50000\n")  # Soft. Sensor 8 temperature
+    (tmp_path / "temp13_input").write_text("50000\n")  # Soft. Sensor 9 temperature
+    (tmp_path / "temp14_input").write_text("50000\n")  # Soft. Sensor 10 temperature
+    (tmp_path / "temp15_input").write_text("50000\n")  # Soft. Sensor 11 temperature
+    (tmp_path / "temp16_input").write_text("50000\n")  # Soft. Sensor 12 temperature
+    (tmp_path / "temp17_input").write_text("50000\n")  # Soft. Sensor 13 temperature
+    (tmp_path / "temp18_input").write_text("50000\n")  # Soft. Sensor 14 temperature
+    (tmp_path / "temp19_input").write_text("50000\n")  # Soft. Sensor 15 temperature
+    (tmp_path / "temp20_input").write_text("50000\n")  # Soft. Sensor 16 temperature
 
     got = mockFarbwerk360Device.get_status()
 
@@ -434,6 +451,22 @@ def test_farbwerk360_get_status_from_hwmon(mockFarbwerk360Device, tmp_path):
         ("Sensor 2", pytest.approx(26.3, 0.1), "°C"),
         ("Sensor 3", pytest.approx(26.7, 0.1), "°C"),
         ("Sensor 4", pytest.approx(25.5, 0.1), "°C"),
+        ("Soft. Sensor 1", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 2", pytest.approx(60, 0.1), "°C"),
+        ("Soft. Sensor 3", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 4", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 5", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 6", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 7", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 8", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 9", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 10", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 11", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 12", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 13", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 14", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 15", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 16", pytest.approx(50, 0.1), "°C"),
     ]
 
     assert sorted(got) == sorted(expected)


### PR DESCRIPTION
Add support for reading sixteen virtual temperature sensors on the Aquacomputer Farbwerk 360.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [x] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `e`) and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
