### PR TITLE
asus_ryujin: support the ASUS Ryujin III EXTREME

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | Type               | Device family and specific documentation | Notes | MRLV |
 | :--                | :-- | --: | :-: |
 | AIO liquid cooler  | [ASUS Ryujin II 360](docs/asus-ryujin-guide.md) | <sup>_p_</sup> | 1.14.0 |
+| AIO liquid cooler  | [ASUS Ryujin III EXTREME](docs/asus-ryujin3-guide.md) | <sup>_p_</sup> | git |
 | AIO liquid cooler  | [ASUS Ryuo I 240](docs/asus-ryuo-guide.md) | <sup>_p_</sup> | git |
 | AIO liquid cooler  | [Corsair Hydro H110i GT](docs/coolit-guide.md) | <sup>_p_</sup> | 1.14.0 |
 | AIO liquid cooler  | [Corsair Hydro H80i GT, H100i GTX, H110i GTX](docs/asetek-690lc-guide.md) | <sup>_Z_</sup> | 1.9.1 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ Device guides
 
 - [ASUS Aura LED (USB-based) controllers](asus-aura-led-guide.md)
 - [ASUS Ryujin II liquid coolers](asus-ryujin-guide.md)
+- [ASUS Ryujin III EXTREME liquid cooler](asus-ryujin3-guide.md)
 - [Aquacomputer D5 Next watercooling pump](aquacomputer-d5next-guide.md)
 - [Aquacomputer Farbwerk 360 RGB controller](aquacomputer-farbwerk360-guide.md)
 - [Aquacomputer Octo fan controller](aquacomputer-octo-guide.md)

--- a/docs/asus-ryujin3-guide.md
+++ b/docs/asus-ryujin3-guide.md
@@ -1,0 +1,70 @@
+# ASUS Ryujin III EXTREME liquid cooler
+_Driver API and source code available in [`liquidctl.driver.asus_ryujin`](../liquidctl/driver/asus_ryujin.py)._
+
+_New in 1.16.0._<br>
+
+## Initialization
+
+Initialization is not required. It outputs the firmware version:
+
+```
+# liquidctl initialize
+ASUS Ryujin III EXTREME
+└── Firmware version    AURJ3-S5F9-0104
+```
+
+## Monitoring
+
+The cooler reports the liquid temperature, the speeds and duties of pump and internal fan.
+
+```
+# liquidctl status
+ASUS Ryujin III EXTREME
+├── Liquid temperature    29.9  °C
+├── Pump duty               30  %
+├── Pump speed            1260  rpm
+├── Pump fan duty           30  %
+└── Pump fan speed         870  rpm
+```
+
+## Speed control
+
+### Setting fan and embedded pump duty
+
+Pump duty can be set using channel `pump`.
+
+```
+# liquidctl set pump speed 90
+```
+
+Use channel `pump-fan` to set the duty of the embedded fan:
+
+```
+# liquidctl set pump-fan speed 50
+```
+
+### Duty to speed relation
+
+The resulting speeds do not scale linearly to the set duty values.
+
+Pump impeller and embedded fan duty values approximately map to the following speeds (± 10%):
+
+| Duty (%) | Pump impeller speed (rpm) | Pump fan speed (rpm) |
+|:---:|:---:|:---:|
+| 0 | 800 | 0 |
+| 10 | 840 | 0 |
+| 20 | 1260 | 0 |
+| 30 | 1710 | **800*** |
+| 40 | 2100 | 1620 |
+| 50 | 2460 | 2229 |
+| 60 | 2460 | 2814 |
+| 70 | 2760 | 3471 |
+| 80 | 3090 | 4026 |
+| 90 | 3360 | 4569 |
+| 100 | 3600 | 5100 |
+
+**Note***: the minimum speed of the embedded pump fan is 800 rpm, meaning the fan may not start spinning at duty values below 30%.
+
+## Screen
+
+The screen of the cooler is not yet supported.

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -337,6 +337,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="18f3", TAG+="uacc
 # ASUS Ryujin II 360
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1988", TAG+="uaccess"
 
+# ASUS Ryujin III EXTREME
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1bcb", TAG+="uaccess"
+
 # ASUS Ryuo I 240
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1887", TAG+="uaccess"
 

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -246,6 +246,8 @@ Cooling channels: (D5 Next:) \fIfan\fR, \fIpump\fR; (Octo:) \fIfan[1\-8]\fR; (Qu
 Lighting channels: not yet supported.
 .SS ASUS Ryujin II 360
 Cooling channels: \fIpump\fR, \fIfans\fR, \fIpump\-fan\fR, \fIexternal\-fans\fR.
+.SS ASUS Ryujin III EXTREME
+Cooling channels: \fIpump\fR, \fIpump\-fan\fR.
 .PP
 Screen: not yet supported.
 .SS ASUS Ryuo II 240

--- a/tests/test_asus_ryujin.py
+++ b/tests/test_asus_ryujin.py
@@ -3,71 +3,34 @@ import pytest
 from _testutils import MockHidapiDevice
 from liquidctl.driver.asus_ryujin import AsusRyujin
 
-
-@pytest.fixture
-def mockRyujin():
-    return AsusRyujin(_MockRyujinDevice(), "Mock ASUS Ryujin II")
-
-
-class _MockRyujinDevice(MockHidapiDevice):
-    def __init__(self):
-        super().__init__(vendor_id=0x0B05, product_id=0x1988)
-        self.requests = []
-        self.response = None
-
-    def write(self, data):
-        super().write(data)
-        self.requests.append(data)
-
-        assert data[0] == 0xEC
-        header = data[1]
-
-        # Sampled responses without trailing zeros
-        if header == 0x82:  # Get firmware info
-            self.response = "ec02004155524a312d533735302d30313034"
-        elif header == 0x99:  # Get cooler status (temperature, pump speed, embedded fan speed)
-            self.response = "ec19001b056405100e"
-        elif header == 0x9A:  # Get pump and embedded fan duty
-            self.response = "ec1a0000223c"
-        elif header == 0xA0:  # Get AIO fan controller fan speeds
-            self.response = "ec200000000c03ee02"
-        elif header == 0xA1:  # Get AIO fan controller duty
-            self.response = "ec2100005b"
-        elif header == 0x1A:  # Set pump and embedded fan duty
-            self.response = "ec1a"
-        elif header == 0x21:  # Set AIO fan controller duty
-            self.response = "ec21"
-        else:
-            self.response = None
-
-    def read(self, length, **kwargs):
-        pre = super().read(length, **kwargs)
-        if pre:
-            return pre
-
-        buf = bytearray(65)
-        buf[0] = 0xEC
-
-        if self.response:
-            response = bytes.fromhex(self.response)
-            buf[: len(response)] = response
-
-        return buf[:length]
-
-
-def test_initialize(mockRyujin):
-    with mockRyujin.connect():
-        (firmware_status,) = mockRyujin.initialize()
-
-        assert firmware_status[1] == "AURJ1-S750-0104"
-
-
-def test_status(mockRyujin):
-    with mockRyujin.connect():
-        actual = mockRyujin.get_status()
-
-        expected = [
-            ("Liquid temperature", pytest.approx(27.5), "°C"),
+PROTOCOL_HEADER = 0xEC
+CMD_GET_FIRMWARE = 0x82
+CMD_GET_STATUS = 0x99
+CMD_GET_PUMP_DUTY = 0x9A
+CMD_GET_FAN_SPEEDS = 0xA0
+CMD_GET_FAN_DUTY = 0xA1
+CMD_SET_PUMP_DUTY = 0x1A
+CMD_SET_FAN_DUTY = 0x21
+DEVICE_CONFIGS = {
+    0x1988: {
+        "name": "Mock ASUS Ryujin II",
+        "fan_count": 4,
+        "pump_speed_offset": 5,
+        "pump_fan_speed_offset": 7,
+        "temp_offset": 3,
+        "duty_channel": 0,
+        "responses": {
+            CMD_GET_FIRMWARE: "ec02004155524a312d533735302d30313034",
+            CMD_GET_STATUS: "ec19001b056405100e",
+            CMD_GET_PUMP_DUTY: "ec1a0000223c",
+            CMD_GET_FAN_SPEEDS: "ec200000000c03ee02",
+            CMD_GET_FAN_DUTY: "ec2100005b",
+            CMD_SET_PUMP_DUTY: "ec1a",
+            CMD_SET_FAN_DUTY: "ec21",
+        },
+        "expected_firmware": "AURJ1-S750-0104",
+        "expected_status": [
+            ("Liquid temperature", 27.5, "°C"),
             ("Pump speed", 1380, "rpm"),
             ("Pump fan speed", 3600, "rpm"),
             ("Pump duty", 34, "%"),
@@ -77,22 +40,163 @@ def test_status(mockRyujin):
             ("External fan 2 speed", 750, "rpm"),
             ("External fan 3 speed", 0, "rpm"),
             ("External fan 4 speed", 0, "rpm"),
-        ]
+        ],
+    },
+    0x1BCB: {
+        "name": "Mock Ryujin III EXTREME",
+        "fan_count": 0,
+        "pump_speed_offset": 7,
+        "pump_fan_speed_offset": 10,
+        "temp_offset": 5,
+        "duty_channel": 1,
+        "responses": {
+            CMD_GET_FIRMWARE: "ec02004155524a332d533546392d30313034",
+            CMD_GET_STATUS: "ec190000001d09ec041e6603",
+            CMD_GET_PUMP_DUTY: "ec1a00011e1e",
+            CMD_SET_PUMP_DUTY: "ec1a",
+        },
+        "expected_firmware": "AURJ3-S5F9-0104",
+        "expected_status": [
+            ("Liquid temperature", 29.9, "°C"),
+            ("Pump speed", 1260, "rpm"),
+            ("Pump fan speed", 870, "rpm"),
+            ("Pump duty", 30, "%"),
+            ("Pump fan duty", 30, "%"),
+        ],
+    },
+}
 
-    assert sorted(actual) == sorted(expected)
+
+class _MockRyujinDevice(MockHidapiDevice):
+    def __init__(self, vendor_id: int, product_id: int):
+        super().__init__(vendor_id, product_id)
+        self.requests = []
+        self.response = None
+        self.config = DEVICE_CONFIGS.get(product_id, {})
+
+    def write(self, data):
+        super().write(data)
+        self.requests.append(data)
+
+        assert data[0] == PROTOCOL_HEADER
+        command = data[1]
+
+        self.response = self.config.get("responses", {}).get(command)
+
+    def read(self, length, **kwargs):
+        pre = super().read(length, **kwargs)
+        if pre:
+            return pre
+
+        buf = bytearray(65)
+        buf[0] = PROTOCOL_HEADER
+
+        if self.response:
+            response = bytes.fromhex(self.response)
+            buf[: len(response)] = response
+
+        return buf[:length]
 
 
-def test_set_fixed_speeds(mockRyujin):
-    with mockRyujin.connect():
-        mockRyujin.set_fixed_speed(channel="pump", duty=10)
-        assert mockRyujin.device.requests[-1][3] == 0x0A
+@pytest.fixture
+def mock_ryujin():
+    product_id = 0x1988
+    config = DEVICE_CONFIGS[product_id]
+    return AsusRyujin(
+        _MockRyujinDevice(vendor_id=0x0B05, product_id=product_id),
+        config["name"],
+        fan_count=config["fan_count"],
+        pump_speed_offset=config["pump_speed_offset"],
+        pump_fan_speed_offset=config["pump_fan_speed_offset"],
+        temp_offset=config["temp_offset"],
+        duty_channel=config["duty_channel"],
+    )
 
-        mockRyujin.set_fixed_speed(channel="pump-fan", duty=20)
-        assert mockRyujin.device.requests[-1][4] == 0x14
 
-        mockRyujin.set_fixed_speed(channel="external-fans", duty=30)
-        assert mockRyujin.device.requests[-1][4] == 0x4C
+@pytest.fixture
+def mock_ryujin3():
+    product_id = 0x1BCB
+    config = DEVICE_CONFIGS[product_id]
+    return AsusRyujin(
+        _MockRyujinDevice(vendor_id=0x0B05, product_id=product_id),
+        config["name"],
+        fan_count=config["fan_count"],
+        pump_speed_offset=config["pump_speed_offset"],
+        pump_fan_speed_offset=config["pump_fan_speed_offset"],
+        temp_offset=config["temp_offset"],
+        duty_channel=config["duty_channel"],
+    )
 
-        mockRyujin.set_fixed_speed(channel="fans", duty=40)
-        assert mockRyujin.device.requests[-2][4] == 0x28
-        assert mockRyujin.device.requests[-1][4] == 0x66
+
+@pytest.mark.parametrize("product_id", [0x1988, 0x1BCB])
+def test_initialize(product_id):
+    config = DEVICE_CONFIGS[product_id]
+    device = AsusRyujin(
+        _MockRyujinDevice(vendor_id=0x0B05, product_id=product_id),
+        config["name"],
+        fan_count=config["fan_count"],
+        pump_speed_offset=config["pump_speed_offset"],
+        pump_fan_speed_offset=config["pump_fan_speed_offset"],
+        temp_offset=config["temp_offset"],
+        duty_channel=config["duty_channel"],
+    )
+
+    with device.connect():
+        (firmware_status,) = device.initialize()
+        assert firmware_status[1] == config["expected_firmware"]
+
+
+@pytest.mark.parametrize("product_id", [0x1988, 0x1BCB])
+def test_status(product_id):
+    config = DEVICE_CONFIGS[product_id]
+    device = AsusRyujin(
+        _MockRyujinDevice(vendor_id=0x0B05, product_id=product_id),
+        config["name"],
+        fan_count=config["fan_count"],
+        pump_speed_offset=config["pump_speed_offset"],
+        pump_fan_speed_offset=config["pump_fan_speed_offset"],
+        temp_offset=config["temp_offset"],
+        duty_channel=config["duty_channel"],
+    )
+
+    with device.connect():
+        actual = device.get_status()
+
+        expected = []
+        for item in config["expected_status"]:
+            name, value, unit = item
+            if name == "Liquid temperature":
+                expected.append((name, pytest.approx(value), unit))
+            else:
+                expected.append((name, value, unit))
+
+        assert sorted(actual) == sorted(expected)
+
+
+def test_set_fixed_speeds_ryujin2(mock_ryujin):
+    with mock_ryujin.connect():
+        mock_ryujin.set_fixed_speed(channel="pump", duty=10)
+        assert mock_ryujin.device.requests[-1][2] == 0x00
+        assert mock_ryujin.device.requests[-1][3] == 0x0A
+
+        mock_ryujin.set_fixed_speed(channel="pump-fan", duty=20)
+        assert mock_ryujin.device.requests[-1][2] == 0x00
+        assert mock_ryujin.device.requests[-1][4] == 0x14
+
+        mock_ryujin.set_fixed_speed(channel="external-fans", duty=30)
+        assert mock_ryujin.device.requests[-1][4] == 0x4C
+
+        mock_ryujin.set_fixed_speed(channel="fans", duty=40)
+        assert mock_ryujin.device.requests[-2][4] == 0x28
+        assert mock_ryujin.device.requests[-1][4] == 0x66
+
+
+def test_set_fixed_speeds_ryujin3(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_fixed_speed(channel="pump", duty=70)
+        assert mock_ryujin3.device.requests[-1][2] == 0x01
+        assert mock_ryujin3.device.requests[-1][3] == 0x46
+
+        mock_ryujin3.set_fixed_speed(channel="pump-fan", duty=50)
+        assert mock_ryujin3.device.requests[-1][2] == 0x01
+        assert mock_ryujin3.device.requests[-1][4] == 0x32

--- a/tests/test_backward_compatibility_asus_ryujin.py
+++ b/tests/test_backward_compatibility_asus_ryujin.py
@@ -1,0 +1,106 @@
+import pytest
+
+from _testutils import MockHidapiDevice
+from liquidctl.driver.asus_ryujin import AsusRyujin
+
+
+@pytest.fixture
+def mockRyujin():
+    return AsusRyujin(
+        _MockRyujinDevice(),
+        "Mock ASUS Ryujin II",
+        fan_count=4,
+        pump_speed_offset=5,
+        pump_fan_speed_offset=7,
+        temp_offset=3,
+        duty_channel=0,
+    )
+
+
+class _MockRyujinDevice(MockHidapiDevice):
+    def __init__(self):
+        super().__init__(vendor_id=0x0B05, product_id=0x1988)
+        self.requests = []
+        self.response = None
+
+    def write(self, data):
+        super().write(data)
+        self.requests.append(data)
+
+        assert data[0] == 0xEC
+        header = data[1]
+
+        # Sampled responses without trailing zeros
+        if header == 0x82:  # Get firmware info
+            self.response = "ec02004155524a312d533735302d30313034"
+        elif header == 0x99:  # Get cooler status (temperature, pump speed, embedded fan speed)
+            self.response = "ec19001b056405100e"
+        elif header == 0x9A:  # Get pump and embedded fan duty
+            self.response = "ec1a0000223c"
+        elif header == 0xA0:  # Get AIO fan controller fan speeds
+            self.response = "ec200000000c03ee02"
+        elif header == 0xA1:  # Get AIO fan controller duty
+            self.response = "ec2100005b"
+        elif header == 0x1A:  # Set pump and embedded fan duty
+            self.response = "ec1a"
+        elif header == 0x21:  # Set AIO fan controller duty
+            self.response = "ec21"
+        else:
+            self.response = None
+
+    def read(self, length, **kwargs):
+        pre = super().read(length, **kwargs)
+        if pre:
+            return pre
+
+        buf = bytearray(65)
+        buf[0] = 0xEC
+
+        if self.response:
+            response = bytes.fromhex(self.response)
+            buf[: len(response)] = response
+
+        return buf[:length]
+
+
+def test_initialize(mockRyujin):
+    with mockRyujin.connect():
+        (firmware_status,) = mockRyujin.initialize()
+
+        assert firmware_status[1] == "AURJ1-S750-0104"
+
+
+def test_status(mockRyujin):
+    with mockRyujin.connect():
+        actual = mockRyujin.get_status()
+
+        expected = [
+            ("Liquid temperature", pytest.approx(27.5), "°C"),
+            ("Pump speed", 1380, "rpm"),
+            ("Pump fan speed", 3600, "rpm"),
+            ("Pump duty", 34, "%"),
+            ("Pump fan duty", 60, "%"),
+            ("External fan duty", 36, "%"),
+            ("External fan 1 speed", 780, "rpm"),
+            ("External fan 2 speed", 750, "rpm"),
+            ("External fan 3 speed", 0, "rpm"),
+            ("External fan 4 speed", 0, "rpm"),
+        ]
+
+    assert sorted(actual) == sorted(expected)
+
+
+def test_set_fixed_speeds(mockRyujin):
+    with mockRyujin.connect():
+        mockRyujin.set_fixed_speed(channel="pump", duty=10)
+        assert mockRyujin.device.requests[-1][3] == 0x0A
+
+        mockRyujin.set_fixed_speed(channel="pump-fan", duty=20)
+        assert mockRyujin.device.requests[-1][4] == 0x14
+
+        mockRyujin.set_fixed_speed(channel="external-fans", duty=30)
+        assert mockRyujin.device.requests[-1][4] == 0x4C
+
+        mockRyujin.set_fixed_speed(channel="fans", duty=40)
+        assert mockRyujin.device.requests[-2][4] == 0x28
+        assert mockRyujin.device.requests[-1][4] == 0x66


### PR DESCRIPTION
## Description

This PR adds support for the ASUS ROG Ryujin III EXTREME AIO cooler by extending the existing Ryujin II driver implementation.

The changes are based on my [previous work reverse-engineering the Linux kernel driver](https://github.com/mzonski/asus_rog_ryujin_iii_extreme-hwmon) driver for this device. Since the Ryujin III EXTREME uses a very similar protocol to the Ryujin II, I was able to adapt the existing driver with minimal modifications. The main differences are that the Ryujin III EXTREME lacks the fan control capabilities present in the Ryujin II, and it requires controlling the fan and pump duty on channel 1 instead of channel 0. These variations required adding some conditional variables while keeping the rest of the protocol implementation intact.

Please let me know if you need any more changes from my side to merge this PR.

---

## Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [x] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [x] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [x] Submit [relevant data, scripts or dissectors](https://github.com/liquidctl/collected-device-data/pull/18) to https://github.com/liquidctl/collected-device-data

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes and `git` MRLV

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
