### PR TITLE
Add H100i Elite RGB support for white device

### DIFF
--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -135,6 +135,8 @@ class HydroPlatinum(UsbHidDriver):
             {'fan_count': 2, 'fan_leds': 0}),
         (0x1b1c, 0x0c37, 'Corsair iCUE H150i Elite RGB',
             {'fan_count': 3, 'fan_leds': 0}),
+        (0x1b1c, 0x0c40, 'Corsair iCUE H100i Elite RGB (White)',
+            {'fan_count': 2, 'fan_leds': 0}),
         (0x1b1c, 0x0c41, 'Corsair iCUE H150i Elite RGB (White)',
             {'fan_count': 3, 'fan_leds': 0})
     ]


### PR DESCRIPTION
Describe what the changes are meant to address.

The documentation states that the H100i Elite RGB is supported, but it didn't work for me. Upon investigation, I discovered that the product ID was not defined in the driver API.

```
> lsusb
...
Bus 001 Device 005: ID 1b1c:0c40 Corsair H100i ELITE WH
...
```

This PR adds `0c40` as white H100i ELITE to driver API.

Testing:

```
> python -m venv liquidctl-test 
> python -m pip install --upgrade pip setuptools setuptools_scm wheel
> python -m pip install --upgrade colorlog crcmod==1.7 docopt hidapi pillow pytest pyusb
> python -m pip install --upgrade "libusb-package; sys_platform == 'win32' or sys_platform == 'cygwin'"
> python -m pip install --upgrade "smbus; sys_platform == 'linux'"

> python -m liquidctl list
Device #0: Corsair iCUE H100i Elite RGB (White)

> sudo python -m liquidctl initialize 
 Corsair iCUE H100i Elite RGB (White)
└── Firmware version    1.2.7

> sudo python -m liquidctl --match corsair set fan speed  20 30  30 50  34 80  40 90  50 100
```

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Adhere to the [development process]
- [ ] Conform to the [style guide]
- [ ] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`