### PR TITLE
hydro_platinum: add support for H115i Elite RGB

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [Corsair Hydro Pro XT H60i, H100i, H115i, H150i](docs/corsair-platinum-pro-xt-guide.md) | | 1.8.1 |
 | AIO liquid cooler  | ~~[Corsair iCUE Elite Capellix H100i, H115i, H150i](docs/corsair-commander-core-guide.md)~~ | <sup>_Bp_</sup> | 1.11.1 |
 | AIO liquid cooler  | [Corsair iCUE Elite RGB H100i, H150i](docs/corsair-platinum-pro-xt-guide.md) | | 1.13.0 |
+| AIO liquid cooler  | [Corsair iCUE Elite RGB H115i](docs/corsair-platinum-pro-xt-guide.md) | | git |
 | AIO liquid cooler  | [EVGA CLC 120 (CL12), 240, 280, 360](docs/asetek-690lc-guide.md) | <sup>_Z_</sup> | 1.9.1 |
 | AIO liquid cooler  | [MSI MPG Coreliquid K360](docs/msi-mpg-coreliquid-guide.md) | <sup>_p_</sup> | git |
 | AIO liquid cooler  | [NZXT Kraken M22](docs/kraken-x2-m2-guide.md) | | 1.10.0 |

--- a/docs/corsair-platinum-pro-xt-guide.md
+++ b/docs/corsair-platinum-pro-xt-guide.md
@@ -2,6 +2,7 @@
 _Driver API and source code available in [`liquidctl.driver.hydro_platinum`](../liquidctl/driver/hydro_platinum.py)._
 
 _Changed in 1.13.0: support added for the H100i and H150i Elite RGB models._<br>
+_Changed in git: the H115i Elite RGB is now supported._<br>
 
 ## Initializing the device and setting the pump mode
 

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -353,16 +353,16 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0c70", ATTRS{idProduct}=="f00d", TAG+="uacc
 # Asetek 690LC (assuming NZXT Kraken X)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="2433", ATTRS{idProduct}=="b200", TAG+="uaccess"
 
-# Corsair Commander Core
+# Corsair Commander Core (broken)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c1c", TAG+="uaccess"
 
-# Corsair Commander Core XT
+# Corsair Commander Core XT (broken)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c2a", TAG+="uaccess"
 
 # Corsair Commander Pro
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c10", TAG+="uaccess"
 
-# Corsair Commander ST
+# Corsair Commander ST (broken)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c32", TAG+="uaccess"
 
 # Corsair HX1000i
@@ -455,6 +455,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1c0c", TAG+="uacc
 # Corsair iCUE H100i Elite RGB
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c35", TAG+="uaccess"
 
+# Corsair iCUE H115i Elite RGB
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c36", TAG+="uaccess"
+
 # Corsair iCUE H150i Elite RGB
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c37", TAG+="uaccess"
 
@@ -488,10 +491,10 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2001", TAG+="uacc
 # NZXT HUE 2 Ambient
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2002", TAG+="uaccess"
 
-# NZXT Kraken 2023
+# NZXT Kraken 2023 (broken)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="300e", TAG+="uaccess"
 
-# NZXT Kraken 2023 Elite
+# NZXT Kraken 2023 Elite (broken)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="300c", TAG+="uaccess"
 
 # NZXT Kraken M22
@@ -535,3 +538,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="200d", TAG+="uacc
 
 # NZXT Smart Device V2
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="200f", TAG+="uaccess"
+
+# Suspected MSI MPG Coreliquid
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="ca00", TAG+="uaccess"
+
+# Suspected MSI MPG Coreliquid
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0db0", ATTRS{idProduct}=="ca02", TAG+="uaccess"

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -359,7 +359,7 @@ Mode	#colors
 .
 .SS Corsair Hydro H100i Platinum, H100i Platinum SE, H115i Platinum
 .SS Corsair Hydro H60i Pro XT, H100i Pro XT, H115i Pro XT, H150i Pro XT
-.SS Corsair Hydro H100i, H150i Elite RGB
+.SS Corsair Hydro H100i, H115i, H150i Elite RGB
 Cooling channels: \fIfan\fR, \fIfan[1\(en2]\fR; (only H150i Pro XT/Elite RGB:) \fIfan3\fR.
 .PP
 Pump mode (\fBinitialize \-\-pump\-mode \fImode\fR): \fIquiet\fR,

--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -10,6 +10,7 @@ Supported devices:
 - Corsair Hydro H115i Pro XT
 - Corsair Hydro H150i Pro XT
 - Corsair iCUE H100i Elite RGB
+- Corsair iCUE H115i Elite RGB
 - Corsair iCUE H150i Elite RGB
 
 Copyright Jonas Malaco and contributors
@@ -129,6 +130,8 @@ class HydroPlatinum(UsbHidDriver):
         (0x1b1c, 0x0c22, 'Corsair Hydro H150i Pro XT',
             {'fan_count': 3, 'fan_leds': 0}),
         (0x1b1c, 0x0c35, 'Corsair iCUE H100i Elite RGB',
+            {'fan_count': 2, 'fan_leds': 0}),
+        (0x1b1c, 0x0c36, 'Corsair iCUE H115i Elite RGB',
             {'fan_count': 2, 'fan_leds': 0}),
         (0x1b1c, 0x0c37, 'Corsair iCUE H150i Elite RGB',
             {'fan_count': 3, 'fan_leds': 0}),


### PR DESCRIPTION
This patch adds support for the Corsair iCUE H115i RGB Elite. This is largely based on #559, which added support for the Corsair iCUE H150i RGB Elite.

It looks like `extra/linux/71-liquidctl.rules` may not have been regenerated after earlier commits. When I regenerated it, a few existing devices were marked as ` (broken)` and two other new devices were added.

Fixes: #608

---

Checklist:

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [x] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [x] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
