### PR TITLE
use updated winusbcdc

### DIFF
--- a/.github/workflows/test-from-sources.yml
+++ b/.github/workflows/test-from-sources.yml
@@ -71,7 +71,7 @@ jobs:
           pyusb \
           "libusb-package; sys_platform == 'win32' or sys_platform == 'cygwin'" \
           "smbus; sys_platform == 'linux'" \
-          "winusbcdc; sys_platform == 'win32'"
+          "winusbcdc>=1.5; sys_platform == 'win32'"
 
     - name: Run unit tests and module doctests
       run: |

--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ python -m pip install --upgrade pip setuptools setuptools_scm wheel
 python -m pip install --upgrade colorlog crcmod==1.7 docopt hidapi pillow pytest pyusb
 python -m pip install --upgrade "libusb-package; sys_platform == 'win32' or sys_platform == 'cygwin'"
 python -m pip install --upgrade "smbus; sys_platform == 'linux'"
-python -m pip install --upgrade "winusbcdc; sys_platform == 'win32'"
+python -m pip install --upgrade "winusbcdc>=1.5; sys_platform == 'win32'"
 ```
 
 At this point, the environment is set up.  To run the test suite, execute:

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,7 +55,7 @@ install_requires =
   pyusb
   pillow
   libusb-package; sys_platform == 'win32' or sys_platform == 'cygwin'
-  winusbcdc; sys_platform == 'win32'
+  winusbcdc>=1.5; sys_platform == 'win32'
   smbus; sys_platform == "linux"
 
 [options.entry_points]


### PR DESCRIPTION
Describe what the changes are meant to address.

My changes to upstream winsubcdc were accepted and a new version was released (1.5). this pr cleans up the unneeded code under "_find_winusb_device" in the kraken3 driver

If the implementation is not trivial, please also include a short overview.

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: <!-- #number of issue (implies Closes tag) or commit SHA -->
Closes: <!-- #number of issue or pull request -->
Related: #479 

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [ x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `e`) and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
