### PR TITLE
prometheus exporter: Add device selection options

### DIFF
--- a/extra/prometheus-liquidctl-exporter
+++ b/extra/prometheus-liquidctl-exporter
@@ -14,12 +14,24 @@ Usage:
   prometheus-liquidctl-exporter [options]
 
 Options:
-  --legacy-690lc          Use Asetek 690LC in legacy mode (old Krakens)
-  --server-port <number>  Port for the HTTP /metrics endpoint
-  -v, --verbose           Output additional information
-  -g, --debug             Show debug information on stderr
-  --version               Display the version number
-  --help                  Show this message
+  --legacy-690lc                     Use Asetek 690LC in legacy mode (old Krakens)
+  --server-port <number>             Port for the HTTP /metrics endpoint
+  -v, --verbose                      Output additional information
+  -g, --debug                        Show debug information on stderr
+  --version                          Display the version number
+  --help                             Show this message
+
+Device selection options (see: list -v):
+  -m, --match <substring>            Filter devices by description substring
+  -n, --pick <number>                Pick among many results for a given filter
+  --vendor <id>                      Filter devices by hexadecimal vendor ID
+  --product <id>                     Filter devices by hexadecimal product ID
+  --release <number>                 Filter devices by hexadecimal release number
+  --serial <number>                  Filter devices by serial number
+  --bus <bus>                        Filter devices by bus
+  --address <address>                Filter devices by address in bus
+  --usb-port <port>                  Filter devices by USB port in bus
+
 
 Copyright Alex Berryman, Jonas Malaco and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
@@ -93,7 +105,16 @@ def _make_opts(arguments):
 
 
 _PARSE_ARG = {
-    '--legacy-690lc': bool
+    '--legacy-690lc': bool,
+    '--vendor': lambda x: int(x, 16),
+    '--product': lambda x: int(x, 16),
+    '--release': lambda x: int(x, 16),
+    '--serial': str,
+    '--bus': str,
+    '--address': str,
+    '--usb-port': lambda x: tuple(map(int, x.split('.'))),
+    '--match': str,
+    '--pick': int,
 }
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds the device selection options from the main liquidctl command line to the prometheus exporter. Feel free let me know if there's anything I can improve about this contribution! :)

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `e`) and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
