### PR TITLE
Fix various issues with Unix file permission handling in `liquidctl.keyval`

### DIFF
--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -71,6 +71,9 @@ def _open_with_lock(path, flags, *, shared=False):
 
         yield f
 
+        if access != os.O_RDONLY:
+            f.flush()  # ensure flushing before automatic unlocking
+
 
 if {'umask', 'stat', 'chmod'} <= os.__dict__.keys() \
         and {os.stat, os.chmod} <= os.supports_fd:
@@ -165,7 +168,6 @@ class _FilesystemBackend:
 
         with _open_with_lock(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC) as f:
             f.write(data)
-            f.flush()  # ensure flushing before automatic unlocking
 
         _LOGGER.debug('stored %s=%r (in %s)', key, value, path)
 
@@ -211,7 +213,6 @@ class _FilesystemBackend:
             assert literal_eval(data) == new_value, 'encode/decode roundtrip fails'
             f.write(data)
             f.truncate()
-            f.flush()  # ensure flushing before automatic unlocking
 
             _LOGGER.debug('replaced with %s=%r (stored in %s)', key, new_value, path)
 

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -61,7 +61,7 @@ def _open_with_lock(path, flags, *, shared=False):
     else:
         raise ValueError(f'Invalid os.open() flags: {flags}')
 
-    with os.fdopen(os.open(path, flags), mode=write_mode) as f:
+    with os.fdopen(os.open(path, flags, 0o666), mode=write_mode) as f:
         if sys.platform == 'win32':
             msvcrt.locking(f.fileno(), msvcrt.LK_LOCK, 1)
         elif shared:

--- a/liquidctl/keyval.py
+++ b/liquidctl/keyval.py
@@ -134,7 +134,7 @@ class _FilesystemBackend:
             # create leaf directory as 0o0700, but do not break ACLs
             os.makedirs(self._write_dir, exist_ok=True)
             # set the sticky bit to prevent removal during cleanup
-            _chmod_bits(self._write_dir, 0o1000, flags=os.O_DIRECTORY)
+            _chmod_bits(self._write_dir, 0o1000)  # flags=os.O_DIRECTORY, but !win32
         _LOGGER.debug('data in %s', self._write_dir)
 
     def load(self, key):


### PR DESCRIPTION
The immediate issue with `liquidctl.keyval` is that it hardcodes Unix permission bits and thus does not play nice with (default) POSIX ACLs, if any are set on `/run/liquidctl`. This, in turn, makes it impossible to use liquidctl as more than one user (even if the necessary permissions are granted on the device nodes).

Normally, `/run/liquidctl/*/*` (e. g. `/run/liquidctl/vid1b1c_pid0c10/loc2`) is created with restricted 0o1700 permission bits, which is reasonable. However, if one desires to grant read/write permissions to these files to more than one user, it is impossible to do so with default ACLs (e. g. `setfacl -d g:liquidctl-users:rwX /run/liquidctl`) because the 0o1700 bits are forcibly set with `os.chmod()`, clearing the POSIX ACL mask value (which is overlaid with group permissions) and invalidating any permission-granting ACLs.

To fix this, we need to work with the permission bits in a semantically correct way. We apply the access restriction by adjusting the process umask value (which is overridden by default ACLs, if any are applicable) prior to file creation. Then, to set the sticky bit, we OR it into the resulting file's permissions without assuming their value.

Additionally, this fixes broken access flags handling in `_open_with_lock()` (as written, it causes all files to be opened with `w+` access string) and sets the mode to `0o666` to avoid creating executable files (as per above, we do not set `0o644` or `0o600` directly in the `os.open()` call, instead letting umask and default ACLs do their job).

---

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: (multiple commits; see individual commit messages)

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes