### PR TITLE
test_cli: don't change the type of sys.argv when monkeypatching it

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,7 +11,7 @@ import liquidctl.cli
 def main(monkeypatch, capsys):
     """Return a function f(*args) to run main with `args` as `sys.argv`."""
     def call_with_args(*args):
-        monkeypatch.setattr(sys, 'argv', args)
+        monkeypatch.setattr(sys, 'argv', list(args))
         try:
             liquidctl.cli.main()
         except SystemExit as exit:


### PR DESCRIPTION
When setting up for the CLI tests, we inadvertently change the type of sys.argv from list to tuple. That worked with OG docopt, but breaks docopt-ng. More importantly, the Python docs say sys.argv is a _list_.

So even though docopt was able to handle it being a tuple, and docopt-ng seems (from a cursory look at its source) to still handle it being a string, let's use the correct type.

Fixes: #708

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [ ] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
