### PR TITLE
Add support for reading virtual temp sensors on Aquacomputer Quadro

### DIFF
--- a/docs/aquacomputer-quadro-guide.md
+++ b/docs/aquacomputer-quadro-guide.md
@@ -24,6 +24,9 @@ The Quadro exposes four temperature sensors and four groups of fan sensors for o
 # liquidctl status
 Aquacomputer Quadro (experimental)
 ├── Sensor 3          15.9  °C
+├── Soft. Sensor 2      40.3  °C 
+├── Soft. Sensor 3      50.0  °C 
+├── Soft. Sensor 13     50.0  °C 
 ├── Fan 1 speed          0  rpm
 ├── Fan 1 power       0.00  W
 ├── Fan 1 voltage     0.00  V
@@ -42,6 +45,8 @@ Aquacomputer Quadro (experimental)
 ├── Fan 4 current     0.00  A
 └── Flow sensor          0  dL/h
 ```
+
+_Changed in git: read virtual temperature sensors as well._<br>
 
 ## Programming the fan speeds
 

--- a/docs/developer/protocol/aquacomputer.md
+++ b/docs/developer/protocol/aquacomputer.md
@@ -213,7 +213,8 @@ Here is what it's currently known to contain:
 
 ## Quadro
 
-The Quadro exposes four temperature sensors and four groups of fan sensor data (outlined in the preamble) through its sensor report.
+The Quadro exposes four physical and sixteen virtual temperature sensors, and four groups of fan sensor data
+(outlined in the preamble) through its sensor report.
 
 ### Sensor report
 
@@ -242,6 +243,22 @@ Here is what it's currently known to contain:
 | Fan 3 substructure                 | 0x8A                     |
 | Fan 4 substructure                 | 0x97                     |
 | Flow sensor                        | 0x6E                     |
+| Virtual temp sensor 1              | 0x3C                     |
+| Virtual temp sensor 2              | 0x3E                     |
+| Virtual temp sensor 3              | 0x40                     |
+| Virtual temp sensor 4              | 0x42                     |
+| Virtual temp sensor 5              | 0x44                     |
+| Virtual temp sensor 6              | 0x46                     |
+| Virtual temp sensor 7              | 0x48                     |
+| Virtual temp sensor 8              | 0x4A                     |
+| Virtual temp sensor 9              | 0x4C                     |
+| Virtual temp sensor 10             | 0x4E                     |
+| Virtual temp sensor 11             | 0x50                     |
+| Virtual temp sensor 12             | 0x52                     |
+| Virtual temp sensor 13             | 0x54                     |
+| Virtual temp sensor 14             | 0x56                     |
+| Virtual temp sensor 15             | 0x58                     |
+| Virtual temp sensor 16             | 0x5A                     |
 
 ### Control report
 

--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -35,8 +35,8 @@ Aquacomputer Quadro
 Quadro is a fan/RGB controller and sends a status HID report every second with
 no initialization being required.
 
-The status HID report exposes four temperature sensor values and four groups
-of fan sensors for optionally connected fans.
+The status HID report exposes four physical and sixteen virtual temperature sensor
+values, and four groups of fan sensors for optionally connected fans.
 
 Driver
 ------
@@ -143,7 +143,9 @@ class Aquacomputer(UsbHidDriver):
             "type": _DEVICE_QUADRO,
             "fan_sensors": [0x70, 0x7D, 0x8A, 0x97],
             "temp_sensors": [0x34, 0x36, 0x38, 0x3A],
+            "virt_temp_sensors": [0x3C + offset * 2 for offset in range(0, 16)],
             "temp_sensors_label": ["Sensor 1", "Sensor 2", "Sensor 3", "Sensor 4"],
+            "virt_temp_sensors_label": [f"Soft. Sensor {num}" for num in range(1, 16 + 1)],
             "fan_speed_label": [f"Fan {num} speed" for num in range(1, 4 + 1)],
             "fan_power_label": [f"Fan {num} power" for num in range(1, 4 + 1)],
             "fan_voltage_label": [f"Fan {num} voltage" for num in range(1, 4 + 1)],

--- a/tests/test_aquacomputer.py
+++ b/tests/test_aquacomputer.py
@@ -822,6 +822,8 @@ def test_quadro_get_status_directly(mockQuadroDevice, has_hwmon, direct_access):
 
     expected = [
         ("Sensor 3", pytest.approx(16.17, 0.1), "°C"),
+        ("Soft. Sensor 1", pytest.approx(23.9, 0.1), "°C"),
+        ("Soft. Sensor 13", pytest.approx(50.0, 0.1), "°C"),
         ("Fan 1 speed", pytest.approx(0, 0.1), "rpm"),
         ("Fan 1 power", pytest.approx(0, 0.1), "W"),
         ("Fan 1 voltage", pytest.approx(0, 0.1), "V"),
@@ -867,6 +869,22 @@ def test_quadro_get_status_from_hwmon(mockQuadroDevice, tmp_path):
     (tmp_path / "in3_input").write_text("0\n")
     (tmp_path / "curr4_input").write_text("0\n")
     (tmp_path / "fan5_input").write_text("603\n")
+    (tmp_path / "temp5_input").write_text("50000\n")  # Soft. Sensor 1 temperature
+    (tmp_path / "temp6_input").write_text("60000\n")  # Soft. Sensor 2 temperature
+    (tmp_path / "temp7_input").write_text("50000\n")  # Soft. Sensor 3 temperature
+    (tmp_path / "temp8_input").write_text("50000\n")  # Soft. Sensor 4 temperature
+    (tmp_path / "temp9_input").write_text("50000\n")  # Soft. Sensor 5 temperature
+    (tmp_path / "temp10_input").write_text("50000\n")  # Soft. Sensor 6 temperature
+    (tmp_path / "temp11_input").write_text("50000\n")  # Soft. Sensor 7 temperature
+    (tmp_path / "temp12_input").write_text("50000\n")  # Soft. Sensor 8 temperature
+    (tmp_path / "temp13_input").write_text("50000\n")  # Soft. Sensor 9 temperature
+    (tmp_path / "temp14_input").write_text("50000\n")  # Soft. Sensor 10 temperature
+    (tmp_path / "temp15_input").write_text("50000\n")  # Soft. Sensor 11 temperature
+    (tmp_path / "temp16_input").write_text("50000\n")  # Soft. Sensor 12 temperature
+    (tmp_path / "temp17_input").write_text("50000\n")  # Soft. Sensor 13 temperature
+    (tmp_path / "temp18_input").write_text("50000\n")  # Soft. Sensor 14 temperature
+    (tmp_path / "temp19_input").write_text("50000\n")  # Soft. Sensor 15 temperature
+    (tmp_path / "temp20_input").write_text("50000\n")  # Soft. Sensor 16 temperature
 
     got = mockQuadroDevice.get_status()
 
@@ -892,6 +910,22 @@ def test_quadro_get_status_from_hwmon(mockQuadroDevice, tmp_path):
         ("Fan 4 voltage", pytest.approx(0, 0.1), "V"),
         ("Fan 4 current", pytest.approx(0, 0.1), "A"),
         ("Flow sensor", pytest.approx(603, 0.1), "dL/h"),
+        ("Soft. Sensor 1", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 2", pytest.approx(60, 0.1), "°C"),
+        ("Soft. Sensor 3", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 4", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 5", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 6", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 7", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 8", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 9", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 10", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 11", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 12", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 13", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 14", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 15", pytest.approx(50, 0.1), "°C"),
+        ("Soft. Sensor 16", pytest.approx(50, 0.1), "°C"),
     ]
 
     assert sorted(got) == sorted(expected)


### PR DESCRIPTION
Add support for reading sixteen virtual temperature sensors on the Aquacomputer Quadro.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [x] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `e`) and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
