### PR TITLE
Ryujin3 screen support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | Type               | Device family and specific documentation | Notes | MRLV |
 | :--                | :-- | :-- | :-: |
 | AIO liquid cooler  | [ASUS Ryujin II 360](docs/asus-ryujin-guide.md) | p | 1.14.0 |
-| AIO liquid cooler  | [ASUS Ryujin III 360, EVA, Extreme, White](docs/asus-ryujin3-guide.md) | p | 1.16.0 |
+| AIO liquid cooler  | [ASUS Ryujin III 360, EVA, Extreme, White](docs/asus-ryujin3-guide.md) | | git |
 | AIO liquid cooler  | [ASUS Ryuo I 240](docs/asus-ryuo-guide.md) | p | 1.16.0 |
 | AIO liquid cooler  | [Corsair Hydro H110i GT](docs/coolit-guide.md) | p | 1.14.0 |
 | AIO liquid cooler  | [Corsair Hydro H80i GT, H100i GTX, H110i GTX](docs/asetek-690lc-guide.md) | Z | 1.9.1 |

--- a/docs/asus-ryujin3-guide.md
+++ b/docs/asus-ryujin3-guide.md
@@ -67,4 +67,75 @@ Pump impeller and embedded fan duty values approximately map to the following sp
 
 ## Screen
 
-The screen of the cooler is not yet supported.
+_New in git._
+
+The Ryujin III has a 320x240 LCD. The screen can be controlled via the `lcd` channel.
+
+### Display a static image
+
+```
+# liquidctl set lcd screen static /path/to/image.png
+```
+
+Any image format supported by Pillow (PNG, JPEG, BMP, etc.) will be automatically
+resized to 320x240 and displayed. Requires `Pillow` (`pip install Pillow`).
+
+### Built-in animation
+
+Switch back to the default ROG animation:
+
+```
+# liquidctl set lcd screen liquid
+```
+
+### Clock mode
+
+Display a clock synced to the system time:
+
+```
+# liquidctl set lcd screen clock 24h
+# liquidctl set lcd screen clock 12h
+```
+
+### Hardware monitor
+
+Display live sensor readings (liquid temperature, pump RPM, fan RPM):
+
+```
+# liquidctl set lcd screen monitor
+```
+
+### Turn off the display
+
+```
+# liquidctl set lcd screen off
+```
+
+### Set brightness
+
+```
+# liquidctl set lcd screen brightness 50
+```
+
+Values range from 0 (off) to 100 (maximum).
+
+### Set orientation
+
+```
+# liquidctl set lcd screen orientation 0
+# liquidctl set lcd screen orientation 1
+```
+
+Where `0` is horizontal (default) and `1` is vertical (rotated). Values `2` and `3` are 180° and 270°.
+
+### Standby / Wake
+
+Put the display to sleep (for system suspend) or wake it back up:
+
+```
+# liquidctl set lcd screen standby
+# liquidctl set lcd screen wake
+```
+
+The standby command sends `EC 5C 20` which the firmware uses for ACPI sleep.
+Wake sends `EC 5C 10` (display reset).

--- a/docs/developer/protocol/asus_ryujin.md
+++ b/docs/developer/protocol/asus_ryujin.md
@@ -80,6 +80,101 @@ The data of all usb packets is 65 bytes long, prefixed with `0xEC`.
     - Header: `0xEC 0x21`
 
 
+## Display Operations
+
+### Switch display mode
+
+- Request:
+    - Header: `0xEC 0x51`
+    - Data:
+        - Byte 2: Display mode
+            - `0x00` = off
+            - `0x04` = animation (built-in ROG animation)
+            - `0x08` = clock
+            - `0x10` = single animation
+            - `0x20` = framebuffer (static image via bulk EP)
+            - `0x21` = hardware monitor
+- Response:
+    - Header: `0xEC 0x51 0x00`
+
+### Set hardware monitor layout
+
+- Request:
+    - Header: `0xEC 0x52`
+    - Data:
+        - Byte 2: Background style (`0x00` = galactic, `0x01` = cyberpunk, `0x02` = custom)
+        - Byte 3: Number of lines (upper nibble)
+        - Byte 4: Number of lines (lower nibble)
+        - Byte 5: Reserved (`0x00`)
+        - Byte 6-9: Background color (R, G, B, alpha)
+        - Byte 10-13: Text color line 1 (R, G, B, alpha)
+        - Byte 14-17: Text color line 2 (R, G, B, alpha)
+        - Byte 18-21: Text color line 3 (R, G, B, alpha)
+        - Byte 22-25: Text color line 4 (R, G, B, alpha)
+- Response:
+    - Header: `0xEC 0x52 0x00`
+
+### Set hardware monitor string
+
+- Request:
+    - Header: `0xEC 0x53`
+    - Data:
+        - Byte 2: Line index (0-based)
+        - Byte 3-20: Label string (18 bytes, null-padded UTF-8)
+        - Byte 21-32: Value string (12 bytes, null-padded UTF-8)
+- Response:
+    - Header: `0xEC 0x53 0x00`
+
+### Set display option
+
+- Request:
+    - Header: `0xEC 0x5C`
+    - Data:
+        - Byte 2: Sub-command
+            - `0x01` = set config (followed by display_type, mode, orientation, reserved, brightness)
+            - `0x10` = reset (wake from standby)
+            - `0x20` = standby (screen off for system sleep)
+        - For sub-command `0x01`:
+            - Byte 3: Display type
+            - Byte 4: Mode byte
+            - Byte 5: Orientation (0-3 for 0°, 90°, 180°, 270°)
+            - Byte 6: Reserved
+            - Byte 7: Brightness (0-100 %)
+- Response:
+    - Header: `0xEC 0x5C 0x00`
+
+### Set clock
+
+- Request:
+    - Header: `0xEC 0x11`
+    - Data:
+        - Byte 2-3: Reserved (`0x00 0x00`)
+        - Byte 4: Prefix (`0x08`)
+        - Byte 5: Reserved (`0x00`)
+        - Byte 6: Hour format (`0x00` = 24h, `0x01` = 12h)
+        - Byte 7: Hour (BCD encoded)
+        - Byte 8: Minute (BCD encoded)
+        - Byte 9: Second (BCD encoded)
+        - Byte 10: PM flag (`0x00` = AM/24h, `0x01` = PM)
+        - Byte 11: Separator flag (`0x01`)
+- Response:
+    - Header: `0xEC 0x11 0x00`
+
+### Flush framebuffer
+
+Used after sending a static image via the bulk endpoint.
+
+- Request:
+    - Header: `0xEC 0x7F`
+    - Data:
+        - Byte 2: `0x03`
+        - Byte 3-4: Frame size bytes (`0x00 0x84 0x03` = 230400 = 320x240x3)
+- Response:
+    - Header: `0xEC 0x7F 0x00`
+
+Note: All display commands send ACK responses (`0xEC` + command byte + status).
+
+
 ## Unknown
 
 - Request:

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -249,7 +249,13 @@ Cooling channels: \fIpump\fR, \fIfans\fR, \fIpump\-fan\fR, \fIexternal\-fans\fR.
 .SS ASUS Ryujin III 360, EVA, Extreme, White
 Cooling channels: \fIpump\fR, \fIpump\-fan\fR.
 .PP
-Screen: not yet supported.
+Screen channel: \fIlcd\fR.
+Screen modes: \fIstatic\fR, \fIliquid\fR, \fIclock\fR, \fImonitor\fR, \fIoff\fR,
+\fIstandby\fR, \fIwake\fR, \fIbrightness\fR, \fIorientation\fR, \fIrelease\fR.
+.PP
+\fIstatic\fR requires a path to an image file and the Pillow package.
+\fIrelease\fR returns pump control to the internal Asetek controller;
+the embedded fan has no internal controller and must always be host\-driven.
 .SS ASUS Ryuo II 240
 Cooling channels: \fIfans\fR, \fIfan\fR. There is only a single fan channel.
 .SS Corsair iCUE Elite Capellix H100i, H115i, H150i

--- a/liquidctl/driver/asus_ryujin.py
+++ b/liquidctl/driver/asus_ryujin.py
@@ -1,13 +1,18 @@
-"""liquidctl driver for the ASUS Ryujin II and Ryujin III EXTREME / 360 liquid coolers.
+"""liquidctl driver for the ASUS Ryujin II and Ryujin III liquid coolers.
+
+Supports fan/pump control, sensor monitoring, and LCD screen control for
+Ryujin III models (320x240 BGR display).
 
 Copyright Florian Freudiger and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import logging
+import sys
+import time
 from typing import List
 
-from liquidctl.driver.usb import UsbHidDriver
+from liquidctl.driver.usb import PyUsbDevice, UsbHidDriver
 from liquidctl.error import ExpectationNotMet, NotSupportedByDriver
 from liquidctl.util import clamp, u16le_from, rpadlist, fraction_of_byte
 
@@ -22,10 +27,37 @@ _REQUEST_GET_COOLER_STATUS = (0x99, 0x19)
 _REQUEST_GET_COOLER_DUTY = (0x9A, 0x1A)
 _REQUEST_GET_CONTROLLER_DUTY = (0xA1, 0x21)
 _REQUEST_GET_CONTROLLER_SPEED = (0xA0, 0x20)
+_REQUEST_GET_DISPLAY_OPTION = (0xDC, 0x5C)
 
 # Command headers that don't need a response
 _CMD_SET_COOLER_SPEED = 0x1A
 _CMD_SET_CONTROLLER_SPEED = 0x21
+_CMD_SWITCH_DISPLAY_MODE = 0x51
+_CMD_SET_HW_MONITOR_LAYOUT = 0x52
+_CMD_SET_HW_MONITOR_STRING = 0x53
+_CMD_SET_DISPLAY_OPTION = 0x5C
+_CMD_SET_CLOCK = 0x11
+_CMD_FLUSH_FRAMEBUFFER = 0x7F
+
+# Display mode bytes (wire encoding, from ryujin.py DisplayMode enum)
+_DISPLAY_MODE_OFF = 0x00
+_DISPLAY_MODE_ANIMATION = 0x04
+_DISPLAY_MODE_CLOCK = 0x08
+_DISPLAY_MODE_SINGLE_ANIM = 0x10
+_DISPLAY_MODE_SLIDESHOW = 0x1F
+_DISPLAY_MODE_FRAMEBUFFER = 0x20
+_DISPLAY_MODE_HW_MONITOR = 0x21
+
+# LCD parameters
+_LCD_WIDTH = 320
+_LCD_HEIGHT = 240
+_LCD_BPP = 3  # BGR, 3 bytes/pixel
+_LCD_FRAME_SIZE = _LCD_WIDTH * _LCD_HEIGHT * _LCD_BPP  # 230,400 bytes
+
+# Endpoints
+_EP_BULK_OUT = 0x01
+_EP_HID_OUT = 0x02
+_EP_HID_IN = 0x82
 
 _STATUS_FIRMWARE = "Firmware version"
 _STATUS_TEMPERATURE = "Liquid temperature"
@@ -36,9 +68,16 @@ _STATUS_COOLER_FAN_DUTY = "Pump fan duty"
 _STATUS_CONTROLLER_FAN_SPEED = "External fan {} speed"
 _STATUS_CONTROLLER_FAN_DUTY = "External fan duty"
 
+# HW monitor background styles
+_HW_MONITOR_STYLES = {
+    "galactic": 0x00,
+    "cyberpunk": 0x01,
+    "custom": 0x02,
+}
+
 
 class AsusRyujin(UsbHidDriver):
-    """ASUS Ryujin II & Ryujin III Extreme / 360 / White Edition liquid coolers."""
+    """ASUS Ryujin II & Ryujin III liquid coolers."""
 
     _MATCHES = [
         (
@@ -51,6 +90,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 7,
                 "temp_offset": 3,
                 "duty_channel": 0,
+                "has_lcd": False,
             },
         ),
         (
@@ -63,6 +103,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 10,
                 "temp_offset": 5,
                 "duty_channel": 1,
+                "has_lcd": True,
             },
         ),
         (
@@ -75,6 +116,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 10,
                 "temp_offset": 5,
                 "duty_channel": 1,
+                "has_lcd": True,
             },
         ),
         (
@@ -87,6 +129,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 10,
                 "temp_offset": 5,
                 "duty_channel": 1,
+                "has_lcd": True,
             },
         ),
         (
@@ -99,6 +142,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 10,
                 "temp_offset": 5,
                 "duty_channel": 1,
+                "has_lcd": True,
             },
         ),
     ]
@@ -112,6 +156,7 @@ class AsusRyujin(UsbHidDriver):
         pump_fan_speed_offset,
         temp_offset,
         duty_channel,
+        has_lcd=False,
         **kwargs,
     ):
         super().__init__(device, description, **kwargs)
@@ -121,10 +166,88 @@ class AsusRyujin(UsbHidDriver):
         self._pump_fan_speed_offset = pump_fan_speed_offset
         self._temp_offset = temp_offset
         self._duty_channel = duty_channel
+        self._has_lcd = has_lcd
+        self._bulk_device = None
 
     def initialize(self, **kwargs):
         msg = self._request(*_REQUEST_GET_FIRMWARE)
         return [(_STATUS_FIRMWARE, "".join(map(chr, msg[3:18])), "")]
+
+    def _get_raw_usb_device(self):
+        """Get a raw pyusb device handle for bulk + HID access.
+
+        Opens a pyusb handle alongside the existing hidapi handle.
+        The hidapi handle is closed first to avoid conflicts.
+        Must call _release_raw_usb_device() after.
+        """
+        if self._bulk_device is not None:
+            return self._bulk_device
+
+        import usb.core
+        import usb.util
+
+        # Close hidapi handle to release the HID interface
+        try:
+            self.device.close()
+        except Exception:
+            pass
+
+        # Find and configure the raw USB device
+        dev = usb.core.find(
+            idVendor=self.vendor_id,
+            idProduct=self.product_id,
+        )
+        if dev is None:
+            raise ExpectationNotMet("could not find USB device for LCD")
+
+        # Detach kernel drivers on both interfaces
+        for i in range(2):
+            try:
+                if dev.is_kernel_driver_active(i):
+                    dev.detach_kernel_driver(i)
+            except Exception:
+                pass
+
+        try:
+            dev.set_configuration()
+        except usb.core.USBError:
+            pass  # already configured
+
+        # Claim both interfaces
+        for i in range(2):
+            try:
+                usb.util.claim_interface(dev, i)
+            except Exception:
+                pass
+
+        self._bulk_device = dev
+        _LOGGER.debug("opened raw USB device for LCD")
+        return dev
+
+    def _release_raw_usb_device(self):
+        """Release the raw USB device and reattach kernel drivers."""
+        if self._bulk_device is not None:
+            import usb.util
+            for i in range(2):
+                try:
+                    usb.util.release_interface(self._bulk_device, i)
+                except Exception:
+                    pass
+            # Reattach kernel HID driver so hidapi works on next invocation
+            try:
+                self._bulk_device.attach_kernel_driver(1)
+            except Exception:
+                pass
+            try:
+                usb.util.dispose_resources(self._bulk_device)
+            except Exception:
+                pass
+            self._bulk_device = None
+
+    def close(self, **kwargs):
+        if self._bulk_device:
+            self._release_raw_usb_device()
+        super().close(**kwargs)
 
     def _get_cooler_duty(self) -> (int, int):
         """Get current pump and embedded fan duty in %."""
@@ -225,9 +348,357 @@ class AsusRyujin(UsbHidDriver):
         for handler in handlers:
             handler(duty)
 
+    def set_speed_profile(self, channel, profile, **kwargs):
+        """Not supported — use set_fixed_speed or ryujin_fand for curves.
+
+        To release back to the internal pump controller:
+
+            liquidctl --match Ryujin set pump speed auto
+        """
+        raise NotSupportedByDriver(
+            "speed profiles are host-driven on this device; "
+            "use set_fixed_speed or the ryujin_fand daemon for fan curves"
+        )
+
+    def _release_cooler_control(self):
+        """Release pump back to internal Asetek pump controller (ctrl_src=0).
+
+        Only the pump has an internal controller. The embedded fan has no
+        internal controller — it stays at whatever duty was last set (or 0 = off).
+        The fan must always be driven by the host.
+        """
+        self._write([_PREFIX, _CMD_SET_COOLER_SPEED, 0x00, 0x00, 0x00])
+
+    # ── LCD Screen Control ──────────────────────────────────────────────
+
     def set_screen(self, channel, mode, value, **kwargs):
-        # Not yet reverse engineered / implemented
-        raise NotSupportedByDriver()
+        """Set the screen mode and content.
+
+        Unstable.
+
+        Supported channels, modes and values:
+
+        | Channel | Mode | Value |
+        | --- | --- | --- |
+        | `lcd` | `static` | path to image file |
+        | `lcd` | `liquid` | — (built-in ROG animation) |
+        | `lcd` | `clock` | `24h` or `12h` (default: `24h`) |
+        | `lcd` | `monitor` | — (HW monitor showing live stats) |
+        | `lcd` | `off` | — |
+        | `lcd` | `standby` | — (screen off for system sleep) |
+        | `lcd` | `wake` | — (screen on, resume from standby) |
+        | `lcd` | `release` | — (release pump to internal controller; fan stays at last duty) |
+        | `lcd` | `brightness` | int between `0` and `100` (%) |
+        | `lcd` | `orientation` | `0`, `1`, `2` or `3` (0°, 90°, 180°, 270°) |
+
+        Requires Ryujin III (models with LCD display).
+        """
+        if not self._has_lcd:
+            raise NotSupportedByDriver("this model does not have an LCD")
+
+        if channel.lower() != "lcd":
+            raise ValueError(f"invalid channel: {channel}, expected: lcd")
+
+        if mode == "static":
+            # Static image needs bulk EP — use pyusb
+            if value is None:
+                raise ValueError("static mode requires a path to an image file")
+            self._set_screen_static(value)
+            self._release_raw_usb_device()
+        elif mode == "liquid":
+            self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_ANIMATION])
+        elif mode == "clock":
+            fmt_24h = value != "12h"
+            self._set_screen_clock_hid(fmt_24h)
+        elif mode == "monitor":
+            self._set_screen_hw_monitor_hid(**kwargs)
+        elif mode == "off":
+            self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_OFF])
+        elif mode == "standby":
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION, 0x20])
+        elif mode == "wake":
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION, 0x10])
+        elif mode == "brightness":
+            if value is None:
+                raise ValueError("brightness mode requires a value (0-100)")
+            brightness = clamp(int(value), 0, 100)
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION,
+                         0x01, 0x00, 0x00, 0x00, 0x00, brightness])
+        elif mode == "orientation":
+            if value is None:
+                raise ValueError("orientation requires 0-3 (0°, 90°, 180°, 270°)")
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION,
+                         0x01, 0x00, 0x00, int(value)])
+        elif mode == "release":
+            self._release_cooler_control()
+        else:
+            raise ValueError(
+                f"invalid mode: {mode}, valid: static, liquid, clock, monitor, off, "
+                f"standby, wake, brightness, orientation, release"
+            )
+
+    def _raw_hid_write(self, cmd: list):
+        """Write a HID command via raw pyusb (not hidapi).
+
+        Used during LCD operations when we have the raw USB handle.
+        """
+        dev = self._get_raw_usb_device()
+        payload = [_PREFIX] + (cmd + [0] * 64)[:64]
+        dev.write(_EP_HID_OUT, payload)
+
+    def _raw_hid_request(self, request_header: int, response_header: int) -> list:
+        """Send a command and read response via raw pyusb."""
+        dev = self._get_raw_usb_device()
+        payload = [_PREFIX, request_header] + [0] * 63
+        dev.write(_EP_HID_OUT, payload)
+        msg = dev.read(_EP_HID_IN, _REPORT_LENGTH, timeout=1000)
+        return list(msg)
+
+    def _raw_get_cooler_status(self):
+        """Read sensors via raw pyusb (used during LCD operations)."""
+        msg = self._raw_hid_request(0x99, 0x19)
+        liquid_temp = msg[self._temp_offset] + msg[self._temp_offset + 1] / 10
+        pump_speed = u16le_from(msg, self._pump_speed_offset)
+        pump_fan_speed = u16le_from(msg, self._pump_fan_speed_offset)
+        return liquid_temp, pump_speed, pump_fan_speed
+
+    def _switch_display_mode(self, mode_byte: int):
+        """Send EC 51 to switch display mode."""
+        self._raw_hid_write([_CMD_SWITCH_DISPLAY_MODE, mode_byte])
+        _LOGGER.debug("switched display mode to 0x%02x", mode_byte)
+
+    def _flush_framebuffer(self):
+        """Send EC 7F 03 00 84 03 to flush framebuffer to LCD."""
+        self._raw_hid_write([_CMD_FLUSH_FRAMEBUFFER, 0x03, 0x00, 0x84, 0x03])
+
+    def _write_bulk(self, data: bytes):
+        """Write raw data to bulk OUT endpoint."""
+        dev = self._get_raw_usb_device()
+        dev.write(_EP_BULK_OUT, data)
+
+    def _set_screen_static(self, path: str):
+        """Display a static image on the LCD.
+
+        Loads the image, converts to 320x240 BGR, sends via bulk endpoint,
+        then flushes. The image stays on screen until another mode is set.
+        """
+        try:
+            from PIL import Image
+        except ImportError:
+            raise NotSupportedByDriver(
+                "Pillow is required for static image mode: pip install Pillow"
+            )
+
+        img = Image.open(path)
+        img = img.resize((_LCD_WIDTH, _LCD_HEIGHT), Image.LANCZOS)
+        img = img.convert("RGB")
+
+        # Convert RGB to BGR byte array
+        pixels = img.tobytes()
+        bgr = bytearray(_LCD_FRAME_SIZE)
+        for i in range(0, len(pixels), 3):
+            bgr[i] = pixels[i + 2]      # B
+            bgr[i + 1] = pixels[i + 1]  # G
+            bgr[i + 2] = pixels[i]      # R
+
+        self._switch_display_mode(_DISPLAY_MODE_FRAMEBUFFER)
+        time.sleep(0.1)
+        self._write_bulk(bytes(bgr))
+        self._flush_framebuffer()
+        _LOGGER.info("displayed static image: %s", path)
+
+    def _set_screen_clock_hid(self, fmt_24h: bool = True):
+        """Switch to clock mode via hidapi (no pyusb needed)."""
+        hr_fmt = 0x00 if fmt_24h else 0x01
+
+        # Configure clock display (EC 5D)
+        self._write([_PREFIX, 0x5D, 0x00, 0x01, 0x08, 0x00, hr_fmt, 0x05])
+        time.sleep(0.05)
+
+        # Sync RTC
+        t = time.localtime()
+        def bcd(val):
+            return ((val // 10) << 4) | (val % 10)
+        hour = t.tm_hour
+        pm = 0x00
+        if not fmt_24h:
+            pm = 0x01 if hour >= 12 else 0x00
+            hour = hour % 12 or 12
+        self._write([_PREFIX, _CMD_SET_CLOCK,
+                     0x00, 0x00, 0x08, 0x00, hr_fmt,
+                     bcd(hour), bcd(t.tm_min), bcd(t.tm_sec), pm, 0x01])
+        time.sleep(0.05)
+
+        # Switch to clock mode
+        self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE,
+                     _DISPLAY_MODE_CLOCK, 0x00, hr_fmt])
+
+    def _set_screen_hw_monitor_hid(self, **kwargs):
+        """Switch to HW monitor mode via hidapi (no pyusb needed)."""
+        # Read sensors while we have the HID handle
+        try:
+            liquid_temp, pump_speed, pump_fan_speed = self._get_cooler_status()
+        except Exception:
+            liquid_temp, pump_speed, pump_fan_speed = 0, 0, 0
+
+        style = _HW_MONITOR_STYLES.get(kwargs.get("style", "custom"), 0x02)
+
+        # Layout (EC 52)
+        self._write([_PREFIX, _CMD_SET_HW_MONITOR_LAYOUT,
+                     style, 0x02, 0x02, 0x00,
+                     0, 0, 0, 0xFF,
+                     255, 255, 255, 0xFF,
+                     255, 255, 255, 0xFF,
+                     255, 255, 255, 0xFF,
+                     255, 255, 255, 0xFF])
+
+        # Switch mode (EC 51)
+        self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_HW_MONITOR])
+        time.sleep(0.2)
+
+        # Send sensor strings (EC 53)
+        DEGC = bytes([0xE2, 0x84, 0x83]).decode("utf-8")
+        RPM = bytes([0xE2, 0x86, 0x8C]).decode("utf-8")
+        lines = [
+            ("Liquid", f"{liquid_temp:.1f}{DEGC}"),
+            ("Pump", f"{pump_speed}{RPM}"),
+            ("Fan", f"{pump_fan_speed}{RPM}"),
+        ]
+        for i, (label, value) in enumerate(lines):
+            lb = list(label.encode("utf-8")[:18]) + [0] * 18
+            vb = list(value.encode("utf-8")[:12]) + [0] * 12
+            self._write([_PREFIX, _CMD_SET_HW_MONITOR_STRING, i] + lb[:18] + vb[:12])
+
+    def _set_screen_clock(self, fmt_24h: bool = True):
+        """Switch to clock mode and sync the RTC.
+
+        hr_fmt wire encoding: 0x00 = 24h, 0x01 = 12h (inverted from what you'd expect).
+        Verified on live hardware (S750, PID 0x1ADA).
+        """
+        hr_fmt = 0x00 if fmt_24h else 0x01
+
+        # Configure clock display (EC 5D)
+        self._raw_hid_write([0x5D, 0x00, 0x01, 0x08, 0x00, hr_fmt, 0x05])
+        time.sleep(0.05)
+
+        # Sync RTC to system time
+        self._sync_clock(fmt_24h)
+        time.sleep(0.05)
+
+        # Switch to clock mode (EC 51 08 00 HR_FMT)
+        self._raw_hid_write([_CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_CLOCK, 0x00, hr_fmt])
+        _LOGGER.info("switched to clock mode (%s)", "24h" if fmt_24h else "12h")
+
+    def _sync_clock(self, fmt_24h: bool = True):
+        """Set the device RTC to the current system time (BCD encoded).
+
+        Packet format verified against live hardware (S750, PID 0x1ADA).
+        Uses ryujin.py prefix layout + BCD time values.
+        """
+        t = time.localtime()
+        hr_fmt = 0x00 if fmt_24h else 0x01
+        pm = 0x00 if fmt_24h else (0x01 if t.tm_hour > 11 else 0x00)
+
+        def bcd(val):
+            return ((val // 10) << 4) | (val % 10)
+
+        hour = t.tm_hour
+        if not fmt_24h:
+            hour = hour % 12
+            if hour == 0:
+                hour = 12
+
+        self._raw_hid_write([
+            _CMD_SET_CLOCK,
+            0x00, 0x00, 0x08, 0x00, hr_fmt,
+            bcd(hour), bcd(t.tm_min), bcd(t.tm_sec), pm, 0x01,
+        ])
+        _LOGGER.debug("synced RTC to %02d:%02d:%02d", t.tm_hour, t.tm_min, t.tm_sec)
+
+    def _set_screen_hw_monitor(self, **kwargs):
+        """Switch to hardware monitor mode showing live sensor data.
+
+        Keyword arguments:
+            style: 'galactic', 'cyberpunk', or 'custom' (default: 'custom')
+            bg_color: (r, g, b) tuple for background (default: black)
+            text_color: (r, g, b) tuple for text (default: white)
+        """
+        # Read sensors BEFORE switching to raw USB (while hidapi is still open)
+        try:
+            liquid_temp, pump_speed, pump_fan_speed = self._get_cooler_status()
+        except Exception:
+            liquid_temp, pump_speed, pump_fan_speed = 0, 0, 0
+
+        style = kwargs.get("style", "custom")
+        bg_r, bg_g, bg_b = kwargs.get("bg_color", (0, 0, 0))
+        txt_r, txt_g, txt_b = kwargs.get("text_color", (255, 255, 255))
+
+        style_byte = _HW_MONITOR_STYLES.get(style, 0x02)
+
+        # Set HW monitor layout (EC 52)
+        self._raw_hid_write([
+            _CMD_SET_HW_MONITOR_LAYOUT,
+            style_byte, 0x02, 0x02, 0x00,
+            bg_r, bg_g, bg_b, 0xFF,
+            txt_r, txt_g, txt_b, 0xFF,
+            txt_r, txt_g, txt_b, 0xFF,
+            txt_r, txt_g, txt_b, 0xFF,
+            txt_r, txt_g, txt_b, 0xFF,
+        ])
+
+        # Switch to HW monitor mode
+        self._switch_display_mode(_DISPLAY_MODE_HW_MONITOR)
+
+        # Send sensor readings
+        lines = [
+            ("Liquid Temp", f"{liquid_temp:.1f}C"),
+            ("Pump", f"{pump_speed}RPM"),
+            ("Fan", f"{pump_fan_speed}RPM"),
+        ]
+        for i, (label, value) in enumerate(lines):
+            self._set_hw_monitor_string(i, label, value)
+
+        _LOGGER.info("switched to HW monitor mode (style=%s)", style)
+
+    def _set_hw_monitor_string(self, index: int, label: str, value: str):
+        """Send EC 53 to set a HW monitor line's label and value."""
+        label_bytes = label.encode("utf-8", errors="replace")[:18]
+        label_padded = list(label_bytes) + [0] * (18 - len(label_bytes))
+
+        value_bytes = value.encode("utf-8", errors="replace")[:12]
+        value_padded = list(value_bytes) + [0] * (12 - len(value_bytes))
+
+        self._raw_hid_write(
+            [_CMD_SET_HW_MONITOR_STRING, index]
+            + label_padded
+            + value_padded
+        )
+
+    def _set_brightness(self, brightness: int):
+        """Set LCD brightness (0-100%)."""
+        brightness = clamp(brightness, 0, 100)
+        self._set_display_option(brightness=brightness)
+        _LOGGER.info("set brightness to %d%%", brightness)
+
+    def _set_display_option(self, brightness=None, orientation=None):
+        """Send EC 5C 01 to set display options.
+
+        Verified from ITCM firmware handler at 0x00EC:
+          payload[0] = 0x01 (set config sub-command)
+          payload[1] = display_type
+          payload[2] = mode_byte
+          payload[3] = orientation
+          payload[4] = (skipped)
+          payload[5] = brightness
+        """
+        brt = brightness if brightness is not None else 30
+        orient = orientation if orientation is not None else 0
+
+        self._raw_hid_write([
+            _CMD_SET_DISPLAY_OPTION,
+            0x01, 0x00, 0x00, orient, 0x00,
+            brt,
+        ])
 
     def _request(self, request_header: int, response_header: int) -> List[int]:
         self.device.clear_enqueued_reports()

--- a/liquidctl/driver/asus_ryujin.py
+++ b/liquidctl/driver/asus_ryujin.py
@@ -228,6 +228,7 @@ class AsusRyujin(UsbHidDriver):
         """Release the raw USB device and reattach kernel drivers."""
         if self._bulk_device is not None:
             import usb.util
+
             for i in range(2):
                 try:
                     usb.util.release_interface(self._bulk_device, i)
@@ -422,13 +423,13 @@ class AsusRyujin(UsbHidDriver):
             if value is None:
                 raise ValueError("brightness mode requires a value (0-100)")
             brightness = clamp(int(value), 0, 100)
-            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION,
-                         0x01, 0x00, 0x00, 0x00, 0x00, brightness])
+            self._write(
+                [_PREFIX, _CMD_SET_DISPLAY_OPTION, 0x01, 0x00, 0x00, 0x00, 0x00, brightness]
+            )
         elif mode == "orientation":
             if value is None:
                 raise ValueError("orientation requires 0-3 (0°, 90°, 180°, 270°)")
-            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION,
-                         0x01, 0x00, 0x00, int(value)])
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION, 0x01, 0x00, 0x00, int(value)])
         elif mode == "release":
             self._release_cooler_control()
         else:
@@ -497,9 +498,9 @@ class AsusRyujin(UsbHidDriver):
         pixels = img.tobytes()
         bgr = bytearray(_LCD_FRAME_SIZE)
         for i in range(0, len(pixels), 3):
-            bgr[i] = pixels[i + 2]      # B
+            bgr[i] = pixels[i + 2]  # B
             bgr[i + 1] = pixels[i + 1]  # G
-            bgr[i + 2] = pixels[i]      # R
+            bgr[i + 2] = pixels[i]  # R
 
         self._switch_display_mode(_DISPLAY_MODE_FRAMEBUFFER)
         time.sleep(0.1)
@@ -517,21 +518,35 @@ class AsusRyujin(UsbHidDriver):
 
         # Sync RTC
         t = time.localtime()
+
         def bcd(val):
             return ((val // 10) << 4) | (val % 10)
+
         hour = t.tm_hour
         pm = 0x00
         if not fmt_24h:
             pm = 0x01 if hour >= 12 else 0x00
             hour = hour % 12 or 12
-        self._write([_PREFIX, _CMD_SET_CLOCK,
-                     0x00, 0x00, 0x08, 0x00, hr_fmt,
-                     bcd(hour), bcd(t.tm_min), bcd(t.tm_sec), pm, 0x01])
+        self._write(
+            [
+                _PREFIX,
+                _CMD_SET_CLOCK,
+                0x00,
+                0x00,
+                0x08,
+                0x00,
+                hr_fmt,
+                bcd(hour),
+                bcd(t.tm_min),
+                bcd(t.tm_sec),
+                pm,
+                0x01,
+            ]
+        )
         time.sleep(0.05)
 
         # Switch to clock mode
-        self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE,
-                     _DISPLAY_MODE_CLOCK, 0x00, hr_fmt])
+        self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_CLOCK, 0x00, hr_fmt])
 
     def _set_screen_hw_monitor_hid(self, **kwargs):
         """Switch to HW monitor mode via hidapi (no pyusb needed)."""
@@ -544,13 +559,36 @@ class AsusRyujin(UsbHidDriver):
         style = _HW_MONITOR_STYLES.get(kwargs.get("style", "custom"), 0x02)
 
         # Layout (EC 52)
-        self._write([_PREFIX, _CMD_SET_HW_MONITOR_LAYOUT,
-                     style, 0x02, 0x02, 0x00,
-                     0, 0, 0, 0xFF,
-                     255, 255, 255, 0xFF,
-                     255, 255, 255, 0xFF,
-                     255, 255, 255, 0xFF,
-                     255, 255, 255, 0xFF])
+        self._write(
+            [
+                _PREFIX,
+                _CMD_SET_HW_MONITOR_LAYOUT,
+                style,
+                0x02,
+                0x02,
+                0x00,
+                0,
+                0,
+                0,
+                0xFF,
+                255,
+                255,
+                255,
+                0xFF,
+                255,
+                255,
+                255,
+                0xFF,
+                255,
+                255,
+                255,
+                0xFF,
+                255,
+                255,
+                255,
+                0xFF,
+            ]
+        )
 
         # Switch mode (EC 51)
         self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_HW_MONITOR])
@@ -608,11 +646,21 @@ class AsusRyujin(UsbHidDriver):
             if hour == 0:
                 hour = 12
 
-        self._raw_hid_write([
-            _CMD_SET_CLOCK,
-            0x00, 0x00, 0x08, 0x00, hr_fmt,
-            bcd(hour), bcd(t.tm_min), bcd(t.tm_sec), pm, 0x01,
-        ])
+        self._raw_hid_write(
+            [
+                _CMD_SET_CLOCK,
+                0x00,
+                0x00,
+                0x08,
+                0x00,
+                hr_fmt,
+                bcd(hour),
+                bcd(t.tm_min),
+                bcd(t.tm_sec),
+                pm,
+                0x01,
+            ]
+        )
         _LOGGER.debug("synced RTC to %02d:%02d:%02d", t.tm_hour, t.tm_min, t.tm_sec)
 
     def _set_screen_hw_monitor(self, **kwargs):
@@ -636,15 +684,35 @@ class AsusRyujin(UsbHidDriver):
         style_byte = _HW_MONITOR_STYLES.get(style, 0x02)
 
         # Set HW monitor layout (EC 52)
-        self._raw_hid_write([
-            _CMD_SET_HW_MONITOR_LAYOUT,
-            style_byte, 0x02, 0x02, 0x00,
-            bg_r, bg_g, bg_b, 0xFF,
-            txt_r, txt_g, txt_b, 0xFF,
-            txt_r, txt_g, txt_b, 0xFF,
-            txt_r, txt_g, txt_b, 0xFF,
-            txt_r, txt_g, txt_b, 0xFF,
-        ])
+        self._raw_hid_write(
+            [
+                _CMD_SET_HW_MONITOR_LAYOUT,
+                style_byte,
+                0x02,
+                0x02,
+                0x00,
+                bg_r,
+                bg_g,
+                bg_b,
+                0xFF,
+                txt_r,
+                txt_g,
+                txt_b,
+                0xFF,
+                txt_r,
+                txt_g,
+                txt_b,
+                0xFF,
+                txt_r,
+                txt_g,
+                txt_b,
+                0xFF,
+                txt_r,
+                txt_g,
+                txt_b,
+                0xFF,
+            ]
+        )
 
         # Switch to HW monitor mode
         self._switch_display_mode(_DISPLAY_MODE_HW_MONITOR)
@@ -668,11 +736,7 @@ class AsusRyujin(UsbHidDriver):
         value_bytes = value.encode("utf-8", errors="replace")[:12]
         value_padded = list(value_bytes) + [0] * (12 - len(value_bytes))
 
-        self._raw_hid_write(
-            [_CMD_SET_HW_MONITOR_STRING, index]
-            + label_padded
-            + value_padded
-        )
+        self._raw_hid_write([_CMD_SET_HW_MONITOR_STRING, index] + label_padded + value_padded)
 
     def _set_brightness(self, brightness: int):
         """Set LCD brightness (0-100%)."""
@@ -694,11 +758,17 @@ class AsusRyujin(UsbHidDriver):
         brt = brightness if brightness is not None else 30
         orient = orientation if orientation is not None else 0
 
-        self._raw_hid_write([
-            _CMD_SET_DISPLAY_OPTION,
-            0x01, 0x00, 0x00, orient, 0x00,
-            brt,
-        ])
+        self._raw_hid_write(
+            [
+                _CMD_SET_DISPLAY_OPTION,
+                0x01,
+                0x00,
+                0x00,
+                orient,
+                0x00,
+                brt,
+            ]
+        )
 
     def _request(self, request_header: int, response_header: int) -> List[int]:
         self.device.clear_enqueued_reports()

--- a/tests/test_asus_ryujin.py
+++ b/tests/test_asus_ryujin.py
@@ -2,6 +2,7 @@ import pytest
 
 from _testutils import MockHidapiDevice
 from liquidctl.driver.asus_ryujin import AsusRyujin
+from liquidctl.error import NotSupportedByDriver
 
 PROTOCOL_HEADER = 0xEC
 CMD_GET_FIRMWARE = 0x82
@@ -19,6 +20,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 7,
         "temp_offset": 3,
         "duty_channel": 0,
+        "has_lcd": False,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a312d533735302d30313034",
             CMD_GET_STATUS: "ec19001b056405100e",
@@ -49,6 +51,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 10,
         "temp_offset": 5,
         "duty_channel": 1,
+        "has_lcd": True,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a332d533546392d30313034",
             CMD_GET_STATUS: "ec190000001d09ec041e6603",
@@ -71,6 +74,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 10,
         "temp_offset": 5,
         "duty_channel": 1,
+        "has_lcd": True,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a322d533735302d30313039",
             CMD_GET_STATUS: "ec1900000021002e0e644803",
@@ -93,6 +97,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 10,
         "temp_offset": 5,
         "duty_channel": 1,
+        "has_lcd": True,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a332d533546392d30313034",
             CMD_GET_STATUS: "ec190000001d09ec041e6603",
@@ -115,6 +120,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 10,
         "temp_offset": 5,
         "duty_channel": 1,
+        "has_lcd": True,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a332d533546392d30313034",
             CMD_GET_STATUS: "ec190000001d09ec041e6603",
@@ -176,6 +182,7 @@ def mock_ryujin():
         pump_fan_speed_offset=config["pump_fan_speed_offset"],
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
+        has_lcd=config["has_lcd"],
     )
 
 
@@ -191,6 +198,7 @@ def mock_ryujin3():
         pump_fan_speed_offset=config["pump_fan_speed_offset"],
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
+        has_lcd=config["has_lcd"],
     )
 
 
@@ -205,6 +213,7 @@ def test_initialize(product_id):
         pump_fan_speed_offset=config["pump_fan_speed_offset"],
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
+        has_lcd=config["has_lcd"],
     )
 
     with device.connect():
@@ -223,6 +232,7 @@ def test_status(product_id):
         pump_fan_speed_offset=config["pump_fan_speed_offset"],
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
+        has_lcd=config["has_lcd"],
     )
 
     with device.connect():
@@ -266,3 +276,80 @@ def test_set_fixed_speeds_ryujin3(mock_ryujin3):
         mock_ryujin3.set_fixed_speed(channel="pump-fan", duty=50)
         assert mock_ryujin3.device.requests[-1][2] == 0x01
         assert mock_ryujin3.device.requests[-1][4] == 0x32
+
+
+def test_set_screen_liquid(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "liquid", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x51
+        assert sent[2] == 0x04
+
+
+def test_set_screen_off(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "off", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x51
+        assert sent[2] == 0x00
+
+
+def test_set_screen_clock_24h(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "clock", "24h")
+        cmds = [r for r in mock_ryujin3.device.requests if r[0] == PROTOCOL_HEADER]
+        cmd_bytes = [r[1] for r in cmds]
+        assert 0x5D in cmd_bytes  # clock config
+        assert 0x11 in cmd_bytes  # set time
+        assert 0x51 in cmd_bytes  # mode switch
+        mode_cmd = [r for r in cmds if r[1] == 0x51][-1]
+        assert mode_cmd[2] == 0x08  # clock mode
+        time_cmd = [r for r in cmds if r[1] == 0x11][-1]
+        assert time_cmd[6] == 0x00  # hr_fmt 0x00 = 24h
+
+
+def test_set_screen_brightness(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "brightness", "75")
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x5C
+        assert sent[2] == 0x01
+        assert sent[7] == 75
+
+
+def test_set_screen_standby(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "standby", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x5C
+        assert sent[2] == 0x20
+
+
+def test_set_screen_wake(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "wake", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x5C
+        assert sent[2] == 0x10
+
+
+def test_set_screen_release(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "release", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x1A
+        assert sent[2] == 0x00
+        assert sent[3] == 0x00
+        assert sent[4] == 0x00
+
+
+def test_set_screen_not_supported_ryujin2(mock_ryujin):
+    with mock_ryujin.connect():
+        with pytest.raises(NotSupportedByDriver):
+            mock_ryujin.set_screen("lcd", "liquid", None)


### PR DESCRIPTION
Add `set_screen()` implementation for Ryujin III models (320x240 BGR LCD). Reverse engineered from `AacAIOFanHal_x64.dll` and ITCM firmware dump, verified on live hardware (ASUS Ryujin III White, FW `AURJ2-S750-0108`).

Supported modes:
  - static: display any image (auto-resized, RGB to BGR via Pillow)
  - liquid: built-in ROG animation
  - clock: 12h/24h with BCD-encoded RTC sync
  - monitor: HW monitor with live sensor data + animated backgrounds
  - off: turn display off
  - standby/wake: ACPI sleep/resume (EC 5C 20/10)
  - brightness: 0-100%
  - orientation: 0-3 (0/90/180/270 degrees)
  - release: return pump to internal Asetek controller (ctrl_src=0)

Architecture:
  - Uses hidapi for all HID commands (kernel driver stays bound)
  - Only static image mode uses pyusb for bulk EP 0x01 framebuffer
  - No device lockups between successive liquidctl invocations

Describe what the changes are meant to address.

If the implementation is not trivial, please also include a short overview.

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: <!-- #number of issue (implies Closes tag) or commit SHA -->
Closes: <!-- #number of issue or pull request -->
Related: <!-- #number of issue/pull request, or link to external discussion -->

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [X] Conform to the [style guide]
- [X] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [x] `liquidctl.8` Linux/Unix/Mac OS man page
    - [x] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [x] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes

----

Note: The HW monitor mode sends a one-shot snapshot of sensor data. Continuous updates require a host-side daemon polling sensors and re-sending EC 53 strings, this is how Armoury Crate works on Windows (via `FANPlayer::play` in the HAL DLL). A proper daemon integration is a gap in the liquidctl framework. I will track this separately.                                                                                                                 
                                                                                                                                                               
The fundamental issue is that liquidctl is designed as a one-shot CLI tool (run command, exit), but the Ryujin III's HW monitor and fan curves need a persistent process. This is an architectural limitation of liquidctl, not something this PR tries to solve. This PR correctly implements that protocol, the daemon is a separate concern.
