### PR TITLE
kraken3: Improve LCD screen setting checks

### DIFF
--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -772,10 +772,10 @@ class KrakenZ3(KrakenX3):
             self.orientation = msg[0x1A]
 
         # Firmware 2.0.0 and onwards broke the implemented image setting mechanism for Kraken 2023
-        # (standard and elite). In those cases, show an error until issue #631 is resolved.
+        # (non-elite). In those cases, show an error until issue #631 is resolved.
         def unsupported_fw_version():
             device_product_id = self.bulk_device.product_id
-            if device_product_id in (0x300C, 0x300E) and self.fw[0] == 2:
+            if device_product_id == 0x300E and self.fw[0] == 2:
                 _LOGGER.error(
                     "setting images is not supported on firmware 2.X.Y, please see issue #631"
                 )

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -648,6 +648,9 @@ class KrakenZ3(KrakenX3):
         return False
 
     def _get_fw_version(self, clear_reports=True):
+        if self.fw is not None:
+            return  # Already cached
+
         if clear_reports:
             self.device.clear_enqueued_reports()
         self._write([0x10, 0x01])  # firmware info

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -780,7 +780,7 @@ class KrakenZ3(KrakenX3):
         # Firmware 2.0.0 and onwards broke the implemented image setting mechanism for Kraken 2023
         # (non-elite). In those cases, show an error until issue #631 is resolved.
         def unsupported_fw_version():
-            device_product_id = self.bulk_device.product_id
+            device_product_id = self.device.product_id
             if device_product_id == 0x300E:
                 self._get_fw_version()
                 if self.fw[0] == 2:

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -248,11 +248,11 @@ class KrakenX3(UsbHidDriver):
         self._status = []
 
         self._read_until({b"\x11\x01": self.parse_firm_info, b"\x21\x03": self.parse_led_info})
+        self._status.append(("Firmware version", f"{self.fw[0]}.{self.fw[1]}.{self.fw[2]}", ""))
         return sorted(self._status)
 
     def parse_firm_info(self, msg):
         self.fw = (msg[0x11], msg[0x12], msg[0x13])
-        self._status.append(("Firmware version", f"{self.fw[0]}.{self.fw[1]}.{self.fw[2]}", ""))
 
     def parse_led_info(self, msg):
         channel_count = msg[14]
@@ -681,6 +681,7 @@ class KrakenZ3(KrakenX3):
         # request static infos
         self._write([0x10, 0x01])  # firmware info
         self._read_until({b"\x11\x01": self.parse_firm_info})
+        self._status.append(("Firmware version", f"{self.fw[0]}.{self.fw[1]}.{self.fw[2]}", ""))
 
         self._write([0x30, 0x01])  # lcd info
         self._read_until({b"\x31\x01": self.parse_lcd_info})

--- a/liquidctl/error.py
+++ b/liquidctl/error.py
@@ -33,8 +33,11 @@ class NotSupportedByDevice(LiquidctlError):
 class NotSupportedByDriver(LiquidctlError):
     """Operation not supported by the driver."""
 
+    def __init__(self, explanation=None):
+        self._explanation = explanation
+
     def __str__(self) -> str:
-        return "operation not supported by the driver"
+        return f"operation not supported by the driver{f': {self._explanation}' if self._explanation is not None else ''}"
 
 
 class UnsafeFeaturesNotEnabled(LiquidctlError):

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -166,6 +166,7 @@ class MockKrakenZ3(KrakenZ3):
         self.lcd_resolution = lcd_resolution
 
         self.screen_mode = None
+        self.fw = None
 
     def set_screen(self, channel, mode, value, **kwargs):
         self.screen_mode = mode


### PR DESCRIPTION
#673 erroneously disallowed Kraken 2023 Elite devices from setting the LCD screen. Also, it introduced a bug because `self.fw` is available during initialization and not populated after. This PR fixes the overall logic.

Related: #631