### PR TITLE
smart_device: add new RGB & Fan Controller id 0x2020

### DIFF
--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -530,6 +530,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2011", TAG+="uacc
 # NZXT RGB & Fan Controller (3+6 channels)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2019", TAG+="uaccess"
 
+# NZXT RGB & Fan Controller (3+6 channels)
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="2020", TAG+="uaccess"
+
 # NZXT Smart Device (V1)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="1714", TAG+="uaccess"
 

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -436,6 +436,10 @@ class SmartDevice2(_BaseSmartDevice):
             'speed_channel_count': 3,
             'color_channel_count': 0
         }),
+        (0x1e71, 0x2020, 'NZXT RGB & Fan Controller (3+6 channels)', {
+            'speed_channel_count': 3,
+            'color_channel_count': 6
+        }),
     ]
 
     _MAX_READ_ATTEMPTS = 12

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -430,11 +430,11 @@ class SmartDevice2(_BaseSmartDevice):
         }),
         (0x1e71, 0x2011, 'NZXT RGB & Fan Controller (3+6 channels)', {
             'speed_channel_count': 3,
-            'color_channel_count': 0
+            'color_channel_count': 0  # protocol changed, see #541
         }),
         (0x1e71, 0x2019, 'NZXT RGB & Fan Controller (3+6 channels)', {
             'speed_channel_count': 3,
-            'color_channel_count': 0
+            'color_channel_count': 0  # protocol changed, see #541
         }),
         (0x1e71, 0x2020, 'NZXT RGB & Fan Controller (3+6 channels)', {
             'speed_channel_count': 3,

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -625,8 +625,7 @@ class SmartDevice2(_BaseSmartDevice):
     def _write_colors(self, cid, mode, colors, sval, direction='forward',):
         mval, mod3, mod4, mincolors, maxcolors = self._COLOR_MODES[mode]
 
-        if not self._color_channels:
-            raise NotSupportedByDevice()
+        assert self._color_channels, "color channels should be available and enabled"
 
         color_count = len(colors)
         if maxcolors == 40:


### PR DESCRIPTION
Both RGB and fan control have been reported to work [on Discord](https://discord.com/channels/780568774964805672/780568774964805675/1237021530953879666).

Oddly, RGB control wasn't working well with the previous other 3+6 controllers, and we even disabled it (`color_channel_count: 0` on those entries). But it appears to work with this variant...

It might be wise to check our issues and see what exactly went wrong in the past.

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware (from report on Discord)
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes