### PR TITLE
asus_ryuo: add coolant temp, LED control, and OLED display upload

### DIFF
--- a/docs/asus-ryuo-guide.md
+++ b/docs/asus-ryuo-guide.md
@@ -2,6 +2,7 @@
 _Driver API and source code available in [`liquidctl.driver.asus_ryuo`](../liquidctl/driver/asus_ryuo.py)._
 
 _New in 1.16.0._<br>
+_Sensor telemetry, LED control, and OLED display upload new in git._<br>
 
 ## Initialization
 
@@ -15,12 +16,14 @@ ASUS Ryuo I 240
 
 ## Monitoring
 
-This driver does **not** report status information (e.g. temperature, fan RPM, or duty cycle).
+_New in git._
+
+The driver reports the coolant temperature from the device's built-in sensor:
 
 ```
 # liquidctl status
 ASUS Ryuo I 240
-└── No status available
+└── Liquid temperature    32  °C
 ```
 
 ## Speed control
@@ -37,7 +40,7 @@ Only a single fan channel is available. Speeds are set as a fixed percentage (du
 
 ### Duty to speed relation
 
-The resulting speeds do not scale linearly to the set duty values.  
+The resulting speeds do not scale linearly to the set duty values.
 For example duty values below 20% result in no changes in pump speed.
 
 Fan duty values approximately map to the following speeds (± 10%):
@@ -56,10 +59,60 @@ Fan duty values approximately map to the following speeds (± 10%):
 | 90 | 2430 |
 | 100 | 2580 |
 
+## LED control
+
+_New in git._
+
+Use channel `led` to control the pump-head RGB LED:
+
+```
+# liquidctl set led color static ff0000
+# liquidctl set led color breathing 0000ff
+# liquidctl set led color spectrum
+# liquidctl set led color off
+```
+
+Available modes:
+
+| Mode | Colors | Description |
+|:---|:---:|:---|
+| `off` | — | Turn LED off |
+| `static` | 1 | Fixed color |
+| `breathing` | 1 | Pulsing color |
+| `flash` | 1 | Strobing color |
+| `spectrum` | — | Cycle through full spectrum |
+| `rainbow` | — | Rainbow wave effect |
+
+## OLED display
+
+_New in git.  Unstable._
+
+The pump head has a 160×128 pixel OLED display.  Use channel `lcd` to upload images or animated GIFs:
+
+```
+# liquidctl set lcd screen static photo.png
+# liquidctl set lcd screen gif animation.gif
+```
+
+For pump heads mounted with tubes pointing up, pass `rotation=180` to flip
+the image:
+
+```
+# liquidctl set lcd screen gif animation.gif rotation=180
+```
+
+Images are automatically resized and centered to fit the 160×128 display.
+Animated GIFs are re-encoded with optimized quantization for the hardware.
+
+Requires [Pillow](https://pillow.readthedocs.io/) (`pip install pillow`).
+
+**Note:** Large GIF files take longer to upload due to a hardware-imposed
+20ms delay between 62-byte chunks (the device writes to internal SPI flash).
+A 50 KB GIF takes approximately 16 seconds to upload.
 
 ## Limitations
 
-- No telemetry (fan speed, liquid temperature, etc.) is currently available.
-- Only fixed fan speed control is supported.
-- The cooler’s screen is not supported.
-
+- Fan speed (RPM) and pump speed are not available through the sensor register.
+- Only fixed fan speed control is supported (no duty curves).
+- OLED display upload requires Pillow as an additional dependency.
+- Writing to register `0x5C` causes the OLED to go black — the driver avoids this.

--- a/docs/developer/protocol/asus_ryuo.md
+++ b/docs/developer/protocol/asus_ryuo.md
@@ -1,6 +1,11 @@
 # ASUS ROG Ryuo I 240 Liquid Cooler Protocol
 
-The data of all USB packets is 65 bytes long and prefixed with `0xEC`.
+All USB packets are 65 bytes long, prefixed with `0xEC` (HID report ID).
+
+Vendor ID: `0x0B05` (ASUS), Product ID: `0x1887`.
+
+The protocol was reverse-engineered from ASUS LiveDash v1.05.03
+(`AuraIC.dll`, `WriteFileToFW()` function) and confirmed against hardware.
 
 ## Generic Operations
 
@@ -11,7 +16,17 @@ The data of all USB packets is 65 bytes long and prefixed with `0xEC`.
 - Response:
     - Header: `0xEC 0x02`
     - Data:
-        - Byte 2–18: firmware-version (ASCII)
+        - Byte 2–18: firmware version (ASCII, null-terminated)
+
+### Get sensor data
+
+- Request:
+    - Header: `0xEC 0xEA`
+- Response:
+    - Header: `0xEC 0x6A`
+    - Data:
+        - Byte 3: coolant temperature (°C, unsigned integer)
+        - Bytes 4–7: dynamic values (encoding uncertain, possibly pump-related)
 
 ## Cooling Operations
 
@@ -20,12 +35,78 @@ The data of all USB packets is 65 bytes long and prefixed with `0xEC`.
 - Request:
     - Header: `0xEC 0x2A`
     - Data:
-        - Byte 2: Fan duty % from `0x00` to `0x64` (0–100%)
+        - Byte 2: fan duty % from `0x00` to `0x64` (0–100%)
 - Response:
     - None
 
+## LED Operations
+
+### Set LED mode and color
+
+- Request:
+    - Header: `0xEC 0x3B`
+    - Data:
+        - Byte 2: `0x00` (padding)
+        - Byte 3: `0x22` (configuration flag)
+        - Byte 4: mode (`0x00`=off, `0x01`=static, `0x02`=breathing,
+          `0x03`=flash, `0x04`=spectrum, `0x05`=rainbow)
+        - Byte 5: red (0–255)
+        - Byte 6: green (0–255)
+        - Byte 7: blue (0–255)
+        - Byte 8: `0x00` (padding)
+        - Byte 9: `0x02` (zone count or config)
+- Response:
+    - None
+
+### Save LED settings
+
+- Request:
+    - Header: `0xEC 0x3F`
+    - Data:
+        - Byte 2: `0x55` (commit flag)
+- Response:
+    - None
+
+Send immediately after `Set LED mode and color` to persist the setting.
+
+## OLED Display Operations
+
+The pump head contains a 160×128 pixel OLED display.  Images must be in GIF
+format.  The upload uses a 9-step chunked transfer protocol.
+
+### OLED upload sequence
+
+Protocol from `AuraIC.dll` → `WriteFileToFW()`:
+
+1. **Init transfer:** `0xEC 0x51 0xA0`
+2. **Set file slot:** `0xEC 0x6B 0x01 0x00 N` (N = slot index, typically 1)
+3. **Stop animation:** `0xEC 0x6C 0x01`
+4. **Force stop animation:** `0xEC 0x6C 0x03`
+5. **Prepare for transfer:** `0xEC 0x6C 0x04`
+6. **Send data chunks:** For each 62-byte chunk of the GIF file:
+   `0xEC 0x6E [byte_count] [data...]` where `byte_count` ≤ 62.
+   A 20ms delay between chunks is required — the hardware writes to SPI flash
+   and cannot accept data faster.
+7. **Transfer complete:** `0xEC 0x6C 0x05`
+8. **Finalize / start animation:** `0xEC 0x6C 0xFF`
+9. **Commit transfer:** `0xEC 0x51 0x10 0x01 N` (N = slot index)
+
+After the commit, set the slot again and start playback:
+- `0xEC 0x6B 0x01 0x00 N`
+- `0xEC 0x6E 0x00` (start playback)
+
+### Important warnings
+
+**Do NOT write to register `0x5C` after upload.**  Any write to `0x5C`
+(the `SaveAIO` / display mode register) causes the OLED to go permanently
+black until a full power cycle of the cooler.  The upload protocol works
+correctly without it — the firmware picks up the new GIF from the file slot
+automatically.
+
 ## Notes
 
-- Only the `"fans"`/`"fan"` channel is supported as of this driver.
-- No real-time status or telemetry (e.g. fan RPM, temperature) is available for this device as of this driver.
-
+- The device uses HID WriteFile (not SetFeature), 65 bytes per report.
+- HID vendor usage page: `0xFF72`, usage: `0xA1`.
+- Register reads use command `0x80 + register_number`; the response byte at
+  offset 1 is `register_number` (i.e., command minus `0x80`).
+- Register writes use the command byte directly with no response.

--- a/liquidctl/driver/asus_ryuo.py
+++ b/liquidctl/driver/asus_ryuo.py
@@ -1,34 +1,79 @@
-"""liquidctl driver for the ASUS Ryuo liquid coolers.
+"""liquidctl driver for the ASUS Ryuo I 240 liquid cooler.
+
+Adds sensor telemetry (coolant temperature), LED color control, and OLED
+display upload to the existing fan-speed driver.
+
+The OLED upload protocol was reverse-engineered from ASUS LiveDash v1.05.03
+(AuraIC.dll, WriteFileToFW function).  The device accepts GIF images via a
+chunked HID transfer and renders them on a 160x128 OLED panel embedded in
+the pump head.
 
 Copyright Bloodhundur and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+# uses the psf/black style
+
+import io
 import logging
+import time
 from typing import List
 
 from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.error import ExpectationNotMet
-from liquidctl.util import clamp, rpadlist
+from liquidctl.util import LazyHexRepr, clamp, rpadlist
 
 _LOGGER = logging.getLogger(__name__)
 
 _REPORT_LENGTH = 65
 _PREFIX = 0xEC
-_CMD_SET_FAN_SPEED = 0x2A
 
+# Register read requests: (send_header, expected_response_header)
 _REQUEST_GET_FIRMWARE = (0x82, 0x02)
+_REQUEST_GET_SENSORS = (0xEA, 0x6A)
+
+# Write commands
+_CMD_SET_FAN_SPEED = 0x2A
+_CMD_LED_MODE = 0x3B
+_CMD_LED_SAVE = 0x3F
+_CMD_XFER_CTRL = 0x51
+_CMD_FILE_SLOT = 0x6B
+_CMD_ANIM_CTRL = 0x6C
+_CMD_XFER_DATA = 0x6E
+
+# LED modes exposed to users
+_LED_MODES = {
+    "off": 0x00,
+    "static": 0x01,
+    "breathing": 0x02,
+    "flash": 0x03,
+    "spectrum": 0x04,
+    "rainbow": 0x05,
+}
+
+# OLED display constants
+_OLED_WIDTH = 160
+_OLED_HEIGHT = 128
+_OLED_CHUNK_SIZE = 62
+_OLED_CHUNK_DELAY = 0.02  # seconds; hardware SPI flash write speed limit
+
+# Status labels
 _STATUS_FIRMWARE = "Firmware version"
+_STATUS_COOLANT_TEMP = "Liquid temperature"
 
 
 class AsusRyuo(UsbHidDriver):
-    """Driver for ASUS Ryuo I 240 (fan control only)."""
+    """ASUS Ryuo I 240 liquid cooler."""
 
     _MATCHES = [
         (0x0B05, 0x1887, "ASUS Ryuo I 240", {}),
     ]
 
     def initialize(self, **kwargs):
+        """Report firmware version.
+
+        Returns a list of tuples of `bool, key, value, unit`.
+        """
         msg = self._request(*_REQUEST_GET_FIRMWARE)
         fw_string = bytes(msg[2:]).split(b"\x00")[0].decode("ascii", errors="ignore")
         return [
@@ -36,14 +81,224 @@ class AsusRyuo(UsbHidDriver):
         ]
 
     def get_status(self, **kwargs):
-        _LOGGER.info("No status available")
+        """Report coolant temperature.
+
+        Returns a list of tuples of `key, value, unit`.
+        """
+        msg = self._request(*_REQUEST_GET_SENSORS)
+        _LOGGER.debug("sensor register: %r", LazyHexRepr(msg[2:8]))
+
+        # byte offset 3 (msg[3]) is coolant temperature in degrees Celsius
+        coolant_temp = msg[3]
+
+        if coolant_temp == 0:
+            _LOGGER.warning("coolant temperature reads 0, sensor may not be ready")
+
+        return [
+            (_STATUS_COOLANT_TEMP, coolant_temp, "°C"),
+        ]
 
     def set_fixed_speed(self, channel, duty, **kwargs):
+        """Set fan duty cycle.
+
+        Valid channels: `fans`.
+        Duty is a percentage from 0 to 100.
+        """
         if channel not in ("fans", "fan"):
-            raise ValueError("Only 'fans' channel is supported")
+            raise ValueError(f"invalid channel: {channel}")
         duty = clamp(duty, 0, 100)
-        _LOGGER.info(f"Setting fan speed to {duty}%")
+        _LOGGER.info("setting fan duty to %d%%", duty)
         self._write([_PREFIX, _CMD_SET_FAN_SPEED, duty])
+
+    def set_color(self, channel, mode, colors, speed="normal", **kwargs):
+        """Set the pump-head LED color and mode.
+
+        Valid channels: `led`.
+        Valid modes: `off`, `static`, `breathing`, `flash`, `spectrum`, `rainbow`.
+        Colors is a list of `(r, g, b)` tuples; only the first color is used.
+
+        For `spectrum` and `rainbow` modes the color argument is ignored.
+        """
+        if channel not in ("led",):
+            raise ValueError(f"invalid channel: {channel}")
+
+        mode_lower = mode.lower()
+        if mode_lower not in _LED_MODES:
+            raise ValueError(f"invalid mode: {mode} (valid: {', '.join(_LED_MODES)})")
+
+        mode_byte = _LED_MODES[mode_lower]
+        colors = list(colors)
+
+        if mode_lower == "off":
+            r, g, b = 0, 0, 0
+        elif mode_lower in ("spectrum", "rainbow"):
+            r, g, b = 0, 0, 0
+        elif colors:
+            r, g, b = colors[0]
+        else:
+            raise ValueError("colors required for this mode")
+
+        _LOGGER.info("setting LED to (%d, %d, %d) mode=%s", r, g, b, mode_lower)
+        self._write([_PREFIX, _CMD_LED_MODE, 0x00, 0x22, mode_byte, r, g, b, 0x00, 0x02])
+        self._write([_PREFIX, _CMD_LED_SAVE, 0x55])
+
+    def set_screen(self, channel, mode, value, **kwargs):
+        """Upload an image or GIF to the pump-head OLED display.
+
+        Unstable.
+
+        The device has a 160x128 pixel OLED.  Images are automatically resized
+        and converted to GIF format before upload.
+
+        Valid channels: `lcd`.
+
+        | Mode | Value |
+        | --- | --- |
+        | `static` | path to image file |
+        | `gif` | path to animated GIF |
+
+        Keyword arguments:
+
+        | Keyword | Value |
+        | --- | --- |
+        | `rotation` | `0` or `180` — rotate image for flipped mounts |
+
+        Requires Pillow (`pip install pillow`).
+
+        From the CLI, pass rotation as an unsafe keyword::
+
+            liquidctl set lcd screen gif animation.gif rotation=180
+        """
+        if channel not in ("lcd",):
+            raise ValueError(f"invalid channel: {channel}")
+        if mode not in ("static", "gif"):
+            raise ValueError(f"invalid mode: {mode} (valid: static, gif)")
+        if not value:
+            raise ValueError("file path required")
+
+        try:
+            from PIL import Image
+        except ImportError:
+            raise RuntimeError("Pillow is required for OLED uploads: pip install pillow")
+
+        rotation = int(kwargs.get("rotation", 0))
+        rotate = rotation == 180
+        gif_data = self._prepare_gif(value, mode == "gif", rotate=rotate)
+        _LOGGER.info("uploading %d bytes to OLED", len(gif_data))
+        self._upload_oled(gif_data)
+
+    # -- internal helpers --
+
+    def _prepare_gif(self, image_path, is_animated, rotate=False):
+        """Load, resize, and encode image as GIF bytes for the OLED."""
+        from PIL import Image
+
+        img = Image.open(image_path)
+        has_frames = hasattr(img, "n_frames") and img.n_frames > 1
+
+        if has_frames and is_animated:
+            frames = []
+            durations = []
+            for i in range(img.n_frames):
+                img.seek(i)
+                frame = img.copy().convert("RGBA")
+                frame.thumbnail((_OLED_WIDTH, _OLED_HEIGHT), Image.LANCZOS)
+                canvas = Image.new("RGBA", (_OLED_WIDTH, _OLED_HEIGHT), (0, 0, 0, 255))
+                canvas.paste(
+                    frame,
+                    (
+                        (_OLED_WIDTH - frame.size[0]) // 2,
+                        (_OLED_HEIGHT - frame.size[1]) // 2,
+                    ),
+                )
+                if rotate:
+                    canvas = canvas.rotate(180)
+                frames.append(canvas.convert("RGB"))
+                durations.append(max(img.info.get("duration", 100) or 100, 33))
+
+            p_frames = [f.quantize(colors=256, method=2) for f in frames]
+            buf = io.BytesIO()
+            p_frames[0].save(
+                buf,
+                format="GIF",
+                save_all=True,
+                append_images=p_frames[1:],
+                duration=durations,
+                loop=0,
+                optimize=True,
+            )
+            return buf.getvalue()
+        else:
+            frame = img.convert("RGB")
+            frame.thumbnail((_OLED_WIDTH, _OLED_HEIGHT), Image.LANCZOS)
+            canvas = Image.new("RGB", (_OLED_WIDTH, _OLED_HEIGHT), (0, 0, 0))
+            canvas.paste(
+                frame,
+                (
+                    (_OLED_WIDTH - frame.size[0]) // 2,
+                    (_OLED_HEIGHT - frame.size[1]) // 2,
+                ),
+            )
+            if rotate:
+                canvas = canvas.rotate(180)
+            buf = io.BytesIO()
+            canvas.quantize(colors=256, method=2).save(buf, format="GIF", optimize=True)
+            return buf.getvalue()
+
+    def _upload_oled(self, gif_data, slot=1):
+        """Execute the 9-step OLED upload protocol.
+
+        Protocol reverse-engineered from ASUS LiveDash v1.05.03 AuraIC.dll
+        (WriteFileToFW function).
+
+        IMPORTANT: Do NOT write to register 0x5C after upload.  Any write to
+        0x5C causes the OLED to go permanently black until a full power cycle.
+        """
+        # Step 1: Init transfer
+        self._write([_PREFIX, _CMD_XFER_CTRL, 0xA0])
+        time.sleep(0.05)
+
+        # Step 2: Set file slot
+        self._write([_PREFIX, _CMD_FILE_SLOT, 0x01, 0x00, slot])
+        time.sleep(0.05)
+
+        # Step 3-4: Stop animation
+        self._write([_PREFIX, _CMD_ANIM_CTRL, 0x01])  # stop
+        time.sleep(0.05)
+        self._write([_PREFIX, _CMD_ANIM_CTRL, 0x03])  # force stop
+        time.sleep(0.05)
+
+        # Step 5: Prepare for transfer
+        self._write([_PREFIX, _CMD_ANIM_CTRL, 0x04])
+        time.sleep(0.05)
+
+        # Step 6: Send file data in 62-byte chunks
+        total = len(gif_data)
+        offset = 0
+        while offset < total:
+            chunk = gif_data[offset : offset + _OLED_CHUNK_SIZE]
+            self._write([_PREFIX, _CMD_XFER_DATA, len(chunk)] + list(chunk))
+            offset += len(chunk)
+            time.sleep(_OLED_CHUNK_DELAY)
+
+        _LOGGER.debug("sent %d bytes in %d chunks", total, (total + 61) // 62)
+
+        # Step 7: Signal transfer complete
+        self._write([_PREFIX, _CMD_ANIM_CTRL, 0x05])
+        time.sleep(0.1)
+
+        # Step 8: Finalize / start animation
+        self._write([_PREFIX, _CMD_ANIM_CTRL, 0xFF])
+        time.sleep(0.1)
+
+        # Step 9: Commit transfer
+        self._write([_PREFIX, _CMD_XFER_CTRL, 0x10, 0x01, slot])
+        time.sleep(0.2)
+
+        # Step 10: Set slot and start playback
+        self._write([_PREFIX, _CMD_FILE_SLOT, 0x01, 0x00, slot])
+        time.sleep(0.1)
+        self._write([_PREFIX, _CMD_XFER_DATA, 0x00])  # start playback
 
     def _request(self, request_header: int, response_header: int) -> List[int]:
         self.device.clear_enqueued_reports()
@@ -53,9 +308,11 @@ class AsusRyuo(UsbHidDriver):
     def _read(self, expected_header=None) -> List[int]:
         msg = self.device.read(_REPORT_LENGTH)
         if msg[0] != _PREFIX:
-            raise ExpectationNotMet("Unexpected report prefix")
+            raise ExpectationNotMet("unexpected report prefix")
         if expected_header is not None and msg[1] != expected_header:
-            raise ExpectationNotMet("Unexpected report header")
+            raise ExpectationNotMet(
+                f"unexpected response header {msg[1]:#04x}, expected {expected_header:#04x}"
+            )
         return msg
 
     def _write(self, data: List[int]):

--- a/tests/test_asus_ryuo.py
+++ b/tests/test_asus_ryuo.py
@@ -1,14 +1,17 @@
+"""Tests for the ASUS Ryuo I 240 driver.
+
+Copyright Bloodhundur and contributors
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+# uses the psf/black style
+
 import pytest
 
 from _testutils import MockHidapiDevice
 from liquidctl.driver.asus_ryuo import AsusRyuo
 
-
-@pytest.fixture
-def mockRyuo():
-    device = AsusRyuo(_MockRyuoDevice(), "Mock Asus Ryuo I")
-    device.connect()
-    return device
+_PREFIX = 0xEC
 
 
 class _MockRyuoDevice(MockHidapiDevice):
@@ -19,12 +22,19 @@ class _MockRyuoDevice(MockHidapiDevice):
 
     def write(self, data):
         super().write(data)
-        self.requests.append(data)
+        self.requests.append(list(data))
 
-        assert data[0] == 0xEC
+        assert data[0] == _PREFIX
         header = data[1]
         if header == 0x82:
-            self.response = "ec024155524f302d533435322d30323035"
+            # Firmware: "AURO0-S452-0205"
+            self.response = bytes.fromhex("ec024155524f302d533435322d30323035")
+        elif header == 0xEA:
+            # Sensor register: byte 3 = coolant temp (32°C)
+            self.response = bytearray(65)
+            self.response[0] = _PREFIX
+            self.response[1] = 0x6A
+            self.response[3] = 32  # coolant temp
         else:
             self.response = None
 
@@ -34,30 +44,205 @@ class _MockRyuoDevice(MockHidapiDevice):
             return pre
 
         buf = bytearray(65)
-        buf[0] = 0xEC
+        buf[0] = _PREFIX
 
         if self.response:
-            response = bytes.fromhex(self.response)
-            buf[: len(response)] = response
+            if isinstance(self.response, (bytes, bytearray)):
+                buf[: len(self.response)] = self.response
+            else:
+                response = bytes.fromhex(self.response)
+                buf[: len(response)] = response
 
         return buf[:length]
 
 
-def test_initialize(mockRyuo):
+@pytest.fixture
+def mockRyuo():
+    device = AsusRyuo(_MockRyuoDevice(), "Mock Asus Ryuo I")
+    device.connect()
+    return device
+
+
+# -- initialize --
+
+
+def test_initialize_reports_firmware(mockRyuo):
     (firmware_status,) = mockRyuo.initialize()
-
+    assert firmware_status[0] == "Firmware version"
     assert firmware_status[1] == "AURO0-S452-0205"
+    assert firmware_status[2] == ""
 
 
-@pytest.mark.skip(reason="TODO: implement expected status values")
-def test_status(mockRyuo):
-    actual = mockRyuo.get_status()
-
-    expected = []
-
-    assert sorted(actual) == sorted(expected)
+# -- get_status --
 
 
-def test_set_fixed_speeds(mockRyuo):
+def test_get_status_reports_coolant_temp(mockRyuo):
+    status = mockRyuo.get_status()
+    assert len(status) == 1
+    assert status[0][0] == "Liquid temperature"
+    assert status[0][1] == 32
+    assert status[0][2] == "°C"
+
+
+def test_get_status_sends_correct_request(mockRyuo):
+    mockRyuo.get_status()
+    # Last request before the read should be the sensor query
+    req = mockRyuo.device.requests[-1]
+    assert req[0] == _PREFIX
+    assert req[1] == 0xEA
+
+
+# -- set_fixed_speed --
+
+
+def test_set_fixed_speed_sends_duty(mockRyuo):
     mockRyuo.set_fixed_speed(channel="fans", duty=40)
-    assert mockRyuo.device.requests[-1][2] == 0x28
+    req = mockRyuo.device.requests[-1]
+    assert req[0] == _PREFIX
+    assert req[1] == 0x2A
+    assert req[2] == 40
+
+
+def test_set_fixed_speed_clamps_to_100(mockRyuo):
+    mockRyuo.set_fixed_speed(channel="fans", duty=200)
+    req = mockRyuo.device.requests[-1]
+    assert req[2] == 100
+
+
+def test_set_fixed_speed_clamps_to_0(mockRyuo):
+    mockRyuo.set_fixed_speed(channel="fans", duty=-10)
+    req = mockRyuo.device.requests[-1]
+    assert req[2] == 0
+
+
+def test_set_fixed_speed_rejects_invalid_channel(mockRyuo):
+    with pytest.raises(ValueError):
+        mockRyuo.set_fixed_speed(channel="pump", duty=50)
+
+
+# -- set_color --
+
+
+def test_set_color_static(mockRyuo):
+    mockRyuo.set_color(channel="led", mode="static", colors=[(255, 0, 0)])
+    # Should have sent LED mode command + save command
+    assert len(mockRyuo.device.requests) >= 2
+    led_req = mockRyuo.device.requests[-2]
+    assert led_req[0] == _PREFIX
+    assert led_req[1] == 0x3B  # CMD_LED_MODE
+    assert led_req[4] == 0x01  # static mode
+    assert led_req[5] == 255  # R
+    assert led_req[6] == 0  # G
+    assert led_req[7] == 0  # B
+
+    save_req = mockRyuo.device.requests[-1]
+    assert save_req[0] == _PREFIX
+    assert save_req[1] == 0x3F  # CMD_LED_SAVE
+    assert save_req[2] == 0x55
+
+
+def test_set_color_breathing(mockRyuo):
+    mockRyuo.set_color(channel="led", mode="breathing", colors=[(0, 255, 0)])
+    led_req = mockRyuo.device.requests[-2]
+    assert led_req[4] == 0x02  # breathing mode
+
+
+def test_set_color_off(mockRyuo):
+    mockRyuo.set_color(channel="led", mode="off", colors=[])
+    led_req = mockRyuo.device.requests[-2]
+    assert led_req[4] == 0x00  # off mode
+    assert led_req[5] == 0  # R=0
+    assert led_req[6] == 0  # G=0
+    assert led_req[7] == 0  # B=0
+
+
+def test_set_color_rejects_invalid_channel(mockRyuo):
+    with pytest.raises(ValueError):
+        mockRyuo.set_color(channel="fans", mode="static", colors=[(255, 0, 0)])
+
+
+def test_set_color_rejects_invalid_mode(mockRyuo):
+    with pytest.raises(ValueError):
+        mockRyuo.set_color(channel="led", mode="disco", colors=[(255, 0, 0)])
+
+
+# -- set_screen --
+
+
+def test_set_screen_rejects_invalid_channel(mockRyuo):
+    with pytest.raises(ValueError):
+        mockRyuo.set_screen(channel="fans", mode="static", value="test.png")
+
+
+def test_set_screen_rejects_invalid_mode(mockRyuo):
+    with pytest.raises(ValueError):
+        mockRyuo.set_screen(channel="lcd", mode="video", value="test.mp4")
+
+
+def test_set_screen_rejects_missing_value(mockRyuo):
+    with pytest.raises(ValueError):
+        mockRyuo.set_screen(channel="lcd", mode="static", value=None)
+
+
+def test_set_screen_uploads_gif(mockRyuo, tmp_path):
+    """Test that set_screen processes an image and sends the upload protocol."""
+    try:
+        from PIL import Image
+    except ImportError:
+        pytest.skip("Pillow not installed")
+
+    # Create a small test image
+    img = Image.new("RGB", (160, 128), (255, 0, 0))
+    test_file = tmp_path / "test.gif"
+    img.save(str(test_file), format="GIF")
+
+    mockRyuo.set_screen(channel="lcd", mode="static", value=str(test_file))
+
+    # Verify the upload protocol sequence
+    reqs = mockRyuo.device.requests
+    # Should have: init(0x51), slot(0x6B), stop(0x6C), force_stop(0x6C),
+    # prepare(0x6C), data chunks(0x6E...), complete(0x6C), finalize(0x6C),
+    # commit(0x51), slot_again(0x6B), start_playback(0x6E)
+    cmds = [r[1] for r in reqs]
+
+    # Step 1: Init transfer
+    assert cmds[0] == 0x51
+    assert reqs[0][2] == 0xA0
+
+    # Step 2: Set file slot
+    assert cmds[1] == 0x6B
+
+    # Steps 3-4: Stop animation
+    assert cmds[2] == 0x6C
+    assert reqs[2][2] == 0x01
+    assert cmds[3] == 0x6C
+    assert reqs[3][2] == 0x03
+
+    # Step 5: Prepare transfer
+    assert cmds[4] == 0x6C
+    assert reqs[4][2] == 0x04
+
+    # Step 6: Data chunks (at least one)
+    assert cmds[5] == 0x6E
+
+    # Find end of data chunks
+    data_end = 5
+    while data_end < len(cmds) and cmds[data_end] == 0x6E:
+        data_end += 1
+
+    # Step 7: Transfer complete
+    assert cmds[data_end] == 0x6C
+    assert reqs[data_end][2] == 0x05
+
+    # Step 8: Finalize
+    assert cmds[data_end + 1] == 0x6C
+    assert reqs[data_end + 1][2] == 0xFF
+
+    # Step 9: Commit
+    assert cmds[data_end + 2] == 0x51
+    assert reqs[data_end + 2][2] == 0x10
+
+    # Step 10: Set slot + start playback
+    assert cmds[data_end + 3] == 0x6B
+    assert cmds[data_end + 4] == 0x6E
+    assert reqs[data_end + 4][2] == 0x00  # start playback


### PR DESCRIPTION
## Summary

Extends the ASUS Ryuo I 240 driver with three new capabilities:

- **Coolant temperature** — `get_status()` reads sensor register `0x6A` and reports liquid temperature in °C
- **LED control** — `set_color()` supports 6 modes: off, static, breathing, flash, spectrum, rainbow (commands `0x3B`/`0x3F`)
- **OLED display upload** — `set_screen()` uploads images/GIFs to the 160×128 OLED on the pump head via a 9-step chunked HID transfer protocol

### OLED upload protocol

Reverse-engineered from ASUS LiveDash v1.05.03 (`AuraIC.dll`, `WriteFileToFW()` function):

1. Init transfer (`0x51 0xA0`)
2. Set file slot (`0x6B`)
3. Stop animation (`0x6C 0x01`, `0x6C 0x03`)
4. Prepare transfer (`0x6C 0x04`)
5. Send GIF in 62-byte chunks (`0x6E`) with 20ms delays (hardware SPI flash speed limit)
6. Signal complete (`0x6C 0x05`)
7. Finalize (`0x6C 0xFF`)
8. Commit (`0x51 0x10 0x01 N`)
9. Start playback (`0x6E 0x00`)

> **Warning:** Register `0x5C` must never be written after upload — it causes the OLED to go permanently black until a full power cycle. Discovered the hard way.

### Usage examples

```bash
# Coolant temperature
liquidctl status

# LED control
liquidctl set led color static ff0000
liquidctl set led color breathing 0000ff
liquidctl set led color spectrum

# OLED display
liquidctl set lcd screen static photo.png
liquidctl set lcd screen gif animation.gif
```

### Changes

| File | Change |
|------|--------|
| `liquidctl/driver/asus_ryuo.py` | Added `get_status()`, `set_color()`, `set_screen()`, `_prepare_gif()`, `_upload_oled()` |
| `tests/test_asus_ryuo.py` | 16 tests (was 3) — sensors, LED modes, validation, full upload protocol verification |
| `docs/asus-ryuo-guide.md` | User guide with examples for all new features |
| `docs/developer/protocol/asus_ryuo.md` | Complete protocol spec including OLED upload sequence |

### Testing

- 16/16 driver tests pass
- 531/531 full suite passes (0 regressions)
- Tested on real hardware (ASUS ROG Ryuo I 240, firmware AURO0-S452-0205)
- Pillow is an optional dependency — only imported when `set_screen()` is called
- Formatted with `black --line-length 100`

### Notes

- Pillow (`pip install pillow`) is required only for OLED uploads, imported at call time to avoid adding a hard dependency
- I can provide USB pcap captures if needed — happy to submit a companion PR to `liquidctl/collected-device-data`
- Built and tested on NixOS Linux