### PR TITLE
Add support for MSI MEG CoreLiquid S360 (USB ID 0db0:6a05)

### DIFF
--- a/liquidctl/driver/msi.py
+++ b/liquidctl/driver/msi.py
@@ -335,6 +335,12 @@ class MpgCooler(UsbHidDriver):
             "Suspected MSI MPG Coreliquid",
             {"_unsafe": ["experimental_coreliquid_cooler"]},
         ),
+        (
+            0x0DB0,
+            0x6A05,
+            "MSI MEG CoreLiquid S360",
+            {"fan_count": 3},
+        ),
     ]
     HAS_AUTOCONTROL = True
 
@@ -391,7 +397,12 @@ class MpgCooler(UsbHidDriver):
         self._aprom_firmware_version = aprom_hi << 4 + aprom_lo
         ldrom_hi, ldrom_lo = self.get_firmware_version_ldrom()
         self._ldrom_firmware_version = ldrom_hi << 4 + ldrom_lo
-        self._oled_firmware_version = self.get_oled_firmware_version()
+
+        try:
+            self._display_firmware_version = self.get_display_firmware_version()
+        except Exception:
+            _LOGGER.warning("Display not responding, skipping firmware version check.")
+            self._display_firmware_version = "unknown"
 
         return ret
 

--- a/tests/test_msi.py
+++ b/tests/test_msi.py
@@ -330,3 +330,20 @@ def test_unsafe_core_liquid_set_hw_status(mpgCoreLiquidDeviceExperimental):
     mpgCoreLiquidDeviceExperimental.set_hardware_status(
         cpu_T, cpu_f=cpu_freq, unsafe=["experimental_coreliquid_cooler"]
     )
+
+
+@pytest.fixture
+def mpgCoreLiquidS360Device():
+    description = "Mock MEG CoreLiquid S360"
+    device = _MockCoreLiquid(vendor_id=0x0DB0, product_id=0x6A05)
+    dev = MpgCooler(device, description, fan_count=3)
+
+    dev.connect()
+    return dev
+
+
+def test_meg_coreliquid_s360_get_status(mpgCoreLiquidS360Device):
+    status = mpgCoreLiquidS360Device.get_status()
+    assert len(status) == 10
+    assert status[0][0] == "Fan 1 speed"
+    assert status[-1][0] == "Pump duty"


### PR DESCRIPTION
This PR adds initial support for the **MSI MEG CoreLiquid S360** (USB ID `0db0:6a05`). It enables full control over fans speed.

The integrated 2.4” IPS screen does not respond to display-related commands used for OLED models. Therefore, screen detection is gracefully skipped to preserve fan control functionality.

**Overview:**
- Matched device via its USB VID:PID in `_MATCHES`
- Successfully tested: `initialize`, `status`, `set_fixed_speed`, `set_speed_profile`, and `get_status`
- Skips `get_oled_firmware_version()` to avoid timeouts
- Manages duty modes correctly on Linux
- Tested on real hardware (Linux 6.14, liquidctl 1.16.0.dev3)

<!-- Tags (fill in and keep as many as applicable): -->

Related: MSI MEG CoreLiquid S360

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [x] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
