### PR TITLE
Razer Hanbo Chroma proof of concept

### DIFF
--- a/docs/razer-hanbo-guide.md
+++ b/docs/razer-hanbo-guide.md
@@ -1,0 +1,95 @@
+# Razer Hanbo Chroma
+_Driver API and source code available in [`liquidctl.driver.razer_hanbo`](../liquidctl/driver/razer_hanbo.py)._
+
+The Razer Hanbo Chroma are a pair of AIO liquid coolers coming in 360mm and
+240mm radiator varieties. Other than the lack of a third fan on the 240mm
+version, they should be otherwise identical.
+
+This driver supports
+- General monitoring
+- Pump profile support
+- Fan profile support
+- Hwmon read offloading with direct-mode fallback
+
+All configuration is done through USB, and persists as long as the device is
+powered, even if the system has gone to Soft Off (S5) state.
+
+This driver is intended to be driven in a Yoda-like manner as there are no
+direct PWM modes. The fan and pump can select from three built-in profiles
+and one custom profile. The fan and pump operate independently and
+have separate custom profiles. All pump profiles use the coolant temperature
+measured internally as a reference and do not need user interaction once
+triggered. Fan profiles however rely on an external reference temperature
+being provided to it in order traverse the curve. Without it the AIO will
+continue using whatever duty cycle is allocated to the default CPU temperature
+which is nominated to be 30°C.
+
+When setting a custom profile, a trait of the Razer Hanbo are that the
+temperature points in the curve are fixed. For this reason any temperatures
+provided to input curves will be ignored. Duty cycles will be processed in
+order and allocated to the following temperatures
+
+20, 30, 40, 50, 60, 70 ,80, 90, 100.
+
+The four profile names for the purposes of the driver are
+- silent
+- balance
+- performance
+- custom
+
+## Initialization
+[Initialization]: #initialization
+
+No initialization is required for the Razer Hanbo. Calling this function
+returns the unit serial number, firmware version and presets the reference
+fan curve temperature to 30°C.
+
+
+```
+# liquidctl --match razer initialize
+Razer Hanbo Chroma
+├── Serial number                    123456789ABCDEF
+└── Firmware version    [128, 0, 1, 1, 32, 0, 2, 16]
+```
+
+## Monitoring
+
+The device reports status on the pump and the fans. The fans are monitored
+collectively. The liquid temperature and currently active profile are also
+reported.
+
+```
+# liquidctl --match razer status
+Razer Hanbo Chroma
+├── Liquid temperature       30.6  °C
+├── Pump speed               1680  rpm
+├── Pump duty                  49  %
+├── Pump profile          balance
+├── Fan speed                1290  rpm
+├── Fan duty                   50  %
+└── Fan profile           balance
+```
+
+## Fan and pump profiles
+
+Like the OEM software, it is not possible to directly issue a PWM duty cycle
+or speed to the fan or pump. The user can select between three preset profiles
+or upload a custom fan profile. All of these utilise the Yoda API in the same
+manner as the MSI MPG Coreliquid.
+
+set_hardware_status() - Upload reference temperature to AIO for fan curve use.
+set_profiles() - Upload a curve. Note that the expected format remains as per
+every other device, but the temperature bytes will be ignored as these are
+fixed values on the Hanbo. Curve does not take effect until custom mode
+is the selected profile.
+set_speed_profile() - Select a profile
+
+## Interaction with Linux hwmon drivers
+[Linux hwmon]: #interaction-with-linux-hwmon-drivers
+
+These devices are supported by the [liquidtux] `razer_hanbo` driver, and status
+data is provided through a standard hwmon sysfs interface.
+
+liquidctl automatically detects when a kernel driver is bound to the device and,
+whenever possible, uses it instead of directly accessing the device.
+Alternatively, direct access to the device can be forced with `--direct-access`.

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -39,6 +39,7 @@ from liquidctl.driver import msi
 from liquidctl.driver import nzxt_epsu
 from liquidctl.driver import rgb_fusion2
 from liquidctl.driver import smart_device
+from liquidctl.driver import razer_hanbo
 if sys.platform == 'linux':
     from liquidctl.driver import ddr4
     from liquidctl.driver import nvidia

--- a/liquidctl/driver/razer_hanbo.py
+++ b/liquidctl/driver/razer_hanbo.py
@@ -1,0 +1,364 @@
+"""liquidctl driver for the Razer Hanbo Chroma series of AIO liquid coolers
+
+Supported devices
+-----------------
+
+- Razer Hanbo Chroma 360mm
+
+Supported features
+------------------
+
+- General monitoring
+- Pump profile support
+- Fan profile support
+- Hwmon offloading with direct-mode fallback
+
+This driver is intended to be driven in a Yoda-like manner as there are no
+direct PWM modes. The fan and pump can select from three built-in profiles
+and one custom profile. The fan and pump operate independently and
+have separate custom profiles. All pump profiles use the coolant temperature
+measured internally as a reference and do not need user interaction once
+triggered. Fan profiles however rely on an external reference temperature
+being provided to it in order traverse the curve. Without it the AIO will
+continue using whatever duty cycle is allocated to the default CPU temperature
+which is nominated to be 30°C.
+
+When setting a custom profile, a trait of the Razer Hanbo are that the
+temperature points in the curve are fixed. For this reason any temperatures
+provided to input curves will be ignored. Duty cycles will be processed in
+order and allocated to the following temperatures
+
+20, 30, 40, 50, 60, 70 ,80, 90, 100.
+
+Copyright Joseph East
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+# uses the psf/black style
+
+import logging
+
+from collections import namedtuple
+from functools import reduce
+
+from liquidctl.error import NotSupportedByDevice, NotSupportedByDriver
+from liquidctl.driver.usb import UsbHidDriver
+from liquidctl.keyval import RuntimeStorage
+from liquidctl.util import clamp, u16be_from
+
+_LOGGER = logging.getLogger(__name__)
+
+_FW_COMMAND = namedtuple("_FW_COMMAND", "header has_payload")
+
+_REPORT_LENGTH = 64
+_MAX_DUTIES = 9
+_MAX_READ_RETRIES = 5
+
+_HWMON_CTRL_MAPPING = {"pump": 1, "fan": 2}
+_CUSTOM_PROFILE_ID = 4
+_PROFILE_MAPPING = {
+    "silent": (0x01, 0x14),
+    "balance": (0x02, 0x32),
+    "performance": (0x03, 0x50),
+    "custom": (_CUSTOM_PROFILE_ID,),
+}
+
+_MINIMUM_THERMAL_UNIT = 20
+_MAXIMUM_THERMAL_UNIT = 100
+_DEFAULT_CPU_TEMP_DEGREES_C = 30
+
+_STATUS_TEMPERATURE = "Liquid temperature"
+_STATUS_PUMP_SPEED = "Pump speed"
+_STATUS_PUMP_DUTY = "Pump duty"
+_STATUS_PUMP_PROFILE = "Pump profile"
+_STATUS_FAN_SPEED = "Fan speed"
+_STATUS_FAN_DUTY = "Fan duty"
+_STATUS_FAN_PROFILE = "Fan profile"
+
+
+class _RazerHanboCommands:
+    get_firmware = _FW_COMMAND((0x01, 0x01), False)
+    get_pump_status = _FW_COMMAND((0x12, 0x01), False)
+    set_pump_profile = _FW_COMMAND((0x14, 0x01), True)
+    set_pump_curve = _FW_COMMAND((0x18, 0x01, 0x01, 0x00), True)
+    get_fan_status = _FW_COMMAND((0x20, 0x01), False)
+    set_fan_profile = _FW_COMMAND((0x22, 0x01), True)
+    set_ref_temp = _FW_COMMAND((0xC0, 0x01), True)
+    set_fan_curve = _FW_COMMAND((0xC8, 0x01, 0x00, 0x00), True)
+
+
+class _RazerHanboReplies:
+    firmware = (34, 0x02, 0x02)
+    pump_status = (11, 0x13, 0x02, 0x01)
+    pump_profile = (3, 0x15, 0x02, 0x01)
+    pump_curve = (3, 0x19, 0x02, 0x01)
+    fan_status = (10, 0x21, 0x02, 0x02, 0x01)
+    fan_profile = (3, 0x23, 0x02, 0x01)
+    bright = (4, 0x71, 0x02)
+    bright_status = (4, 0x73, 0x02)
+    rgb = (2, 0x81, 0x02, 0x01)
+    rgb_state = (4, 0x83, 0x02)
+    ref_temp = (3, 0xC1, 0x02, 0x01)
+    fan_curve = (3, 0xC9, 0x02, 0x01)
+
+
+class RazerHanbo(UsbHidDriver):
+    """liquidctl driver for the Razer Hanbo Chroma cooler"""
+
+    _custom_profiles = {
+        "pump": [0x14, 0x28, 0x3C, 0x50, 0x64, 0x64, 0x64, 0x64, 0x64],
+        "fan": [0x18, 0x1E, 0x28, 0x30, 0x3C, 0x51, 0x64, 0x64, 0x64],
+    }
+    _MATCHES = [
+        (
+            0x1532,
+            0x0F35,
+            "Razer Hanbo Chroma",
+            {},
+        ),
+    ]
+    HAS_AUTOCONTROL = True
+    _active_profile = {"pump": 0, "fan": 0}
+
+    """ Unimplemented or unsupported features """
+
+    def set_color(self, channel, mode, colors, **kwargs):
+        raise NotSupportedByDriver()
+
+    def set_screen(self, channel, mode, value, **kwargs):
+        raise NotSupportedByDevice()
+
+    def set_fixed_speed(self, channel, duty, **kwargs):
+        raise NotSupportedByDevice()
+
+    def _hanbo_hid_read_validate_report(self, signature):
+        """For a received packet, validate the format before
+        returning. As there could be multiple users of the
+        we could be receiving a report destined for someone
+        else. In which case we ignore it and continue looking.
+        This is limited to _MAX_READ_RETRIES as there shouldn't
+        many concurrent users and the HidapiDevice class
+        manages timeouts on the bus.
+        """
+
+        # Generate the expected header
+        header = bytearray(signature[1:])
+
+        i = 0
+        array = [[] for _ in range(_MAX_READ_RETRIES)]
+
+        while i < _MAX_READ_RETRIES:
+            array[i] = self._read()
+            if array[i] != None and header == array[i][0 : len(header)]:
+                if reduce(lambda a, b: a + b, array[i][signature[0] :]) == 0:
+                    return array[i]
+            i += 1
+        raise ValueError(
+            f"Unable to catch report, expected type {signature[1:]}. Packet dump {array}"
+        )
+
+    def initialize(self, direct_access=False, **kwargs):
+        """Initialize the device and the driver.
+        The Hanbo does not require initialization but we do some housekeeping
+        * If hwmon does not exist, set the default CPU reference temperature
+        * Print the firmware and serial number
+        """
+
+        self._write(_RazerHanboCommands.get_firmware.header)
+        array = self._hanbo_hid_read_validate_report(_RazerHanboReplies.firmware)
+
+        if not self._hwmon:
+            self.set_hardware_status(_DEFAULT_CPU_TEMP_DEGREES_C)
+            self._hanbo_hid_read_validate_report(_RazerHanboReplies.ref_temp)
+
+        return [
+            ("Serial number", (array[2:17]).decode('utf-8'), ""),
+            ("Firmware version", list(array[26:34]), ""),
+        ]
+
+    def _get_status_directly(self):
+
+        self._write(_RazerHanboCommands.get_pump_status.header)
+        array = self._hanbo_hid_read_validate_report(_RazerHanboReplies.pump_status)
+        if array == None:
+            _LOGGER.warning(
+                "No matching pump reports after requesting them "
+                "Something is spamming the interface or there's a failure"
+            )
+        status_readings = [
+            (_STATUS_TEMPERATURE, array[5] + (array[6] / 10), "°C"),
+            (_STATUS_PUMP_SPEED, u16be_from(array, offset=7), "rpm"),
+            (_STATUS_PUMP_DUTY, array[10], "%"),
+            (
+                _STATUS_PUMP_PROFILE,
+                (
+                    list(_PROFILE_MAPPING.keys())[array[3] - 1]
+                    if self._active_profile["pump"] != "custom"
+                    else "custom"
+                ),
+                "",
+            ),
+        ]
+
+        # Status is acquired from two commands, the pump and fan respectively.
+        self._write(_RazerHanboCommands.get_fan_status.header)
+        array = self._hanbo_hid_read_validate_report(_RazerHanboReplies.fan_status)
+
+        if array == None:
+            _LOGGER.warning(
+                "No matching fan reports after requesting them"
+                "Something is spamming the interface or there's a failure"
+            )
+        status_readings.append((_STATUS_FAN_SPEED, u16be_from(array, offset=6), "rpm"))
+        status_readings.append((_STATUS_FAN_DUTY, array[9], "%"))
+        status_readings.append(
+            (
+                _STATUS_FAN_PROFILE,
+                (
+                    list(_PROFILE_MAPPING.keys())[array[4] - 1]
+                    if self._active_profile["fan"] != "custom"
+                    else "custom"
+                ),
+                "",
+            )
+        )
+        return status_readings
+
+    def _get_status_from_hwmon(self):
+        status_readings = [
+            (_STATUS_TEMPERATURE, round(self._hwmon.read_int("temp1_input") * 1e-3, 1), "°C"),
+            (_STATUS_PUMP_SPEED, self._hwmon.read_int("fan1_input"), "rpm"),
+            (_STATUS_PUMP_DUTY, self._hwmon.read_int("pwm1"), "%"),
+            (
+                _STATUS_PUMP_PROFILE,
+                list(_PROFILE_MAPPING.keys())[self._hwmon.read_int("pwm1_enable") - 1],
+                "",
+            ),
+            (_STATUS_FAN_SPEED, self._hwmon.read_int("fan2_input"), "rpm"),
+            (_STATUS_FAN_DUTY, self._hwmon.read_int("pwm2"), "%"),
+            (
+                _STATUS_FAN_PROFILE,
+                list(_PROFILE_MAPPING.keys())[self._hwmon.read_int("pwm2_enable") - 1],
+                "",
+            ),
+        ]
+
+        """ PWM readings from hwmon are approximate due to lm-sensor scaling.
+        This is not the case when reading the values directly.
+        """
+        return status_readings
+
+    def get_status(self, direct_access=False, **kwargs):
+        """Get a status report.
+
+        Returns a list of `(property, value, unit)` tuples.
+        """
+
+        if self._hwmon and not direct_access:
+            _LOGGER.info("bound to %s kernel driver, reading status from hwmon", self._hwmon.driver)
+            return self._get_status_from_hwmon()
+
+        else:
+            if self._hwmon:
+                _LOGGER.warning(
+                    "directly reading the status despite %s kernel driver", self._hwmon.driver
+                )
+            return self._get_status_directly()
+
+    def set_hardware_status(self, T, direct_access=True, **kwargs):
+        if self._hwmon and not direct_access:
+            _LOGGER.info(
+                "bound to %s kernel driver, writing reference temp to hwmon", self._hwmon.driver
+            )
+            self._hwmon.write_int(f"temp2_input", clamp(int(T), 0, 100) * 1000)
+
+        else:
+            if self._hwmon:
+                _LOGGER.warning(
+                    "directly writing reference temp despite %s kernel driver", self._hwmon.driver
+                )
+            header = _RazerHanboCommands.set_ref_temp.header
+            """ The last 3 bytes presumably relate to an unused GPU temp monitoring function.
+            A fixed temperature of 30 degrees C is provided with every update.
+            """
+            self._write(header + (clamp(int(T), 0, 100), 0x00, 0x1E, 0x00))
+
+    def set_profiles(self, channels, profiles, direct_access=True, **kwargs):
+        """
+        Set custom or device preset fan curve for multiple channels.
+
+        NOTE: Fan curves require setting and updating a reference
+        temperature via device.set_cpu_status() to function.
+        Pump curves are autonomous.
+        """
+
+        for ch, prof in zip(channels, profiles):
+            if (
+                ch in self._custom_profiles and prof in _PROFILE_MAPPING
+            ):  # Which happens to have all channels, so a good sanity checker
+                # First, switch between hwmon or direct modes
+                if self._hwmon and not direct_access:
+                    _LOGGER.info(
+                        "bound to %s kernel driver, setting profiles from hwmon", self._hwmon.driver
+                    )
+                    # Do hwmon routines here
+                    if _PROFILE_MAPPING[prof][0] == _CUSTOM_PROFILE_ID:
+                        hwmon_tempate = "temp{}_auto_point{}_pwm"
+                        for index, point in enumerate(self._custom_profiles[ch]):
+                            self._hwmon.write_int(
+                                hwmon_tempate.format(_HWMON_CTRL_MAPPING[ch], index + 1), point
+                            )
+                        self._hwmon.write_int(
+                            f"pwm{_HWMON_CTRL_MAPPING[ch]}_enable", _PROFILE_MAPPING[prof][0]
+                        )
+                        self._active_profile[ch] = prof
+                else:
+                    if self._hwmon:
+                        _LOGGER.warning(
+                            "directly setting profiles despite %s kernel driver",
+                            self._hwmon.driver,
+                        )
+                    if _PROFILE_MAPPING[prof][0] == _CUSTOM_PROFILE_ID:
+                        command = getattr(_RazerHanboCommands, f"set_{ch}_curve").header
+                        command += tuple(self._custom_profiles[ch])
+                        self._active_profile[ch] = prof
+                    else:
+                        command = getattr(_RazerHanboCommands, f"set_{ch}_profile").header
+                        command += _PROFILE_MAPPING[prof]
+                        self._active_profile[ch] = prof
+                    self._write(command)
+
+    def set_speed_profile(self, channel, profile, **kwargs):
+        """Sets and sanity checks a curve profile. It does not
+        upload it to the AIO, that happens using set_profiles().
+        """
+        profile = list(profile)
+        if channel in self._custom_profiles:
+            if len(profile) == _MAX_DUTIES * 2:
+                new_curve = profile[1::2]  # Ignore temperatures as hardware does not use them.
+                new_curve = sorted(new_curve)
+                if (
+                    min(new_curve) >= _MINIMUM_THERMAL_UNIT
+                    and max(new_curve) == _MAXIMUM_THERMAL_UNIT
+                ):
+                    self._custom_profiles[channel] = new_curve
+                else:
+                    _LOGGER.warning(
+                        "Curve is not monotonically increasing or has"
+                        "values outside valid range of 20-100 duty. Not applying"
+                    )
+
+    @staticmethod
+    def _make_buffer(array, fill=0, total_size=_REPORT_LENGTH):
+        return bytearray(list(array) + ((total_size - (len(array) + 1)) * [fill]))
+
+    def _write(self, array, fill=0, total_size=_REPORT_LENGTH):
+        self.device.clear_enqueued_reports()
+        return self.device.write(self._make_buffer(array, fill, total_size))
+
+    def _read(self, size=_REPORT_LENGTH):
+        try:
+            return bytearray(self.device.read(size))
+        except:
+            _LOGGER.info("USB timeout occurred")
+            return None

--- a/tests/test_razer_hanbo.py
+++ b/tests/test_razer_hanbo.py
@@ -1,0 +1,350 @@
+# uses the psf/black style
+
+from struct import pack, unpack
+from math import modf
+from functools import reduce
+
+import pytest
+import os
+import re
+import random
+
+from _testutils import MockHidapiDevice, Report
+from liquidctl.driver.hwmon import HwmonDevice
+from liquidctl.driver.razer_hanbo import (
+    RazerHanbo,
+    _RazerHanboCommands,
+    _RazerHanboReplies,
+    _REPORT_LENGTH,
+    _FW_COMMAND,
+    _PROFILE_MAPPING,
+    _MAXIMUM_THERMAL_UNIT,
+    _DEFAULT_CPU_TEMP_DEGREES_C,
+)
+from liquidctl.driver.usb import _DEFAULT_TIMEOUT_MS
+
+_FIRMWARE_RESPONSE = bytes.fromhex(
+    "313233343536373839414243444546" "000000000000000000800001012000" "0210"
+)
+
+
+@pytest.fixture
+def razerHanboChromaDevice():
+
+    description = "Mock Razer Hanbo Chroma"
+    device = _MockHanbo(vendor_id=0x1532, product_id=0x0F35)
+    dev = RazerHanbo(device, description)
+
+    dev.connect()
+    return dev
+
+
+class _MockHanbo(MockHidapiDevice):
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self._active_pump_profile = bytearray([2])
+        self._active_fan_profile = bytearray([2])
+        self._fan_rpm = pack(">h", random.randint(200, 2000))
+        self._fan_duty = bytearray([random.randint(0, 100)])
+        self._pump_rpm = pack(">h", random.randint(200, 1000))
+        self._pump_duty = bytearray([random.randint(0, 100)])
+        self._liquid_temp = list(modf(round(random.uniform(20, 60), 1))[::-1])
+        self._packet_reply = None
+        self._prev_packet_reply = None
+        self._cpu_temp = None
+        self._cmd_report_id = {}
+        self._validate_buffer = []
+
+        # Generate command lookup table
+        for var in filter(lambda a: a[0] != "_", dir(_RazerHanboCommands)):
+            self._cmd_report_id[(getattr(_RazerHanboCommands, var).header[0])] = {
+                var: (getattr(_RazerHanboCommands, var).has_payload)
+            }
+
+        # Convert temperature into hex form per firmware
+        self._liquid_temp[1] *= 10
+        self._liquid_temp = bytearray([round(item) for item in self._liquid_temp])
+        self._liquid_temp_val = int(self._liquid_temp[0]) + int(self._liquid_temp[1]) / 10
+
+    def read(self, length, *, timeout=_DEFAULT_TIMEOUT_MS):
+        assert self._packet_reply != None
+        reply = bytearray(list(getattr(_RazerHanboReplies, self._packet_reply)[1:]))
+        if self._packet_reply == "pump_status":
+            reply += (
+                self._active_pump_profile
+                + self._active_pump_profile
+                + self._liquid_temp
+                + self._pump_rpm
+                + self._pump_duty
+                + self._pump_duty
+            )
+        if self._packet_reply == "firmware":
+            reply += bytearray(_FIRMWARE_RESPONSE)
+        if self._packet_reply == "fan_status":
+            reply += (
+                self._active_fan_profile
+                + self._active_fan_profile
+                + self._fan_rpm
+                + self._fan_duty
+                + self._fan_duty
+            )
+
+        reply = bytearray(list(reply) + ((_REPORT_LENGTH - (len(reply) + 1)) * [0]))
+        return reply
+
+    def write(self, data):
+        assert data[0] in self._cmd_report_id
+        var = next(iter(self._cmd_report_id[data[0]].keys()))
+        if next(iter(self._cmd_report_id[data[0]].values())):
+            self._prev_packet_reply = self._packet_reply
+            if var == "set_pump_profile":
+                self._validate_buffer = [data[2], data[3]]
+                self._active_pump_profile = bytearray([data[2]])
+
+            elif var == "set_pump_curve":
+                if self._prev_packet_reply == "fan_curve":
+                    self._validate_buffer += data[4:13]
+                else:
+                    self._validate_buffer = data[4:13]
+
+            elif var == "set_fan_profile":
+                self._validate_buffer = [data[2], data[3]]
+                self._active_fan_profile = bytearray([data[2]])
+
+            elif var == "set_ref_temp":
+                self._validate_buffer = int(data[2])
+                assert self._validate_buffer >= 0
+                assert self._validate_buffer <= 100
+                assert data[3] == 0
+                assert int(data[4]) >= 0
+                assert int(data[4]) <= 100
+                assert data[5] == 0
+                self._cpu_temp = self._validate_buffer
+
+            elif var == "set_fan_curve":
+                if self._prev_packet_reply == "pump_curve":
+                    self._validate_buffer += data[4:13]
+                else:
+                    self._validate_buffer = data[4:13]
+
+        elif data[1] == 0x01:
+            assert reduce(lambda a, b: a + b, data[2:]) == 0
+
+        self._packet_reply = re.sub("^[^_]*_", "", var)
+
+    def create_sysfs_status_nodes(self, tmp_path):
+        (tmp_path / "temp1_input").write_text(str(int(self._liquid_temp_val * 1000)) + "\n")
+        (tmp_path / "fan1_input").write_text(str(list(unpack(">h", self._pump_rpm))[0]) + "\n")
+        (tmp_path / "pwm1").write_text(str(int.from_bytes(self._pump_duty)) + "\n")
+        (tmp_path / "pwm1_enable").write_text(str(int.from_bytes(self._active_pump_profile)) + "\n")
+        (tmp_path / "fan2_input").write_text(str(list(unpack(">h", self._fan_rpm))[0]) + "\n")
+        (tmp_path / "pwm2").write_text(str(int.from_bytes(self._fan_duty)) + "\n")
+        (tmp_path / "pwm2_enable").write_text(str(int.from_bytes(self._active_fan_profile)) + "\n")
+
+
+""" Fetch a status report
+Check for correctness
+"""
+
+
+@pytest.mark.parametrize("has_hwmon,direct_access", [(False, False), (True, True), (True, False)])
+def test_razerhanbo_get_status(razerHanboChromaDevice, has_hwmon, direct_access, tmp_path):
+    if has_hwmon:
+        razerHanboChromaDevice._hwmon = HwmonDevice("mock_module", tmp_path)
+        razerHanboChromaDevice.device.create_sysfs_status_nodes(tmp_path)
+
+        temperature, pump_speed, pump_duty, pump_profile, fan_speed, fan_duty, fan_profile = (
+            razerHanboChromaDevice.get_status(direct_access)
+        )
+    if not (has_hwmon == False and direct_access == False):
+        assert temperature == (
+            "Liquid temperature",
+            razerHanboChromaDevice.device._liquid_temp_val,
+            "°C",
+        )
+        assert pump_speed == (
+            "Pump speed",
+            list(unpack(">h", razerHanboChromaDevice.device._pump_rpm))[0],
+            "rpm",
+        )
+        assert pump_duty == (
+            "Pump duty",
+            int.from_bytes(razerHanboChromaDevice.device._pump_duty),
+            "%",
+        )
+        assert pump_profile == (
+            "Pump profile",
+            list(_PROFILE_MAPPING.keys())[
+                int.from_bytes(razerHanboChromaDevice.device._active_pump_profile) - 1
+            ],
+            "",
+        )
+        assert fan_speed == (
+            "Fan speed",
+            list(unpack(">h", razerHanboChromaDevice.device._fan_rpm))[0],
+            "rpm",
+        )
+        assert fan_duty == (
+            "Fan duty",
+            int.from_bytes(razerHanboChromaDevice.device._fan_duty),
+            "%",
+        )
+        assert fan_profile == (
+            "Fan profile",
+            list(_PROFILE_MAPPING.keys())[
+                int.from_bytes(razerHanboChromaDevice.device._active_fan_profile) - 1
+            ],
+            "",
+        )
+
+
+""" Set the CPU reference temperature
+Check no out of bounds values are written
+"""
+
+
+@pytest.mark.parametrize("has_hwmon,direct_access", [(False, False), (True, True), (True, False)])
+def test_razerhanbo_set_hardware_status(razerHanboChromaDevice, has_hwmon, direct_access, tmp_path):
+    if has_hwmon:
+        razerHanboChromaDevice._hwmon = HwmonDevice("mock_module", tmp_path)
+        (tmp_path / "temp2_input").write_text("0")
+
+    testval = 40
+
+    razerHanboChromaDevice.set_hardware_status(testval, direct_access)
+
+    if not direct_access and has_hwmon:
+        assert (tmp_path / "temp2_input").read_text() == str(testval * 1000)
+
+    if direct_access:
+        assert razerHanboChromaDevice.device._cpu_temp == testval
+
+    testval = -5
+
+    razerHanboChromaDevice.set_hardware_status(testval, direct_access)
+
+    if not direct_access and has_hwmon:
+        assert (tmp_path / "temp2_input").read_text() == str(0)
+
+    if direct_access:
+        assert razerHanboChromaDevice.device._cpu_temp == 0
+
+    testval = 7465144
+
+    razerHanboChromaDevice.set_hardware_status(testval, direct_access)
+
+    if not direct_access and has_hwmon:
+        assert (tmp_path / "temp2_input").read_text() == str(100000)
+
+    if direct_access:
+        assert razerHanboChromaDevice.device._cpu_temp == _MAXIMUM_THERMAL_UNIT
+
+
+""" Apply a set profile to the driver
+Check for packet correctness and that a status report reflects this.
+"""
+
+
+@pytest.mark.parametrize("has_hwmon,direct_access", [(False, False), (True, True), (True, False)])
+def test_razerhanbo_set_profiles(razerHanboChromaDevice, has_hwmon, direct_access, tmp_path):
+    if has_hwmon:
+        razerHanboChromaDevice._hwmon = HwmonDevice("mock_module", tmp_path)
+        razerHanboChromaDevice.device.create_sysfs_status_nodes(tmp_path)
+
+    channels = ("fan", "pump")
+    profiles = ("silent", "performance")
+    razerHanboChromaDevice.set_profiles(channels, profiles, direct_access)
+
+    if has_hwmon:
+        # Python driver doesn't update sysfs, do that manually
+        razerHanboChromaDevice.device._active_pump_profile = bytearray([3])
+        razerHanboChromaDevice.device._active_fan_profile = bytearray([1])
+        razerHanboChromaDevice.device.create_sysfs_status_nodes(tmp_path)
+
+    temperature, pump_speed, pump_duty, pump_profile, fan_speed, fan_duty, fan_profile = (
+        razerHanboChromaDevice.get_status(direct_access)
+    )
+    assert pump_profile[1] == "performance"
+    assert fan_profile[1] == "silent"
+
+
+""" Fetch firmware report
+Validates that firmware & serial number are fetched and that the
+CPU reference temperature has been set
+"""
+
+
+def test_razerhanbo_initialize(razerHanboChromaDevice):
+    s_report, f_report = razerHanboChromaDevice.initialize()
+    assert s_report == ("Serial number", _FIRMWARE_RESPONSE[0:15].decode("utf-8"), "")
+    assert f_report == ("Firmware version", list(_FIRMWARE_RESPONSE[24:32]), "")
+    assert razerHanboChromaDevice.device._cpu_temp == _DEFAULT_CPU_TEMP_DEGREES_C
+
+
+""" Apply custom curves to the driver
+Validates internal data structures only
+"""
+
+
+def test_razerhanbo_set_speed_profile(razerHanboChromaDevice):
+
+    channel = "fan"
+    profile = bytes.fromhex("0014001400200025002F0032004000500064")
+    razerHanboChromaDevice.set_speed_profile(channel, profile)
+    assert razerHanboChromaDevice._custom_profiles["fan"] == list(profile[1::2])
+    channel = "pump"
+    profile = bytes.fromhex("0014001800200025002F0064006400640064")
+    razerHanboChromaDevice.set_speed_profile(channel, profile)
+    assert razerHanboChromaDevice._custom_profiles["pump"] == list(profile[1::2])
+
+    profile = bytes.fromhex("0030001800200025002F0064006400640064")
+    razerHanboChromaDevice.set_speed_profile(channel, profile)
+    assert razerHanboChromaDevice._custom_profiles["pump"] != list(profile[1::2])
+
+
+""" Apply a custom curve and check that -
+In the case of direct, that dissected protocol received the correct values.
+In the case of hwmon, the correct sequence was written to mock sysfs
+Check the status report reflects custom mode
+"""
+
+
+@pytest.mark.parametrize("has_hwmon,direct_access", [(False, False), (True, True), (True, False)])
+def test_razerhanbo_set_profiles_curve(razerHanboChromaDevice, has_hwmon, direct_access, tmp_path):
+    if has_hwmon:
+        razerHanboChromaDevice._hwmon = HwmonDevice("mock_module", tmp_path)
+
+    channels = ("fan", "pump")
+    profiles = ("custom", "custom")
+
+    razerHanboChromaDevice.set_profiles(channels, profiles, direct_access)
+    if has_hwmon:
+        # Python driver doesn't update sysfs, do that manually
+        razerHanboChromaDevice.device._active_pump_profile = bytearray([4])
+        razerHanboChromaDevice.device._active_fan_profile = bytearray([4])
+        razerHanboChromaDevice.device.create_sysfs_status_nodes(tmp_path)
+
+    if direct_access:
+        assert (
+            list(razerHanboChromaDevice.device._validate_buffer)
+            == razerHanboChromaDevice._custom_profiles["fan"]
+            + razerHanboChromaDevice._custom_profiles["pump"]
+        )
+
+    if has_hwmon and not direct_access:
+        hwmon_tempate = "temp{}_auto_point{}_pwm"
+        sysfs_temp = []
+
+        for index, i in enumerate(list(("pump", "fan"))):
+            for point in range(1, 10):
+                sysfs_temp.append(
+                    int((tmp_path / hwmon_tempate.format(index + 1, point)).read_text())
+                )
+            assert sysfs_temp == razerHanboChromaDevice._custom_profiles[i]
+            sysfs_temp = []
+
+    temperature, pump_speed, pump_duty, pump_profile, fan_speed, fan_duty, fan_profile = (
+        razerHanboChromaDevice.get_status(direct_access)
+    )
+    assert pump_profile[1] == "custom"
+    assert fan_profile[1] == "custom"


### PR DESCRIPTION
This draft pull request introduces basic support for the Razer Hanbo Chroma AIO

[Manufacturer website](https://www.razer.com/au-en/gaming-pc-accessories/razer-hanbo-chroma)

Developed / tested against Razer Hanbo Chroma 360mm firmware v1.2.0 on Opensuse Tumbleweed Kernel 6.14.

This is a proof of concept which provides the base methods rather than a complete implementation. The Razer Hanbo Chroma is a profile driven device that requires active feedback, similar to the MSI MPG CoreLiquid K360 with the Yoda script. Driving this device doesn't seem to be compatible with the existing CLI workflows.

Reading of sensors, firmware version and serial number is fully supported. The ability to change fan profiles, create curves and update the reference temperature is behind the yoda-like function calls inaccessible from the CLI.

A hwmon driver has been proposed in https://github.com/liquidctl/liquidtux/pull/73 which implements profile features, though needing root for sysfs write access makes those moot outside of development. A mostly-complete userland fallback is implemented in this pull request.  ARGB support has been proposed under [OpenRGB](https://gitlab.com/CalcProgrammer1/OpenRGB/-/merge_requests/2811), mainly to support interop scenarios of multiple users on the device.

There are various todos that are shared between the implementations but the showstopper here is that I can't see a way of meaningfully controlling this device outside of Yoda or a Yoda-like manner.  



Any suggestions on how this can be used?

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Adhere to the [development process]
- [ ] Conform to the [style guide]
- [ ] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
