### PR TITLE
Corsair Commander Core: Add support for speed curve profiles

### DIFF
--- a/docs/corsair-commander-core-guide.md
+++ b/docs/corsair-commander-core-guide.md
@@ -1,8 +1,10 @@
 # Corsair Commander Core, Core XT and ST
 _Driver API and source code available in [`liquidctl.driver.commander_core`](../liquidctl/driver/commander_core.py)._
 
+_New in 1.9.0: fixed duty cycles are now supported._<br>
 _Changed in 1.11.0: the Corsair Commander Core XT is now supported._<br>
 _Changed in 1.12.0: the Corsair Commander ST is now supported._<br>
+_New in 1.13.1: speed curve profiles are now supported._<br>
 
 Currently, functionality implemented is listed here. More is planned to be added.
 
@@ -66,9 +68,24 @@ Corsair Commander Core XT
 
 ## Programming the pump and fan speeds
 
-_New in 1.9.0._<br>
+### Speed curve profiles
 
-Currently, the pump and each fan can be set to a fixed duty cycle.
+The pump or fans speeds can be configured using a speed curve profile with a minimum of 2 or up to 7 curve points.
+
+Each curve point consists of both a temperature (in celsius) and a duty (percentage).
+
+
+```
+liquidctl set fans speed 28 0  35 50  40 75  41 85  42 90  43 95  44 100
+              |          |  |
+           channel       |  duty
+                      temp
+```
+
+
+### Fixed duty cycle
+
+The pump or fan speeds can be set to a fixed duty cycle.
 
 ```
 # liquidctl set fan1 speed 70
@@ -76,18 +93,22 @@ Currently, the pump and each fan can be set to a fixed duty cycle.
                channel    duty
 ```
 
-Valid channel values on the Core (non-XT) and ST are `pump`, `fanN`, where 1 <= N <= 6 is the fan number.
-On the Core XT, the `pump` channel is not present. The `fans` channel can be used to simultaneously
-configure all fans.
 
 In iCUE the pump can be set to different modes that correspond to a fixed percent that can be used in liquidctl.
 Quiet is 75%, Balanced is 85% and Extreme is 100%.
 
-_Note: the pump and some fans have a limit to how slow they can go and will not stop when set to zero.
-This is a hardware limitation that cannot be changed._
+### Device channels
 
-_Note: the cooler's lights flash with every update.
-Due to limitations in both the device hardware and liquidctl, there currently is no way to solve this problem.
-For more information, see: [#448]._
+Valid channel values on the Core (non-XT) and ST are `pump`, `fanN`, where 1 <= N <= 6 is the fan number.
+On the Core XT, the `pump` channel is not present. The `fans` channel can be used to simultaneously
+configure all fans.
+
+### Notes
+- A channel may only be configured with a single fixed duty cycle or a single fan curve profile (independently
+from the other channel configurations).
+- _The pump and some fans have a limit to how slow they can go and will not stop when set to zero.
+This is a hardware limitation that cannot be changed._
+- _The cooler's lights flash with every update. Due to limitations in both the device hardware and liquidctl,
+there currently is no way to solve this problem. For more information, see: [#448]._
 
 [#448]: https://github.com/liquidctl/liquidctl/issues/448

--- a/docs/developer/protocol/commander_core.md
+++ b/docs/developer/protocol/commander_core.md
@@ -133,7 +133,25 @@ Command:
 | 0x07, 0x08 | Data Type (Included in data length) |
 | 0x09-... | Data |
 
-### `0x08` - Read
+### `0x07` - Write More
+For writing data that does not fit in a single 96 byte Host->Device packet.
+
+Can be sent multiple times consecutively until data is completely written.
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x08 |
+| 0x01 | 0x07 |
+| 0x02 | Channel |
+| 0x03-... | Data |
+
+### `0x08` - Read Initial/More/Final
+
+Read More and Read Final are used to read data larger than the 96 byte device->host packet size.
+
+Byte index 0x03 must incremented as each piece of the data is read (i.e. 0x01 first, 0x02 second, and 0x03 third).
 
 Command:
 
@@ -141,9 +159,11 @@ Command:
 | ---------- | ----------- |
 | 0x00 | 0x08 |
 | 0x01 | 0x08 |
-| 0x02 | Channel |
+| 0x02 | 0x00 |
+| 0x03 | 0x01 for Read Initial or 0x02 for Read More or 0x03 for Read Final |
 
-Response:
+
+Read Initial Response:
 
 | Byte index | Description |
 | ---------- | ----------- |
@@ -152,6 +172,16 @@ Response:
 | 0x02 | 0x00 |
 | 0x03, 0x04 | Data type |
 | 0x05-... | Data |
+
+
+Read More/Final Response:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| 0x00 | 0x00 |
+| 0x01 | 0x08 |
+| 0x02 | 0x00 |
+| 0x03-... | Data |
 
 ## Modes:
 
@@ -225,9 +255,9 @@ Data Type: `0x10 0x00`
 | ---------- | ----------- |
 | 0x00 | Number of temperature sensors |
 | 0x01 | 0x00 if connected or 0x01 if not connected |
-| 0x02, 0x03 | Temperature in Celsius (needs to be divided by 10) |
+| 0x02, 0x03 | Temperature in Celsius with 10ths decimal (3b:01 = 315 = 31.5C) |
 | 0x04 | 0x00 if connected or 0x01 if not connected |
-| 0x05, 0x06 | Temperature in Celsius (needs to be divided by 10) |
+| 0x05, 0x06 | Temperature in Celsius with 10ths decimal (3b:01 = 315 = 31.5C) |
 
 ### `0x60 0x6d` - Hardware Speed Device Mode
 
@@ -267,3 +297,39 @@ Data Type: `0x04 0x00`
 | 0x09, 0x0a | Speed as percentage for Fan 4 | Speed as percentage for Fan 5 |
 | 0x0b, 0x0c | Speed as percentage for Fan 5 | Speed as percentage for Fan 6 |
 | 0x0d, 0x0e | Speed as percentage for Fan 6 | |
+
+### `0x62 0x6d` - Hardware Speed Curve (Percentage)
+
+Data Type: `0x05 0x00`
+
+| Byte index | Description (Core) |
+| ---------- | ----------- |
+| 0x00 | Number of Ports |
+| 0x01-0x1e | Speed Curve for AIO/EXT |
+| 0x1f-0x3c | Speed Curve for Fan 1 |
+| 0x3d-0x5a | Speed Curve for Fan 2 |
+| 0x5b-0x78 | Speed Curve for Fan 3 |
+| 0x79-0x96 | Speed Curve for Fan 4 |
+| 0x97-0xb4 | Speed Curve for Fan 5 |
+| 0xb5-0xd2 | Speed Curve for Fan 6 |
+
+Speed Curve:
+
+| Byte index | Description (Core) |
+| ---------- | ----------- |
+| 0x00 | Temperature sensor to use 0x00 for water 0x01 for plugged in sensor |
+| 0x01 | Number of speed curve points |
+| 0x02-0x05 | Speed curve point 1 |
+| 0x06-0x09 | Speed curve point 2 |
+| 0x0a-0x0d | Speed curve point 3 |
+| 0x0e-0x11 | Speed curve point 4 |
+| 0x12-0x15 | Speed curve point 5 |
+| 0x16-0x19 | Speed curve point 6 |
+| 0x1a-0x1d | Speed curve point 7 |
+
+Speed Point:
+
+| Byte index | Description (Core) |
+| ---------- | ----------- |
+| 0x00, 0x01 | Temperature in Celsius with 10ths decimal (3b:01 = 315 = 31.5C) |
+| 0x02, 0x03 | Point speed (%) |

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -29,8 +29,11 @@ _CMD_SLEEP = (0x01, 0x03, 0x00, 0x01)
 _CMD_GET_FIRMWARE = (0x02, 0x13)
 _CMD_CLOSE_ENDPOINT = (0x05, 0x01, 0x00)
 _CMD_OPEN_ENDPOINT = (0x0d, 0x00)
-_CMD_READ = (0x08, 0x00)
+_CMD_READ_INITIAL = (0x08, 0x00, 0x01)
+_CMD_READ_MORE = (0x08, 0x00, 0x02)
+_CMD_READ_FINAL = (0x08, 0x00, 0x03)
 _CMD_WRITE = (0x06, 0x00)
+_CMD_WRITE_MORE = (0x07, 0x00)
 
 _MODE_LED_COUNT = (0x20,)
 _MODE_GET_SPEEDS = (0x17,)
@@ -38,6 +41,7 @@ _MODE_GET_TEMPS = (0x21,)
 _MODE_CONNECTED_SPEEDS = (0x1a,)
 _MODE_HW_SPEED_MODE = (0x60, 0x6d)
 _MODE_HW_FIXED_PERCENT = (0x61, 0x6d)
+_MODE_HW_CURVE_PERCENT = (0x62, 0x6d)
 
 _DATA_TYPE_SPEEDS = (0x06, 0x00)
 _DATA_TYPE_LED_COUNT = (0x0f, 0x00)
@@ -45,7 +49,10 @@ _DATA_TYPE_TEMPS = (0x10, 0x00)
 _DATA_TYPE_CONNECTED_SPEEDS = (0x09, 0x00)
 _DATA_TYPE_HW_SPEED_MODE = (0x03, 0x00)
 _DATA_TYPE_HW_FIXED_PERCENT = (0x04, 0x00)
+_DATA_TYPE_HW_CURVE_PERCENT = (0x05, 0x00)
 
+_FAN_MODE_FIXED_PERCENT = 0x00
+_FAN_MODE_CURVE_PERCENT = 0x02
 
 class CommanderCore(UsbHidDriver):
     """Corsair Commander Core"""
@@ -137,7 +144,57 @@ class CommanderCore(UsbHidDriver):
         raise NotSupportedByDriver
 
     def set_speed_profile(self, channel, profile, **kwargs):
-        raise NotSupportedByDriver
+        channels = self._parse_channels(channel)
+        curve_points = list(profile)
+        if len(curve_points) < 2:
+            ValueError('a minimum of 2 speed curve points must be configured.')
+        if len(curve_points) > 7:
+            ValueError('a maximum of 7 speed curve points may be configured.')
+
+        with self._wake_device_context():
+            # Set hardware speed mode
+            res = self._read_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE)
+            device_count = res[0]
+
+            data = bytearray(res[0:device_count + 1])
+            for chan in channels:
+                data[chan + 1] = _FAN_MODE_CURVE_PERCENT
+            self._write_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE, data)
+
+
+            # Read in data and split by device
+            res = self._read_data(_MODE_HW_CURVE_PERCENT, _DATA_TYPE_HW_CURVE_PERCENT)
+            device_count = res[0]
+            data_by_device = []
+
+            i = 1
+            for _ in range(0, device_count):
+                count = res[i+1]
+                start = i
+                end = i + 4 * count + 2
+                i = end
+                data_by_device.append(res[start:end])
+
+            # Modify data for channels in channels array
+            for chan in channels:
+                new_data = []
+
+                # set temperature sensor
+                new_data.append(b"\x00")
+
+                # set number of curve points
+                new_data.append(int.to_bytes(len(curve_points), length=1, byteorder="big"))
+
+                # set curve points
+                for (temp, duty) in curve_points:
+                    new_data.append(int.to_bytes(temp*10, length=2, byteorder="little", signed=False))
+                    new_data.append(int.to_bytes(clamp(duty, 0, 100), length=2, byteorder="little", signed=False))
+
+                # Update device data
+                data_by_device[chan] = b''.join(new_data)
+
+            out = bytes([device_count]) + b''.join(data_by_device)
+            self._write_data(_MODE_HW_CURVE_PERCENT, _DATA_TYPE_HW_CURVE_PERCENT, out)
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         channels = self._parse_channels(channel)
@@ -149,7 +206,7 @@ class CommanderCore(UsbHidDriver):
 
             data = bytearray(res[0:device_count + 1])
             for chan in channels:
-                data[chan + 1] = 0x00  # Set the device's hardware mode to fixed percent
+                data[chan + 1] = _FAN_MODE_FIXED_PERCENT
             self._write_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE, data)
 
             # Set speed
@@ -201,12 +258,14 @@ class CommanderCore(UsbHidDriver):
 
     def _read_data(self, mode, data_type):
         self._send_command(_CMD_OPEN_ENDPOINT, mode)
-        raw_data = self._send_command(_CMD_READ)
+        raw_data = self._send_command(_CMD_READ_INITIAL)
+        more_raw_data = self._send_command(_CMD_READ_MORE)
+        final_raw_data = self._send_command(_CMD_READ_FINAL)
         self._send_command(_CMD_CLOSE_ENDPOINT)
         if tuple(raw_data[3:5]) != data_type:
             raise ExpectationNotMet('device returned incorrect data type')
 
-        return raw_data[5:]
+        return raw_data[5:] + more_raw_data[3:] + final_raw_data[3:]
 
     def _send_command(self, command, data=()):
         # self.device.write expects buf[0] to be the report number or 0 if not used
@@ -229,7 +288,7 @@ class CommanderCore(UsbHidDriver):
 
         res = self.device.read(_RESPONSE_LENGTH)
         while res[0] != 0x00:
-            res = self.device.read(_RESPONSE_LENGTH)        
+            res = self.device.read(_RESPONSE_LENGTH)
         buf = bytes(res)
         assert buf[1] == command[0], 'response does not match command'
         return buf
@@ -247,12 +306,38 @@ class CommanderCore(UsbHidDriver):
 
         self._send_command(_CMD_OPEN_ENDPOINT, mode)
 
-        buf = bytearray(len(data) + len(data_type) + 4)
-        buf[0: 2] = int.to_bytes(len(data) + 2, length=2, byteorder="little", signed=False)
-        buf[4: 4 + len(data_type)] = data_type
-        buf[4 + len(data_type):] = data
+        # Write data
+        data_len = len(data)
+        data_start_index = 0
+        while (data_start_index < data_len):
+            if (data_start_index == 0):
+                # First 9 bytes are in use
+                packet_data_len = _REPORT_LENGTH - 9
 
-        self._send_command(_CMD_WRITE, buf)
+                if (data_len < packet_data_len):
+                    packet_data_len = data_len
+
+                # Num Data Length bytes + 0x05 + 0x06 + Num Data Type bytes + Num Data bytes
+                buf = bytearray(2 + 2 + len(data_type) + packet_data_len)
+
+                # Data Length value (includes data type length) - 0x03 and 0x04
+                buf[0: 2] = int.to_bytes(data_len + len(data_type), length=2, byteorder="little", signed=False)
+                # Data Type value - 0x07 and 0x08
+                buf[4: 4 + len(data_type)] = data_type
+                # Data - 0x09 onwards
+                buf[4 + len(data_type):] = data[0:packet_data_len]
+
+                self._send_command(_CMD_WRITE, buf)
+                data_start_index += packet_data_len
+            else:
+                # First 3 bytes are in use
+                packet_data_len = _REPORT_LENGTH - 3
+                if data_len - data_start_index < packet_data_len:
+                    packet_data_len = data_len - data_start_index
+
+                self._send_command(_CMD_WRITE_MORE, data[data_start_index:data_start_index + packet_data_len])
+                data_start_index += packet_data_len
+
         self._send_command(_CMD_CLOSE_ENDPOINT)
 
     def _fan_to_channel(self, fan):


### PR DESCRIPTION
Continues where #454 left off and implements support for speed curve configuration for the pump/fans in the Corsair Commander Core driver.  Much of this is based off the initial work by @ParkerMc (thank you!) but has deviated significantly from the protocol documented in the original merge request.

Two areas are of particular interest:

1. `_CMD_READ` has been split into 3 separate read commands (`_CMD_READ_INITIAL`,`_CMD_READ_MORE`,`_CMD_READ_FINAL`) which are necessary to continue reading data from the device when the data exceeds the device->host packet size.

2. The addition of `_CMD_WRITE_MORE` which allows writing data to the device when the data exceeds the host->device packet size.  (Based off the work @ParkerMc did for [OpenRGB](https://github.com/CalcProgrammer1/OpenRGB/blob/master/Controllers/CorsairCommanderCoreController/CorsairCommanderCoreController.cpp#L203-L274)).

I am currently running this on my Gentoo Linux system without any hiccups and the fan duties are adjusting appropriately based on temperature readings in all cases I've tested.  The Corsair Commander Core is running the latest v2.11.221 firmware.

I've verified all existing tests are passing and also added two new tests for speed curve profiles.  If anyone is available to aid with further testing that would be helpful.


Note: Missing from this implementation is the ability to specify which temperature sensor is utilized by a speed curve profile, but extending support should be straight forward once this gets merged.  Currently it is hard coded to utilize the built-in water temperature sensor.


Closes: #454, #447
Related: #218, #520, #623

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [x] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [x] Document the protocol in `docs/developer/protocol/`