### PR TITLE
aquacomputer: Sleep for 0.2s in direct code path

### DIFF
--- a/liquidctl/driver/aquacomputer.py
+++ b/liquidctl/driver/aquacomputer.py
@@ -464,6 +464,9 @@ class Aquacomputer(UsbHidDriver):
         checksum_bytes = crc16usb_func(checksum_part)
         put_unaligned_be16(checksum_bytes, ctrl_settings, report_length - 2)
 
+        # Some devices (Octo, Quadro and Aquaero) can not accept reports in quick succession, so slow down a bit
+        time.sleep(0.2)
+
         self.device.send_feature_report(ctrl_settings)
 
     def set_fixed_speed(self, channel, duty, direct_access=False, **kwargs):


### PR DESCRIPTION
Fixes #766. Add a 0.2s delay in the aquacomputer driver when setting config directly (not through hwmon) to match the hwmon path behavior, to avoid confusing the device when multiple sets are done in quick succession.