### PR TITLE
NZXT Kraken 2024 Elite RGB | Set RGB Channels

### DIFF
--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -80,6 +80,7 @@ _COLOR_CHANNELS_KRAKENX = {"external": 0b001, "ring": 0b010, "logo": 0b100, "syn
 _COLOR_CHANNELS_KRAKENZ = {
     "external": 0b001,
 }
+
 _COLOR_CHANNELS_KRAKEN2023 = {"ring": 0b001, "external": 0b010, "sync": 0b111}
 
 _HWMON_CTRL_MAPPING_KRAKENX = {"pump": 1}


### PR DESCRIPTION
I left out the ability to address the RGB on this unit initally. Once again, it's got overlap with the other Kraken models so it was a drop-in fix. (edit: ha ha ha) Differences between them is that with the lack of a logo channel, the address for the ring and radiator are different, but simple as swapping the strings around.


Fixes: N/A
Closes: N/A
Related: #746

---

Checklist:

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`
