### PR TITLE
corsair_hid_psu: add support for HX1200i ATX 3.1 #2

### DIFF
--- a/docs/corsair-hxi-rmi-psu-guide.md
+++ b/docs/corsair-hxi-rmi-psu-guide.md
@@ -3,6 +3,7 @@ _Driver API and source code available in [`liquidctl.driver.corsair_hid_psu`](..
 
 _Changed in 1.12.0: HX1500i and HX1000i 2022 re-issue are now also supported._<br>
 _Changed in 1.15.0: HX1200i ATX 3.1 (CP-9020281-NA) refresh is now supported._<br>
+_Changed in 1.16.0: HX1200i ATX 3.1 #2 (CP-9020307-NA) refresh is now supported._<br>
 
 ## Initialization
 

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -380,6 +380,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1c08", TAG+="uacc
 # Corsair HX1200i ATX 3.1
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1c23", TAG+="uaccess"
 
+# Corsair HX1200i ATX 3.1 #2
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1c27", TAG+="uaccess"
+
 # Corsair HX1500i
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="1c1f", TAG+="uaccess"
 

--- a/liquidctl/driver/corsair_hid_psu.py
+++ b/liquidctl/driver/corsair_hid_psu.py
@@ -67,6 +67,9 @@ class CorsairHidPsu(UsbHidDriver):
 
     # support for hwmon: corsair-psu, Linux 5.11 (5.13 recommended)
 
+    # note: quadratic equation coefficients calculated with the following script:
+    # https://github.com/liquidctl/collected-device-data/blob/master/psu-efficiency/interpolate
+
     _MATCHES = [
         (0x1b1c, 0x1c05, 'Corsair HX750i', {
             'fpowin115': (0.00013153276902318052, 1.0118732314945875, 9.783796618886313),
@@ -87,10 +90,20 @@ class CorsairHidPsu(UsbHidDriver):
         (0x1b1c, 0x1c23, 'Corsair HX1200i ATX 3.1', {
             # CP-9020281-NA
             # Certification is source for efficiency numbers https://www.cybenetics.com/evaluations/psus/2510/
-            # 115v: 10%-.8877, 20%-.91774, 50%-.92095, 100%-.88146
-            # 230v: 10%-.89881, 20%-.92956, 50%-.93047, 100%-.91292
+            #        10%    20%    50%    100%
+            # 115v: .8877  .91774 .92095 .88146
+            # 230v: .89881 .92956 .93047 .91292
             'fpowin115': (9.930197967499293e-05, 1.003634953854399, 13.956713659543981),
             'fpowin230': (4.716701557627399e-05, 1.031689131040792, 8.562560345390088),
+        }),
+        (0x1b1c, 0x1c27, 'Corsair HX1200i ATX 3.1 #2', {
+            # CP-9020307-NA
+            # Certification is source for efficiency numbers https://www.cybenetics.com/evaluations/psus/2733/
+            #        10%    20%    50%    100%
+            # 115v: .88875 .91886 .92168 .88731
+            # 230v: .89954 .93143 .93185 .92003
+            'fpowin115': (8.701178559061476e-05, 1.0119502460041445, 12.725770701505295),
+            'fpowin230': (3.4692421780176756e-05, 1.0391630676290817, 7.429785098514605),
         }),
         (0x1b1c, 0x1c0a, 'Corsair RM650i', {
             'fpowin115': (0.00017323493381072683, 1.0047044721686030, 12.376592422281606),
@@ -121,6 +134,11 @@ class CorsairHidPsu(UsbHidDriver):
     ]
 
     def __init__(self, *args, fpowin115=None, fpowin230=None, **kwargs):
+        """
+        Args:
+            fpowin115: coefficients of a quadratic function that maps from output power to input power at 115V
+            fpowin230: coefficients of a quadratic function that maps from output power to input power at 230V
+        """
         assert fpowin115 and fpowin230
 
         super().__init__(*args, **kwargs)
@@ -278,7 +296,7 @@ class CorsairHidPsu(UsbHidDriver):
         _LOGGER.debug('input power estimates: %.3f W @ 115 V; %.3f W @ 230 V', for_in115v, for_in230v)
 
         # linearly interpolate for input_voltage
-        return for_in115v + (for_in230v - for_in115v) / 115 * (input_voltage - 115)
+        return for_in115v + (for_in230v - for_in115v) * (input_voltage - 115) / 115
 
     def _write(self, data):
         assert len(data) <= _REPORT_LENGTH


### PR DESCRIPTION
Adds support for `HX1200i ATX 3.1 #2 (2025)`
- Old model: CP-9020281-UK / A74PA40291D67D
  - [Cybernetics test](https://www.cybenetics.com/evaluations/psus/2510/)
  - [Corsair](https://www.corsair.com/uk/en/p/psu/cp-9020281-uk/hx1200i-fully-modular-ultra-low-noise-platinum-atx-1200-watt-pc-power-supply-uk-cp-9020281-uk)
- New model: CP-9020307-UK / AAR2A451M04C8Z
  - [Cybernetics test](https://www.cybenetics.com/evaluations/psus/2733/)
  - [Corsair](https://www.corsair.com/uk/en/p/psu/cp-9020307-uk/hx1200i-fully-modular-ultra-low-noise-platinum-atx-1200-watt-pc-power-supply-uk-cp-9020307-uk)

The refresh has the same name as the older model but Cybernetics lists it as `#2`. I used [this PR](https://github.com/liquidctl/liquidctl/pull/763) and [this issue](https://github.com/liquidctl/liquidctl/issues/762) as reference.

```
$ sudo lsusb -d 1b1c:1c27 -v
Bus 001 Device 012: ID 1b1c:1c27 Corsair HX1200i Power Supply
Negotiated speed: Full Speed (12Mbps)
Device Descriptor:
  bLength                18
  bDescriptorType         1
  bcdUSB               2.00
  bDeviceClass            0 [unknown]
  bDeviceSubClass         0 [unknown]
  bDeviceProtocol         0 
  bMaxPacketSize0         8
  idVendor           0x1b1c Corsair
  idProduct          0x1c27 HX1200i Power Supply
  bcdDevice            1.00
  iManufacturer           1 CORSAIR
  iProduct                2 HX1200i Power Supply
  iSerial                 0 
  bNumConfigurations      1
  Configuration Descriptor:
    bLength                 9
    bDescriptorType         2
    wTotalLength       0x0029
    bNumInterfaces          1
    bConfigurationValue     1
    iConfiguration          0 
    bmAttributes         0xc0
      Self Powered
    MaxPower              100mA
    Interface Descriptor:
      bLength                 9
      bDescriptorType         4
      bInterfaceNumber        0
      bAlternateSetting       0
      bNumEndpoints           2
      bInterfaceClass         3 Human Interface Device
      bInterfaceSubClass      0 [unknown]
      bInterfaceProtocol      0 
      iInterface              0 
        HID Device Descriptor:
          bLength                 9
          bDescriptorType        33
          bcdHID               1.11
          bCountryCode            0 Not supported
          bNumDescriptors         1
          bDescriptorType        34 (null)
          wDescriptorLength      29
          Report Descriptors: 
            ** UNAVAILABLE **
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x81  EP 1 IN
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0040  1x 64 bytes
        bInterval               1
      Endpoint Descriptor:
        bLength                 7
        bDescriptorType         5
        bEndpointAddress     0x01  EP 1 OUT
        bmAttributes            3
          Transfer Type            Interrupt
          Synch Type               None
          Usage Type               Data
        wMaxPacketSize     0x0040  1x 64 bytes
        bInterval               1
Device Status:     0x0001
  Self Powered
```

Setting fan speed works. sensors seem to work correctly.
```
$ liquidctl list
Device #0: Corsair HX1200i ATX 3.1 #2
$ liquidctl initialize --match corsair
$ liquidctl status
Corsair HX1200i ATX 3.1 #2
├── Current uptime                    9:07:23  
├── Total uptime             2 days, 19:27:23  
├── VRM temperature                      40.2  °C
├── Case temperature                     39.8  °C
├── Fan control mode                 Hardware  
├── Fan speed                               0  rpm
├── Input voltage                      230.00  V
├── +12V OCP mode                  Multi rail  
├── +12V output voltage                 11.97  V
├── +12V output current                  3.25  A
├── +12V output power                   38.00  W
├── +5V output voltage                   5.05  V
├── +5V output current                   5.00  A
├── +5V output power                    25.00  W
├── +3.3V output voltage                 3.30  V
├── +3.3V output current                 0.75  A
├── +3.3V output power                   2.00  W
├── Total power output                  58.00  W
├── Estimated input power               68.00  W
└── Estimated efficiency                   85  %
$ liquidctl --match corsair set fan speed 50
$ liquidctl status
Corsair HX1200i ATX 3.1 #2
├── Current uptime                    9:09:08  
├── Total uptime             2 days, 19:29:08  
├── VRM temperature                      40.5  °C
├── Case temperature                     40.0  °C
├── Fan control mode                 Software  
├── Fan speed                            1008  rpm
├── Input voltage                      230.00  V
├── +12V OCP mode                  Multi rail  
├── +12V output voltage                 11.97  V
├── +12V output current                  2.75  A
├── +12V output power                   28.00  W
├── +5V output voltage                   5.05  V
├── +5V output current                   5.00  A
├── +5V output power                    25.00  W
├── +3.3V output voltage                 3.30  V
├── +3.3V output current                 0.75  A
├── +3.3V output power                   2.00  W
├── Total power output                  58.00  W
├── Estimated input power               68.00  W
└── Estimated efficiency                   85  %
```

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: (did not submit an issue)
Closes: Na
Related: https://github.com/liquidctl/liquidctl/pull/763

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [X] Adhere to the [development process]
- [X] Conform to the [style guide]
- [X] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [X] Verify that all (other) automated tests (still) pass
- [X] Update/add documentation
    - [X] README, with ["new/changed in" notes]
    - [X] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [X] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [X] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [X] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
