### PR TITLE
Hwmon support for nzxt-kraken3

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ subjective "from more to less liquid control-ly" order.
 | AIO liquid cooler  | [NZXT Kraken X31, X41, X61](docs/asetek-690lc-guide.md) | USB | <sup>_LZ_</sup> | 1.9.1 |
 | AIO liquid cooler  | [NZXT Kraken X42, X52, X62, X72](docs/kraken-x2-m2-guide.md) | USB HID | <sup>_h_</sup> | 1.11.1 |
 | AIO liquid cooler  | [NZXT Kraken X53, X63, X73](docs/kraken-x3-z3-guide.md) | USB HID | <sup>_h_</sup> | 1.11.1 |
-| AIO liquid cooler  | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | USB & USB HID | <sup>_e_</sup> | 1.11.1 |
+| AIO liquid cooler  | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | USB & USB HID | <sup>_he_</sup> | 1.11.1 |
 | Pump controller    | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | USB HID | <sup>_ehp_</sup> | 1.11.1 |
 | Fan/LED controller | [Aquacomputer Octo](docs/aquacomputer-octo-guide.md) | USB HID | <sup>_ehp_</sup> | 1.11.1 |
 | Fan/LED controller | [Aquacomputer Quadro](docs/aquacomputer-quadro-guide.md) | USB HID | <sup>_ehp_</sup> | 1.11.1 |

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -74,9 +74,9 @@ Fixed speeds can be set by specifying the desired channel and duty value.
 ```
 
 | Channel | Minimum duty | Maximum duty | X models | Z models |
-| --- | --- | --- | :---: | :---: |
+| --- | -- | --- | :---: | :---: |
 | `pump` | 20% | 100% | ✓ | ✓ |
-| `fan` | 20% | 100% | | ✓ |
+| `fan` | 0% | 100% | | ✓ |
 
 For profiles, one or more temperature–duty pairs are supplied instead of single value.
 

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -174,16 +174,14 @@ Images and GiFs are automatically resized and rotated to match the device orient
 [Linux hwmon]: #interaction-with-linux-hwmon-drivers
 
 _New in 1.9.0._<br>
+_Changed in git: expanded support for reading and writing through hwmon._<br>
 
-Kraken X3 devices feature incomplete support by the [liquidtux] `nzxt-kraken3`
-driver, and partial status data is provided through a standard hwmon sysfs
-interface.
-
-_As of February 2022, the driver is too limited for liquidctl to use; still..._
+Kraken X3 devices feature support by the [liquidtux] `nzxt-kraken3` driver,
+and status data is provided through a standard hwmon sysfs interface.
 
 Starting with version 1.9.0, liquidctl automatically detects when a kernel
 driver is bound to the device and, whenever possible, uses it instead of
-directly accessing the device.  Alternatively, direct access to the device can
+directly accessing the device. Alternatively, direct access to the device can
 be forced with `--direct-access`.
 
 [liquidtux]: https://github.com/liquidctl/liquidtux

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -176,7 +176,7 @@ Images and GiFs are automatically resized and rotated to match the device orient
 _New in 1.9.0._<br>
 _Changed in git: expanded support for reading and writing through hwmon._<br>
 
-Kraken X3 devices feature support by the [liquidtux] `nzxt-kraken3` driver,
+Kraken X3 and Z3 devices feature support by the [liquidtux] `nzxt-kraken3` driver,
 and status data is provided through a standard hwmon sysfs interface.
 
 Starting with version 1.9.0, liquidctl automatically detects when a kernel

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -100,6 +100,10 @@ _COLOR_CHANNELS_KRAKENZ = {
     "external": 0b001,
 }
 
+_HWMON_CTRL_MAPPING_KRAKENX = {"pump": "pwm1"}
+
+_HWMON_CTRL_MAPPING_KRAKENZ = {"pump": "pwm1", "fan": "pwm2"}
+
 # Available LED channel modes/animations
 # name -> (mode, size/variant, speed scale, min colors, max colors)
 # FIXME any point in a one-color *alternating* or tai-chi animations?
@@ -203,7 +207,7 @@ class KrakenX3(UsbHidDriver):
             {
                 "speed_channels": _SPEED_CHANNELS_KRAKENX,
                 "color_channels": _COLOR_CHANNELS_KRAKENX,
-                "hwmon_ctrl_mapping": {"pump": "pwm1"},
+                "hwmon_ctrl_mapping": _HWMON_CTRL_MAPPING_KRAKENX,
             },
         ),
         (
@@ -213,7 +217,7 @@ class KrakenX3(UsbHidDriver):
             {
                 "speed_channels": _SPEED_CHANNELS_KRAKENX,
                 "color_channels": _COLOR_CHANNELS_KRAKENX,
-                "hwmon_ctrl_mapping": {"pump": "pwm1"},
+                "hwmon_ctrl_mapping": _HWMON_CTRL_MAPPING_KRAKENX,
             },
         ),
     ]
@@ -530,7 +534,7 @@ class KrakenZ3(KrakenX3):
             {
                 "speed_channels": _SPEED_CHANNELS_KRAKENZ,
                 "color_channels": _COLOR_CHANNELS_KRAKENZ,
-                "hwmon_ctrl_mapping": {"pump": "pwm1", "fan": "pwm2"},
+                "hwmon_ctrl_mapping": _HWMON_CTRL_MAPPING_KRAKENZ,
             },
         )
     ]

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -393,10 +393,10 @@ class KrakenX3(UsbHidDriver):
             )
 
         if self._hwmon:
-            hwmon_pwm_name = f"pwm{self._hwmon_ctrl_mapping[channel]}"
+            hwmon_pwm_enable_name = f"pwm{self._hwmon_ctrl_mapping[channel]}_enable"
 
             # Check if the required attribute is present
-            if self._hwmon.has_attribute(hwmon_pwm_name):
+            if self._hwmon.has_attribute(hwmon_pwm_enable_name):
                 # It is, and if we have to use direct access, warn that we are sidestepping the kernel driver
                 if direct_access:
                     _LOGGER.warning(

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -373,7 +373,12 @@ class KrakenX3(UsbHidDriver):
             pwm_duty = duty * 255 // 100
             self._hwmon.write_int(f"temp{hwmon_ctrl_channel}_auto_point{idx + 1}_pwm", pwm_duty)
 
-        # Wait just for a bit so the last report goes through (if it was in curve mode already)
+        # The device can get confused when hammered with HID reports, which can happen when
+        # we set all curve points (done above) through the kernel driver, when the device
+        # is in curve mode. In that case, the driver sends a report for each point value change
+        # to update it. We send the whole curve to the device again by setting pwmX_enable to 2,
+        # regardless of what it was, to ensure that the curve is properly applied. Wait just for
+        # a bit to ensure that goes through
         time.sleep(0.2)
 
         # Set channel to curve mode

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -299,11 +299,20 @@ class KrakenX3(UsbHidDriver):
         ]
 
     def _get_status_from_hwmon(self):
-        return [
+        status_readings = [
             (_STATUS_TEMPERATURE, self._hwmon.read_int("temp1_input") * 1e-3, "°C"),
             (_STATUS_PUMP_SPEED, self._hwmon.read_int("fan1_input"), "rpm"),
-            (_STATUS_PUMP_DUTY, self._hwmon.read_int("pwm1") * 100.0 / 255, "%"),
         ]
+
+        if self._hwmon.has_attribute("pwm1"):
+            status_readings.append(
+                (_STATUS_PUMP_DUTY, self._hwmon.read_int("pwm1") * 100.0 / 255, "%")
+            )
+        else:
+            # An older version of the kernel driver only exposed coolant temp and pump speed
+            _LOGGER.warning("pump duty cannot be read from %s kernel driver", self._hwmon.driver)
+
+        return status_readings
 
     def get_status(self, direct_access=False, **kwargs):
         """Get a status report.

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -697,23 +697,6 @@ class KrakenZ3(KrakenX3):
             (_STATUS_FAN_DUTY, self._hwmon.read_int("pwm2") * 100.0 / 255, "%"),
         ]
 
-    def get_status(self, direct_access=False, **kwargs):
-        """Get a status report.
-
-        Returns a list of `(property, value, unit)` tuples.
-        """
-
-        if self._hwmon and not direct_access:
-            _LOGGER.info("bound to %s kernel driver, reading status from hwmon", self._hwmon.driver)
-            return self._get_status_from_hwmon()
-
-        if self._hwmon:
-            _LOGGER.warning(
-                "directly reading the status despite %s kernel driver", self._hwmon.driver
-            )
-
-        return self._get_status_directly()
-
     def _read_until_first_match(self, parsers):
         for _ in range(_MAX_READ_ATTEMPTS):
             msg = self._read()

--- a/tests/test_backward_compatibility_14.py
+++ b/tests/test_backward_compatibility_14.py
@@ -50,16 +50,19 @@ def test_kraken3_backwards_modes_are_deprecated(caplog):
     from liquidctl.driver.kraken3 import KrakenX3
     from liquidctl.driver.kraken3 import _COLOR_CHANNELS_KRAKENX
     from liquidctl.driver.kraken3 import _SPEED_CHANNELS_KRAKENX
+    from liquidctl.driver.kraken3 import _HWMON_CTRL_MAPPING_KRAKENX
 
     for mode in modes:
         base_mode = mode.replace('backwards-', '')
 
         old = KrakenX3(MockHidapiDevice(), 'Mock X63',
                        speed_channels=_SPEED_CHANNELS_KRAKENX,
-                       color_channels=_COLOR_CHANNELS_KRAKENX)
+                       color_channels=_COLOR_CHANNELS_KRAKENX,
+                       hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENX)
         new = KrakenX3(MockHidapiDevice(), 'Mock X63',
                        speed_channels=_SPEED_CHANNELS_KRAKENX,
-                       color_channels=_COLOR_CHANNELS_KRAKENX)
+                       color_channels=_COLOR_CHANNELS_KRAKENX,
+                       hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENX)
 
         colors = [RADICAL_RED, MOUNTAIN_MEADOW]
 

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -509,10 +509,12 @@ def test_krakenz3_set_speed_profile_hwmon(mock_krakenz3, has_support, tmp_path):
             )
     else:
         # Assert fallback to direct access
-        pump_report = mock_krakenz3.device.sent[0]
+        pump_report, fan_report = mock_krakenz3.device.sent
 
         assert pump_report.number == 0x72
         assert pump_report.data[3:43] == test_curve_final_pwm
+        assert fan_report.number == 0x72
+        assert fan_report.data[3:43] == test_curve_final_pwm
 
 
 def test_krakenz3_not_totally_broken(mock_krakenz3):

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -12,6 +12,8 @@ from liquidctl.driver.kraken3 import (
     _SPEED_CHANNELS_KRAKENX,
     _COLOR_CHANNELS_KRAKENZ,
     _SPEED_CHANNELS_KRAKENZ,
+    _HWMON_CTRL_MAPPING_KRAKENX,
+    _HWMON_CTRL_MAPPING_KRAKENZ
 )
 from test_krakenz3_response import krakenz3_response
 
@@ -39,6 +41,7 @@ def mock_krakenx3():
         "Mock Kraken X73",
         speed_channels=_SPEED_CHANNELS_KRAKENX,
         color_channels=_COLOR_CHANNELS_KRAKENX,
+        hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENX
     )
 
     dev.connect()
@@ -53,6 +56,7 @@ def mock_krakenz3():
         "Mock Kraken Z73",
         speed_channels=_SPEED_CHANNELS_KRAKENZ,
         color_channels=_COLOR_CHANNELS_KRAKENZ,
+        hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENZ
     )
 
     dev.connect()


### PR DESCRIPTION
With the [nzxt-kraken3](https://github.com/liquidctl/liquidtux/blob/master/nzxt-kraken3.c) HWMON driver now having expanded support for NZXT Kraken X53/X63/X73 and Z53/Z63/Z73 devices, allow liquidctl to leverage it when available.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [x] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `e`) and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
