### PR TITLE
Coolit H110i GT: post-merge fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 
 | Type               | Device family and specific documentation | Notes | MRLV |
 | :--                | :-- | --: | :-: |
-| AIO liquid cooler  | [Corsair Hydro H110i GT](docs/coolit-guide.md) | | git |
 | AIO liquid cooler  | [ASUS Ryujin II 360](docs/asus-ryujin-guide.md) | <sup>_p_</sup> | git |
+| AIO liquid cooler  | [Corsair Hydro H110i GT](docs/coolit-guide.md) | <sup>_p_</sup> | git |
 | AIO liquid cooler  | [Corsair Hydro H80i GT, H100i GTX, H110i GTX](docs/asetek-690lc-guide.md) | <sup>_Z_</sup> | 1.9.1 |
 | AIO liquid cooler  | [Corsair Hydro H80i v2, H100i v2, H115i](docs/asetek-690lc-guide.md) | <sup>_Z_</sup> | 1.9.1 |
 | AIO liquid cooler  | [Corsair Hydro Pro H100i, H115i, H150i](docs/asetek-pro-guide.md) | <sup>_Z_</sup> | 1.9.1 |

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -299,6 +299,12 @@ the first LED that the lighting effect should be for.
 the number of LEDs that the lighting effect should applied to.
 .BI \-\-temperature\-sensor= number ,
 The temperature sensor that should be used to control the fan curves, probe 1 by default.
+.SS Corsair Hydro H110i GT
+Cooling channels: \fIfan1\fR, \fIfan2\fR.
+.PP
+Pump mode (\fBinitialize \-\-pump\-mode \fImode\fR): \fIquiet\fR (default), \fIextreme\fR.
+.PP
+Lighting channels: not yet supported.
 .SS Corsair Hydro H80i GT, H100i GTX, H110i GTX
 .SS Corsair Hydro H80i v2, H100i v2, H115i
 .SS EVGA CLC 120 (CL12), 240, 280, 360

--- a/liquidctl/driver/coolit.py
+++ b/liquidctl/driver/coolit.py
@@ -21,6 +21,7 @@ import re
 
 from enum import Enum, unique
 
+from liquidctl.error import NotSupportedByDevice, NotSupportedByDriver
 from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.keyval import RuntimeStorage
 from liquidctl.util import clamp, fraction_of_byte, u16le_from, normalize_profile
@@ -252,6 +253,14 @@ class CoolitDriver(UsbHidDriver):
             self._data.store("pump_mode", _PumpMode[pump_mode.upper()].value)
 
         self._send_set_cooling()
+
+    def set_color(self, channel, mode, colors, **kwargs):
+        """Not supported by this driver."""
+        raise NotSupportedByDriver()
+
+    def set_screen(self, channel, mode, value, **kwargs):
+        """Not supported by this device."""
+        raise NotSupportedByDevice()
 
     def _get_hw_fan_channels(self, channel):
         channel = channel.lower()

--- a/liquidctl/driver/coolit.py
+++ b/liquidctl/driver/coolit.py
@@ -109,7 +109,7 @@ def _quoted(*names):
     return ", ".join(map(repr, names))
 
 
-class CoolitDriver(UsbHidDriver):
+class Coolit(UsbHidDriver):
     """liquidctl driver for Corsair H110i GT cooler"""
 
     _MATCHES = [

--- a/liquidctl/driver/coolit.py
+++ b/liquidctl/driver/coolit.py
@@ -214,7 +214,7 @@ class Coolit(UsbHidDriver):
             ("Pump speed", u16le_from(res, offset=20), "rpm"),
         ]
 
-    def set_fixed_speed(self, channel, duty, pump_mode="", **kwargs):
+    def set_fixed_speed(self, channel, duty, **kwargs):
         """Set fan or fans to a fixed speed duty.
 
         Valid channel values are "fanN", where N >= 1 is the fan number, and
@@ -225,13 +225,9 @@ class Coolit(UsbHidDriver):
             self._data.store(f"{hw_channel}_mode", _FanMode.FIXED_DUTY.value)
             self._data.store(f"{hw_channel}_duty", duty)
             LOGGER.info(f"setting {hw_channel} to duty mode")
-
-        if pump_mode and pump_mode in ["quiet", "extreme"]:
-            self._data.store("pump_mode", _PumpMode[pump_mode.upper()].value)
-
         self._send_set_cooling()
 
-    def set_speed_profile(self, channel, profile, pump_mode="", **kwargs):
+    def set_speed_profile(self, channel, profile, **kwargs):
         """Set fan or fans to follow a speed duty profile.
 
         Valid channel values are "fanN", where N >= 1 is the fan number, and
@@ -248,10 +244,6 @@ class Coolit(UsbHidDriver):
             self._data.store(f"{hw_channel}_mode", _FanMode.CUSTOM_PROFILE.value)
             self._data.store(f"{hw_channel}_profile", profile)
             LOGGER.info(f"setting {hw_channel} to profile mode")
-
-        if pump_mode and pump_mode in ["quiet", "extreme"]:
-            self._data.store("pump_mode", _PumpMode[pump_mode.upper()].value)
-
         self._send_set_cooling()
 
     def set_color(self, channel, mode, colors, **kwargs):

--- a/tests/test_coolit.py
+++ b/tests/test_coolit.py
@@ -1,0 +1,30 @@
+import pytest
+
+from _testutils import MockHidapiDevice, MockRuntimeStorage
+from liquidctl.driver.coolit import Coolit
+
+
+class MockDevice(MockHidapiDevice):
+    def read(self, length, **kwargs):
+        return [0] * length
+
+
+@pytest.fixture
+def mock_h110i_gt():
+    mock_raw_dev = MockDevice(vendor_id=0xDEAD, product_id=0xBEEF, address="42")
+    mock_storage = MockRuntimeStorage(key_prefixes=["mock_h110i_gt"])
+    dev = Coolit(
+        mock_raw_dev,
+        "Mock H100i GT",
+        fan_count=2,
+        rgb_fans=False,
+    )
+    return dev.connect(runtime_storage=mock_storage)
+
+
+def test_driver_not_totally_broken(mock_h110i_gt):
+    cooler = mock_h110i_gt
+    cooler.initialize()
+    _ = cooler.get_status(pump_mode="extreme")
+    cooler.set_fixed_speed("fan1", 42, pump_mode="quiet")
+    cooler.set_speed_profile("fan2", [(20, 30), (40, 90)], pump_mode="extreme")

--- a/tests/test_coolit.py
+++ b/tests/test_coolit.py
@@ -26,5 +26,5 @@ def test_driver_not_totally_broken(mock_h110i_gt):
     cooler = mock_h110i_gt
     cooler.initialize()
     _ = cooler.get_status(pump_mode="extreme")
-    cooler.set_fixed_speed("fan1", 42, pump_mode="quiet")
-    cooler.set_speed_profile("fan2", [(20, 30), (40, 90)], pump_mode="extreme")
+    cooler.set_fixed_speed("fan1", 42)
+    cooler.set_speed_profile("fan2", [(20, 30), (40, 90)])


### PR DESCRIPTION
Several small changes/fixes for the new Coolit H100i GT support.

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: #637

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [ ] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [x] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
