### PR TITLE
docs: note that CAM must be closed for kraken drivers to work

### DIFF
--- a/docs/kraken-x2-m2-guide.md
+++ b/docs/kraken-x2-m2-guide.md
@@ -11,6 +11,7 @@ All configuration is done through USB, and persists as long as the device still 
 
 All capabilities available at the hardware level are supported, but other features offered by CAM, like presets based on CPU or GPU temperatures, have not been implemented.  Pump and fan control based on liquid temperature is supported on units running firmware versions 4 or above.
 
+Monitoring and/or configuring the coolers is not possible with CAM running, otherwise you'll get errors such as `OSError('read error')`.
 
 ## NZXT Kraken M22
 

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -7,6 +7,7 @@ Both X and Z models house seventh-generation Asetek pump designs, plus secondary
 
 All configuration is done through USB, and persists as long as the device still gets power, even if the system has gone to Soft Off (S5) state.  The coolers also report relevant data via USB, including pump and/or fan speeds and liquid temperature.  The pump speed can be sent to the motherboard (or other device) via the sense pin of a standard fan connector.
 
+Monitoring and/or configuring the coolers is not possible with CAM running, otherwise you'll get errors such as `OSError('read error')`.
 
 ## NZXT Kraken X53, X63, X73
 


### PR DESCRIPTION
Inspired by the linked issue. Add a note to Kraken docs that CAM can't be running if you want liquidctl to work.

Fixes: #532 <!-- #number of issue (implies Closes tag) or commit SHA -->
