### PR TITLE
Rudimentry support for the Kraken Elite 2024 RGB 

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [NZXT Kraken X53, X63, X73](docs/kraken-x3-z3-guide.md) | <sup>_h_</sup> | 1.11.1 |
 | AIO liquid cooler  | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | <sup>_h_</sup> | 1.11.1 |
 | AIO liquid cooler  | ~~[NZXT Kraken 2023 Standard, Elite](docs/kraken-x3-z3-guide.md)~~ | <sup>_B_</sup> | git |
+| AIO liquid cooler  | [NZXT Kraken 2024 Elite, Elite RGB](docs/kraken-x3-z3-guide.md) | <sup>_B_</sup> | git |
 | Pump controller    | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | <sup>_hp_</sup> | 1.11.1 |
 | Fan/LED controller | [Aquacomputer Octo](docs/aquacomputer-octo-guide.md) | <sup>_hp_</sup> | 1.11.1 |
 | Fan/LED controller | [Aquacomputer Quadro](docs/aquacomputer-quadro-guide.md) | <sup>_hp_</sup> | 1.11.1 |

--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [NZXT Kraken X53, X63, X73](docs/kraken-x3-z3-guide.md) | <sup>_h_</sup> | 1.11.1 |
 | AIO liquid cooler  | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | <sup>_h_</sup> | 1.11.1 |
 | AIO liquid cooler  | ~~[NZXT Kraken 2023 Standard, Elite](docs/kraken-x3-z3-guide.md)~~ | <sup>_B_</sup> | git |
-| AIO liquid cooler  | [NZXT Kraken 2024 Elite, Elite RGB](docs/kraken-x3-z3-guide.md) | <sup>_B_</sup> | git |
+| AIO liquid cooler  | [NZXT Kraken 2024 Elite RGB](docs/kraken-x3-z3-guide.md) | <sup>_B_</sup> | git |
 | Pump controller    | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | <sup>_hp_</sup> | 1.11.1 |
 | Fan/LED controller | [Aquacomputer Octo](docs/aquacomputer-octo-guide.md) | <sup>_hp_</sup> | 1.11.1 |
 | Fan/LED controller | [Aquacomputer Quadro](docs/aquacomputer-quadro-guide.md) | <sup>_hp_</sup> | 1.11.1 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,7 +26,7 @@ Device guides
 - [Corsair HXi and RMi series PSUs](corsair-hxi-rmi-psu-guide.md)
 - [Corsair Hydro Platinum, Pro XT and Elite RGB all-in-one liquidctl coolers](corsair-platinum-pro-xt-guide.md)
 - [DDR4 DIMMs](ddr4-guide.md)
-- [Fourth-generation (X3/Z3/2023) NZXT liquid coolers](kraken-x3-z3-2023-guide.md)
+- [Fourth-generation (X3/Z3/2023/2024) NZXT liquid coolers](kraken-x3-z3-2023-guide.md)
 - [Gigabyte RGB Fusion 2.0 lighting controllers](gigabyte-rgb-fusion2-guide.md)
 - [NVIDIA graphics cards](nvidia-guide.md)
 - [NZXT E-series PSUs](nzxt-e-series-psu-guide.md)

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -30,7 +30,7 @@ Kraken 2023 AIOs use the same pump and as their Z3 predecessor but the integrate
 
 ## NZXT Kraken 2024 Elite RGB
 
-The functionality of the 2024 RGB AIO is identical to the 2023 model, retaining the 640x640 LCD. There's now a light ring on the pump housing. As of the 1.2.0 firmware, are still able to use GIF and static modes. 
+The functionality of the 2024 RGB AIO is identical to the 2023 model, retaining the 640x640 LCD. There's now a light ring on the pump housing. As of the 1.2.1 firmware, it's still able to use GIF and static modes.
 
 ## Initialization
 

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -28,7 +28,7 @@ In addition to this, Kraken Z coolers restore the embedded fan controller that i
 
 Kraken 2023 AIOs use the same pump and as their Z3 predecessor but the integrated led controller has been removed. The LCD resolution is 240x240 for the standard version and 640x640 for the elite one.
 
-## NZXT Kraken 2024 Elite, Elite RGB
+## NZXT Kraken 2024 Elite RGB
 
 The functionality of the 2024 RGB AIO is identical to the 2023 model, retaining the 640x640 LCD. There's now a light ring on the pump housing. As of the 1.2.0 firmware, are still able to use GIF and static modes. 
 
@@ -178,7 +178,7 @@ Adds support for NZXT Kraken 2023 Standard, Elite
 
 *On 2023 models (standard and Elite), GIF screen mode is no longer supported for firmware versions 2.X (see [#631][`issue-631`]).*
 
-Adds support for NZXT Kraken 2024 Elite, Elite RGB
+Adds support for NZXT Kraken 2024 Elite RGB
 
 _New in 1.11.0._<br>
 

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -28,6 +28,9 @@ In addition to this, Kraken Z coolers restore the embedded fan controller that i
 
 Kraken 2023 AIOs use the same pump and as their Z3 predecessor but the integrated led controller has been removed. The LCD resolution is 240x240 for the standard version and 640x640 for the elite one.
 
+## NZXT Kraken 2024 Elite, Elite RGB
+
+The functionality of the 2024 RGB AIO is identical to the 2023 model, retaining the 640x640 LCD. There's now a light ring on the pump housing. As of the 1.2.0 firmware, are still able to use GIF and static modes. 
 
 ## Initialization
 
@@ -166,13 +169,15 @@ they will be removed in a future version and are kept for now for backward compa
 | `backwards-rainbow-pulse` | None | ✓ |
 
 
-## The LCD screen (only Z and 2023 models)
+## The LCD screen (only Z, 2023, 2024 models)
 
 _New in git._<br>
 
 Adds support for NZXT Kraken 2023 Standard, Elite
 
 *On 2023 models (standard and Elite), GIF screen mode is no longer supported for firmware versions 2.X (see [#631][`issue-631`]).*
+
+Adds support for NZXT Kraken 2024 Elite, Elite RGB
 
 _New in 1.11.0._<br>
 

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -102,6 +102,7 @@ _New in git._<br>
 
 Adds support for NZXT Kraken 2023 Standard, Elite
 
+Adds support for NZXT Kraken 2024 Elite, Elite RGB
 
 ## RGB lighting with LEDs
 

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -102,7 +102,7 @@ _New in git._<br>
 
 Adds support for NZXT Kraken 2023 Standard, Elite
 
-Adds support for NZXT Kraken 2024 Elite, Elite RGB
+Adds support for NZXT Kraken 2024 Elite RGB
 
 ## RGB lighting with LEDs
 

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -506,6 +506,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="300e", TAG+="uacc
 # NZXT Kraken 2023 Elite (broken)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="300c", TAG+="uaccess"
 
+# NZXT Kraken Elite RGB 2023
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="3012", TAG+="uaccess"
+
 # NZXT Kraken M22
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="1715", TAG+="uaccess"
 

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -506,7 +506,7 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="300e", TAG+="uacc
 # NZXT Kraken 2023 Elite (broken)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="300c", TAG+="uaccess"
 
-# NZXT Kraken Elite RGB 2023
+# NZXT Kraken 2024 Elite RGB
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1e71", ATTRS{idProduct}=="3012", TAG+="uaccess"
 
 # NZXT Kraken M22

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -494,6 +494,7 @@ Lighting channels: \fIexternal\fR.
 LCD screens: \fIlcd\fR.
 .
 .SS NZXT Kraken 2023 Standard, Elite
+.SS NZXT Kraken 2024 Elite RGB
 Cooling channels: \fIpump\fR, \fIfan\fR.
 .PP
 Lighting channels: none.

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -597,7 +597,7 @@ class KrakenZ3(KrakenX3):
         (
             0x1E71,
             0x3012,
-            "NZXT Kraken 2023 RGB",
+            "NZXT Kraken Elite RGB 2023",
             {
                 "speed_channels": _SPEED_CHANNELS_KRAKEN2023,
                 "color_channels": _COLOR_CHANNELS_KRAKEN2023,

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -597,7 +597,7 @@ class KrakenZ3(KrakenX3):
         (
             0x1E71,
             0x3012,
-            "NZXT Kraken Elite RGB 2023",
+            "NZXT Kraken 2024 Elite RGB",
             {
                 "speed_channels": _SPEED_CHANNELS_KRAKEN2023,
                 "color_channels": _COLOR_CHANNELS_KRAKEN2023,

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -594,7 +594,7 @@ class KrakenZ3(KrakenX3):
                 "lcd_resolution": (240, 240),
             },
         ),
-                (
+        (
             0x1E71,
             0x3012,
             "NZXT Kraken 2023 RGB",

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -594,6 +594,18 @@ class KrakenZ3(KrakenX3):
                 "lcd_resolution": (240, 240),
             },
         ),
+                (
+            0x1E71,
+            0x3012,
+            "NZXT Kraken 2023 RGB",
+            {
+                "speed_channels": _SPEED_CHANNELS_KRAKEN2023,
+                "color_channels": _COLOR_CHANNELS_KRAKEN2023,
+                "hwmon_ctrl_mapping": _HWMON_CTRL_MAPPING_KRAKENZ,
+                "bulk_buffer_size": 1024 * 1024 * 2,  # 2 MB
+                "lcd_resolution": (640, 640),
+            },
+        ),
     ]
 
     def __init__(


### PR DESCRIPTION
Because the 2024 model Kraken Elite functions pretty similar to the Z models, most of what needed to be added was the device ID. This managed to allow pump/fan speed setting and changes to the LCD, but not much else. This simply makes the device work with liquidctl. Why "RGB" - is due to the additional changes to the pump housing and fan casing, which have more LEDs from what I can glean.

Closes: #745

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [x] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [x] `liquidctl.8` Linux/Unix/Mac OS man page

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes and `git` MRLV

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
 