### PR TITLE
Fix MRLV question type from input to dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -44,7 +44,7 @@ body:
       placeholder: e.g. Corsair Hydro H100i Pro XT
     validations:
       required: false
-  - type: input
+  - type: dropdown
     id: checked-supported-devices
     attributes:
       label: Does your version of liquidctl support the device in question?


### PR DESCRIPTION
Quick fix for #647, the right type for the question is `dropdown`.