### PR TITLE
kraken3: Show an error when setting an image on unsupported fw

### DIFF
--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -771,6 +771,17 @@ class KrakenZ3(KrakenX3):
             self.brightness = msg[0x18]
             self.orientation = msg[0x1A]
 
+        # Firmware 2.0.0 and onwards broke the implemented image setting mechanism for Kraken 2023
+        # (standard and elite). In those cases, show an error until issue #631 is resolved.
+        def unsupported_fw_version():
+            device_product_id = self.bulk_device.product_id
+            if device_product_id in (0x300C, 0x300E) and self.fw[0] == 2:
+                _LOGGER.error(
+                    "setting images is not supported on firmware 2.X.Y, please see issue #631"
+                )
+                return True
+            return False
+
         self._read_until({b"\x31\x01": parse_lcd_info})
 
         if mode == "brightness":
@@ -786,10 +797,14 @@ class KrakenZ3(KrakenX3):
             self._write([0x30, 0x02, 0x01, self.brightness, 0x0, 0x0, 0x1, int(value_int / 90)])
             return
         elif mode == "static":
+            if unsupported_fw_version():
+                return
             data = self._prepare_static_file(value, self.orientation)
             self._send_data(data, [0x02, 0x0, 0x0, 0x0] + list(len(data).to_bytes(4, "little")))
             return
         elif mode == "gif":
+            if unsupported_fw_version():
+                return
             data = self._prepare_gif_file(value, self.orientation)
             assert (
                 len(data) / 1000 < _LCD_TOTAL_MEMORY

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -251,8 +251,8 @@ class KrakenX3(UsbHidDriver):
         return sorted(self._status)
 
     def parse_firm_info(self, msg):
-        fw = f"{msg[0x11]}.{msg[0x12]}.{msg[0x13]}"
-        self._status.append(("Firmware version", fw, ""))
+        self.fw = (msg[0x11], msg[0x12], msg[0x13])
+        self._status.append(("Firmware version", f"{self.fw[0]}.{self.fw[1]}.{self.fw[2]}", ""))
 
     def parse_led_info(self, msg):
         channel_count = msg[14]


### PR DESCRIPTION
We don't support setting images on 2023 NZXT Kraken models since firmware 2.0.0. Show an error if that's the case, instead of letting it fail.

This effectively prevents the user from trying to set images on the affected devices. I don't think there's anything to gain by giving out just a warning and letting it fail.

Related: #631

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [ ] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
