### PR TITLE
ci: Force MacOS runner to macos-12

### DIFF
--- a/.github/workflows/test-from-sources.yml
+++ b/.github/workflows/test-from-sources.yml
@@ -14,15 +14,15 @@ jobs:
       fail-fast: false
       max-parallel: 10
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-12, windows-latest]
         python-version: ['3.12', '3.11', '3.10', '3.9', '3.8']
         exclude:
           # mac os: exclude all but the last two python releases
-          - os: macos-latest
+          - os: macos-12
             python-version: '3.10'
-          - os: macos-latest
+          - os: macos-12
             python-version: '3.9'
-          - os: macos-latest
+          - os: macos-12
             python-version: '3.8'
           # windows: exclude all but the last two python releases
           - os: windows-latest
@@ -48,7 +48,7 @@ jobs:
         sudo apt-get install -y libusb-1.0-0-dev libudev-dev
 
     - name: Install system dependencies (macOS)
-      if: matrix.os == 'macos-latest'
+      if: matrix.os == 'macos-12'
       run: |
         brew install libusb
 


### PR DESCRIPTION
As noticed in #637, the latest MacOS runner is now M1/ARM, which at the moment doesn't find the required libraries correctly. Explicitly switch to MacOS 12 (Intel) for the time being.