### PR TITLE
Fix 'wings' mode in SmartDevice

### DIFF
--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -643,7 +643,7 @@ class SmartDevice2(_BaseSmartDevice):
             for [g, r, b] in colors:
                 self._write([0x22, 0x10, cid])  # clear out all independent LEDs
                 self._write([0x22, 0x11, cid])  # clear out all independent LEDs
-                color_lists = [] * 3
+                color_lists = [0] * 3
                 color_lists[0] = [g, r, b] * 8
                 color_lists[1] = [int(x // 2.5) for x in color_lists[0]]
                 color_lists[2] = [int(x // 4) for x in color_lists[1]]
@@ -653,7 +653,7 @@ class SmartDevice2(_BaseSmartDevice):
                             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x06,
                             0x05, 0x85, 0x05, 0x85, 0x05, 0x85, 0x00, 0x00,
                             0x00, 0x00, 0x00, 0x00])
-                    self._write(msg + color_lists[i % 4])
+                    self._write(msg + color_lists[i % 3])
                 self._write([0x22, 0x03, cid, 0x08])   # this actually enables wings mode
         else:
             byte7 = (mod4 & 0x10) >> 4  # sets 'moving' flag for moving alternating modes


### PR DESCRIPTION
Using `wings` mode currently fails with an `IndexError`. I didn't run the automated tests since it's just two lines and it's broken in its current state anyway.

---

Checklist:

- [x ] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x ] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
