### PR TITLE
Draft: Avoiding excessively read/write in the device when using yoda

### DIFF
--- a/extra/yoda.py
+++ b/extra/yoda.py
@@ -105,12 +105,19 @@ elif sys.platform.startswith("linux") or sys.platform.startswith("freebsd"):
         psutil = None
 
 
-def read_sensors(device, **kwargs):
+devices_sensors = None
+def read_sensors(device, sensors_to_read, **kwargs):
+    global devices_sensors
+    if not devices_sensors:
+        devices_sensors = {}
     sensors = {}
-    for k, v, u in device.get_status(**kwargs):
-        if u == "°C":
-            sensor_name = k.lower().replace(" ", "_").replace("_temperature", "")
-            sensors[f"{INTERNAL_CHIP_NAME}.{sensor_name}"] = v
+    # Only read device sensors when required
+    if device in devices_sensors and sensors_to_read in devices_sensors[device]:
+        for k, v, u in device.get_status(**kwargs):
+            if u == "°C":
+                sensor_name = k.lower().replace(" ", "_").replace("_temperature", "")
+                sensors[f"{INTERNAL_CHIP_NAME}.{sensor_name}"] = v
+        devices_sensors[device] = sensors
     if sys.platform == "darwin":
         istats_stdout = subprocess.check_output(["istats"]).decode("utf-8")
         for line in istats_stdout.split("\n"):
@@ -267,9 +274,10 @@ def control(device, channels, profiles, sensors, update_interval, **kwargs):
 
     LOGGER.info("starting...")
     failures = 0
+    last_duty = {}
     while True:
         try:
-            sensor_data = read_sensors(device, **kwargs)
+            sensor_data = read_sensors(device, sensors, **kwargs)
             for i, (channel, profile, sensor) in enumerate(zip(channels, profiles, sensors)):
                 # compute the exponential moving average (ema), used as a low-pass filter (lpf)
                 ema = averages[i]
@@ -290,7 +298,13 @@ def control(device, channels, profiles, sensors, update_interval, **kwargs):
                     ema,
                     duty,
                 )
+                if channel not in last_duty:
+                    last_duty[channel] = duty
+                # Only reapply duty when duty changed
+                if last_duty[channel] == duty:
+                    continue
                 apply_duty(channel, duty, **kwargs)
+                last_duty[channel] = duty
             if getattr(device, "NEEDS_TIME", False):
                 device.set_time(datetime.now(), **kwargs)
             if getattr(device, "NEEDS_HWSTATUS", False):


### PR DESCRIPTION
I have a icue h150i elite and when using yoda to control the pump and fans based on CPU temperature, the RGB blinks all the time. 

It blinks every time the device is touched (read_sensors or apply_duty). I did some small changes that made it blink much less in such way that it is acceptable.

1) Just read sensors in device with the sensors we want to read are from the device (In my use case, it comes from the CPU so I don't need to have the blink from reading the device sensors).

2) Just apply duty when the duty changed. If the temperature of the sensor is stable, for example, there is no need to stay setting the same fan speed all the time. 

Obs.: This was useful to me. I just built my PC today and tried the script. I'm creating this PR as a draft to discussion, as I didn't check yet the style guide... or added tests...
