### PR TITLE
aquacomputer: Revert #670 and add explanation for required hwmon entries

### DIFF
--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -476,7 +476,10 @@ class Aquacomputer(UsbHidDriver):
         if self._hwmon:
             hwmon_pwm_name, hwmon_pwm_enable_name = self._fan_name_to_hwmon_names(channel)
 
-            # Check if the required attributes are present
+            # pwmX and pwmX_enable attributes are required in order to set the PWM value,
+            # as well as the channel mode to "direct PWM value". Without pwmX_enable,
+            # we can't guarantee that the PWM value will at all be used, as the channel
+            # could be in a different mode (PID, curve, fan follow).
             if self._hwmon.has_attribute(hwmon_pwm_name) and self._hwmon.has_attribute(
                 hwmon_pwm_enable_name
             ):


### PR DESCRIPTION
Revert #670 as that proved to be an incomplete fix due to the underlying in-tree kernel driver implementation (see related commit). Also, add an explanation to liquidctl why both pwmX and pwmX_enable attributes are required for setting PWM value successfully.

Related: #670, #671

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
