### PR TITLE
Don't depend on port numbers

### DIFF
--- a/liquidctl/driver/asetek.py
+++ b/liquidctl/driver/asetek.py
@@ -351,7 +351,7 @@ class Legacy690Lc(_Base690Lc):
             self._data = runtime_storage
         else:
             ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
-            loc = f'bus{self.bus}_port{"_".join(map(str, self.port))}'
+            loc = f'bus{self.bus}_address{self.address}'
             self._data = RuntimeStorage(key_prefixes=[ids, loc, 'legacy'])
         return ret
 

--- a/liquidctl/driver/usb.py
+++ b/liquidctl/driver/usb.py
@@ -176,8 +176,10 @@ class BaseUsbDriver(BaseDriver):
     def port(self):
         """Physical location of the device, or None if N/A.
 
-        Tuple of USB port numbers, from the root hub to this device.  Not
-        dependendent on bus enumeration order.
+        Tuple of USB port numbers, from the root hub to this device.
+
+        Only available for PyUSB-backed devices, and only when using LibUSB 1.0.
+        But has the advantage of not depending on the bus enumeration order.
         """
         return self.device.port
 

--- a/tests/_testutils.py
+++ b/tests/_testutils.py
@@ -82,6 +82,10 @@ class MockHidapiDevice:
 class MockPyusbDevice():
     def __init__(self, vendor_id=None, product_id=None, release_number=None,
                  serial_number=None, bus=None, address=None, port=None):
+
+        assert port is None, \
+            'port numbers are only available on libusb-1.0 and should not be dependended on'
+
         self.vendor_id = vendor_id
         self.product_id = product_id
         self.release_number = release_number

--- a/tests/test_asetek.py
+++ b/tests/test_asetek.py
@@ -17,7 +17,7 @@ def mockModern690LcDevice():
 
 @pytest.fixture
 def mockLegacy690LcDevice():
-    device = MockPyusbDevice(vendor_id=0xffff, product_id=0xb200, bus=1, port=(1,))
+    device = MockPyusbDevice(vendor_id=0xffff, product_id=0xb200, bus=1, address=2)
     dev = Legacy690Lc(device, 'Mock Legacy 690LC')
 
     runtime_storage = MockRuntimeStorage(key_prefixes=['testing'])


### PR DESCRIPTION
Port numbers are only available on libusb-1.0.

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: #703
Closes: <!-- #number of issue or pull request -->
Related: <!-- #number of issue/pull request, or link to external discussion -->

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [ ] Verify that the changes work as expected on real hardware
- [x] ~~Add~~ Adjust automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
