### PR TITLE
aquacomputer: Write to pwmX_enable only if it's available

### DIFF
--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -428,11 +428,12 @@ class Aquacomputer(UsbHidDriver):
     def _set_fixed_speed_hwmon(self, channel, duty):
         hwmon_pwm_name, hwmon_pwm_enable_name = self._fan_name_to_hwmon_names(channel)
 
-        # Set channel to direct percent mode
-        self._hwmon.write_int(hwmon_pwm_enable_name, 1)
+        # Set channel to direct percent mode, if pwmX_enable exists
+        if self._hwmon.has_attribute(hwmon_pwm_enable_name):
+            self._hwmon.write_int(hwmon_pwm_enable_name, 1)
 
-        # Some devices (Octo, Quadro and Aquaero) can not accept reports in quick succession, so slow down a bit
-        time.sleep(0.2)
+            # Some devices (Octo, Quadro and Aquaero) can not accept reports in quick succession, so slow down a bit
+            time.sleep(0.2)
 
         # Convert duty from percent to PWM range (0-255)
         pwm_duty = duty * 255 // 100
@@ -474,13 +475,12 @@ class Aquacomputer(UsbHidDriver):
         duty = clamp(duty, 0, 100)
 
         if self._hwmon:
-            hwmon_pwm_name, hwmon_pwm_enable_name = self._fan_name_to_hwmon_names(channel)
+            hwmon_pwm_name, _ = self._fan_name_to_hwmon_names(channel)
 
-            # Check if the required attributes are present
-            if self._hwmon.has_attribute(hwmon_pwm_name) and self._hwmon.has_attribute(
-                hwmon_pwm_enable_name
-            ):
-                # They are, and if we have to use direct access, warn that we are sidestepping the kernel driver
+            # Check if pwmX is present, as that's the baseline for being able to set a PWM speed
+            # If pwmX_enable is also present, great! But we'll make use of that in the specialized function
+            if self._hwmon.has_attribute(hwmon_pwm_name):
+                # If we have to use direct access, warn that we are sidestepping the kernel driver
                 if direct_access:
                     _LOGGER.warning(
                         "directly writing fixed speed despite %s kernel driver having support",


### PR DESCRIPTION
If `pwmX_enable` is not present, but `pwmX` is, use only that for Aquacomputer devices to set the speed.

Fixes: #669

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
