### PR TITLE
fix: Lian Li Fan speed stuck at 100%

### DIFF
--- a/liquidctl/driver/lianli_uni.py
+++ b/liquidctl/driver/lianli_uni.py
@@ -102,7 +102,7 @@ class LianLiUni(UsbHidDriver):
         """
         channel = _parse_channel(channel)
 
-        if desired_state is ChannelMode.FIXED:
+        if desired_state is ChannelMode.AUTO:
             debug_string = "enabling"
             channel_byte = 0x11 << (channel - 1)  # enables auto mode
         else:


### PR DESCRIPTION
Fixed issue where fan speed would always be 100% when attempting to set the speed and would always go to the lowest setting the hardware would allow when initialized.

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: #853 
Closes: #853 
Related: N/A

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Adhere to the [development process]
- [ ] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
