### PR TITLE
[CLI] Print the usb port in json status

### DIFF
--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -248,6 +248,7 @@ def _dev_status_obj(dev, status):
     return {
         'bus': dev.bus,
         'address': dev.address,
+        'port': '.'.join(map(str, dev.port)) if dev.port else None,
         'description': dev.description.replace(' (experimental)', ''),
         'status': [convert(x) for x in status]
     }

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -268,7 +268,7 @@ class VirtualBusDevice(BaseDriver):
 
     @property
     def port(self):
-        return None
+        return [12, 34]
 
 
 class VirtualBus(BaseBus):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -37,7 +37,7 @@ def test_json_list(main):
             'serial_number': None,
             'bus': 'virtual',
             'address': 'virtual_address',
-            'port': None,
+            'port': [12, 34],
             'driver': 'VirtualBusDevice',
             'experimental': True,
         }
@@ -54,6 +54,7 @@ def test_json_initialize(main):
         {
             'bus': 'virtual',
             'address': 'virtual_address',
+            'port': '12.34',
             'description': 'Virtual Bus Device',
             'status': [
                 { 'key': 'Firmware version', 'value': '3.14.16', 'unit': '' },
@@ -72,6 +73,7 @@ def test_json_status(main):
         {
             'bus': 'virtual',
             'address': 'virtual_address',
+            'port': '12.34',
             'description': 'Virtual Bus Device',
             'status': [
                 { 'key': 'Temperature', 'value': 30.4, 'unit': '°C' },


### PR DESCRIPTION
When printing the status of devices in json inside the cli, we get `bus` and `address`, but when `bus` is a `usb`, `address` is quite useless and it would be good to see the `port` to address the correct device using `--usb-port`. As you can see in [this](https://github.com/jmarucha/FanControl.Liquidctl/issues/16#issuecomment-1484169867) comment, the `port` is not shown:

```json
[
    {
        "bus": "usb1",
        "address": 4,
        "description": "Asetek 690LC (assuming EVGA CLC)",
        "status": [...]
    }
]
```

After the patch:

```json
[
    {
        "bus": "usb1",
        "address": 4,
        "port": "11",
        "description": "Asetek 690LC (assuming EVGA CLC)",
        "status": [...]
    }
]
```

The implementation is taken from the [_list_devices_human](https://github.com/liquidctl/liquidctl/blob/c20fbb0f6ae4a0ee6cc6bd091ecd7ad99502cb0e/liquidctl/cli.py#L218) function which already shows the port.

There is one [test](https://github.com/SuspiciousActivity/liquidctl/actions/runs/4572209608/jobs/8071227024) failing that I have no idea why, and to be honest I don't know what it even does and how it has anything to do with my patch. So if someone could give some help on that, that'd be great.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes (at least `e`) and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
