### PR TITLE
feat: add RGB ring support for Kraken 2024 Elite (0x3012)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Changes since 1.16.0
+
+Added:
+
+- NZXT Kraken Elite V2: control the pump RGB ring, the external RGB-fan header, and `sync` (liquidctl#882, building on liquidctl#803)
+
 ## [1.16.0] – 2026-03-03
 
 ### Changes since 1.15.0

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [NZXT Kraken X53, X63, X73](docs/kraken-x3-z3-guide.md) | h | 1.11.1 |
 | AIO liquid cooler  | [NZXT Kraken Z53, Z63, Z73](docs/kraken-x3-z3-guide.md) | h | 1.14.0 |
 | AIO liquid cooler  | [NZXT Kraken 2023 Standard, Elite](docs/kraken-x3-z3-guide.md) | p | 1.14.0 |
-| AIO liquid cooler  | [NZXT Kraken 2024 Elite RGB](docs/kraken-x3-z3-guide.md) | p | 1.15.0 |
+| AIO liquid cooler  | [NZXT Kraken Elite V2 (2024 Elite)](docs/kraken-x3-z3-guide.md) | p | 1.15.0 |
 | AIO liquid cooler  | [NZXT Kraken 2024 Plus](docs/kraken-x3-z3-guide.md) | | 1.16.0 |
 | Pump controller    | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | hp | 1.15.0 |
 | Fan/LED controller | [Aquacomputer Farbwerk](docs/aquacomputer-farbwerk-guide.md) | hp | 1.16.0 |

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -29,9 +29,19 @@ In addition to this, Kraken Z coolers restore the embedded fan controller that i
 Kraken 2023 AIOs use the same pump and as their Z3 predecessor but the integrated LED controller has been removed. The LCD resolution is 240x240 for the standard version and 640x640 for the Elite variant, which also features a light ring on the pump housing. **Controlling the light ring is not yet supported**.
 
 
-## NZXT Kraken 2024 Elite RGB
+## NZXT Kraken Elite V2
 
-The functionality of the 2024 RGB AIO is identical to the 2023 model, retaining the 640x640 LCD. As of the 1.2.1 firmware, it's still able to use GIF and static modes. **Controlling the light ring is not yet supported**.
+NZXT's 2024 Kraken Elite refresh, which the cooler reports over USB as _Kraken Elite V2_.  It shares the 2023 Elite's 640x640 LCD pump and adds an addressable RGB ring around the pump cap.  A single USB id (`1e71:3012`) covers both the RGB-fan bundle (retailed as _Kraken Elite RGB_) and the plain-fan bundle (_Kraken Elite_); these are the same cooler — firmware-identical and indistinguishable over USB — so liquidctl uses the generation name for both.  As of the 1.2.1 firmware, the GIF and static LCD modes are also supported.
+
+Three lighting channels are exposed: `ring`, the pump-cap ring; `external`, the RGB header where the bundled RGB (radiator) fans connect (empty when no RGB accessory is plugged in); and `sync`, which drives both at once.  The ring is driven with the Hue 2 _direct_ protocol; `fixed` is mapped to a per-LED `super-fixed` write so the whole ring shows a single solid color, instead of the periodic flicker the animation protocol produces on this channel.  (For a solid ring color use the `ring` channel; the same `fixed` on `sync` reaches the ring over the animation protocol and may flicker.)
+
+```
+# liquidctl set ring color fixed 00aaff
+# liquidctl set external color spectrum-wave
+# liquidctl set sync color breathing ff2608 --speed slower
+```
+
+NZXT RGB fans (and other Hue 2 accessories) daisy-chained to the cooler's RGB header are controlled through the `external` channel; run `liquidctl initialize` to list the connected accessories.  The complete list of color modes is in the [RGB lighting](#rgb-lighting-with-leds) section below.
 
 
 ## NZXT Kraken 2024 Plus
@@ -109,18 +119,20 @@ _New in 1.14.0._<br>
 
 Adds support for NZXT Kraken 2023 Standard, Elite
 
-Adds support for NZXT Kraken 2024 Elite RGB
+Adds support for NZXT Kraken Elite V2 (2024 Elite)
 
 ## RGB lighting with LEDs
 
 One or more LED channels are provided, depending on the model.
 
-| Channel | Type | LED count | X models | Z models |
-| --- | --- | --- | :---: | :---: |
-| `external` | HUE 2/HUE+ accessories | up to 40 | ✓ |  ✓ |
-| `ring` | Infinity mirror: ring | 8 | ✓ | |
-| `logo` | Infinity mirror: logo | 1 | ✓ | |
-| `sync` | Synchronize all channels | up to 40 | ✓ | |
+| Channel | Type | LED count | X models | Z models | 2024 Elite |
+| --- | --- | --- | :---: | :---: | :---: |
+| `external` | HUE 2/HUE+ accessories | up to 40 | ✓ |  ✓ | ✓ |
+| `ring` | Pump ring | 8 (X3) | ✓ | | ✓ |
+| `logo` | Infinity mirror: logo | 1 | ✓ | | |
+| `sync` | Synchronize all channels | up to 40 | ✓ | | ✓ |
+
+On the 2024 Elite the `ring` is the RGB ring around the pump-cap LCD, addressed over the Hue 2 _direct_ protocol; `external` is the RGB-fan (radiator) header; and `sync` drives both together.
 
 Color modes can be set independently for each lighting channel, but the specified color mode will then apply to all devices daisy chained on that channel.
 

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -505,11 +505,17 @@ Lighting channels: \fIexternal\fR.
 LCD screens: \fIlcd\fR.
 .
 .SS NZXT Kraken 2023 Standard, Elite
-.SS NZXT Kraken 2024 Elite RGB
 .SS NZXT Kraken 2024 Plus
 Cooling channels: \fIpump\fR, \fIfan\fR.
 .PP
 Lighting channels: none.
+.PP
+LCD screens: \fIlcd\fR.
+.
+.SS NZXT Kraken Elite V2
+Cooling channels: \fIpump\fR, \fIfan\fR.
+.PP
+Lighting channels: \fIring\fR, \fIexternal\fR, \fIsync\fR.
 .PP
 LCD screens: \fIlcd\fR.
 .TS

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -81,8 +81,14 @@ _COLOR_CHANNELS_KRAKENZ = {
     "external": 0b001,
 }
 
-# Available color channels and IDs for model Z coolers
+# Available color channels and IDs for 2023 models (no RGB support)
 _COLOR_CHANNELS_KRAKEN2023 = {}
+
+# Available color channels and IDs for 2024 Elite models (ring on external channel, no logo)
+_COLOR_CHANNELS_KRAKEN2024_ELITE = {"ring": 0b001}
+
+# Ring LED count for 2024 Elite pump ring accessory
+_KRAKEN2024_ELITE_RING_LEDS = 24
 
 _HWMON_CTRL_MAPPING_KRAKENX = {"pump": 1}
 
@@ -213,6 +219,7 @@ class KrakenX3(UsbHidDriver):
         self._speed_channels = speed_channels
         self._color_channels = color_channels
         self._hwmon_ctrl_mapping = hwmon_ctrl_mapping
+        self._hue2_direct_ring = kwargs.pop("hue2_direct_ring", False)
         self._fw = None
 
     def initialize(self, direct_access=False, **kwargs):
@@ -256,15 +263,21 @@ class KrakenX3(UsbHidDriver):
         self._fw = (msg[0x11], msg[0x12], msg[0x13])
 
     def parse_led_info(self, msg):
+        channels_without_sync = len(self._color_channels) - ("sync" in self._color_channels)
         channel_count = msg[14]
-        assert channel_count == len(self._color_channels) - (
-            "sync" in self._color_channels
-        ), f"Unexpected number of color channels received: {channel_count}"
 
         def find(channel, accessory):
             offset = 15  # offset of first channel/first accessory
             acc_id = msg[offset + channel * HUE2_MAX_ACCESSORIES_IN_CHANNEL + accessory]
             return Hue2Accessory(acc_id) if acc_id else None
+
+        if channels_without_sync == 0:
+            # device with no color support (e.g. Kraken 2023 non-Elite)
+            return
+
+        assert channel_count == channels_without_sync, (
+            f"Unexpected number of color channels received: {channel_count}"
+        )
 
         for i in range(HUE2_MAX_ACCESSORIES_IN_CHANNEL):
             accessory = find(0, i)
@@ -272,12 +285,23 @@ class KrakenX3(UsbHidDriver):
                 break
             self._status.append((f"LED accessory {i + 1}", accessory, ""))
 
-        if len(self._color_channels) > 1:
+        if "ring" in self._color_channels and "logo" in self._color_channels:
+            # multi-channel devices with ring + logo (Kraken X3)
             found_ring = find(1, 0) == Hue2Accessory.KRAKENX_GEN4_RING
             found_logo = find(2, 0) == Hue2Accessory.KRAKENX_GEN4_LOGO
             self._status.append(("Pump Ring LEDs", "detected" if found_ring else "missing", ""))
             self._status.append(("Pump Logo LEDs", "detected" if found_logo else "missing", ""))
             assert found_ring and found_logo, "Pump ring and/or logo were not detected"
+        elif "ring" in self._color_channels and "logo" not in self._color_channels:
+            # ring without logo (Kraken 2024 Elite — external + ring, no logo)
+            ring_acc = find(0, 0)
+            found_ring = ring_acc in (
+                Hue2Accessory.KRAKENX_GEN4_RING,
+                Hue2Accessory.KRAKEN_2024_ELITE_RING,
+            )
+            self._status.append(("Pump Ring LEDs", "detected" if found_ring else "missing", ""))
+            if not found_ring:
+                _LOGGER.warning("pump ring was not detected (got acc_id=%s)", ring_acc)
 
     def _get_status_directly(self):
         self.device.clear_enqueued_reports()
@@ -349,6 +373,14 @@ class KrakenX3(UsbHidDriver):
         elif len(colors) > maxcolors:
             _LOGGER.warning("too many colors for mode=%s, dropping to %d", mode, maxcolors)
             colors = colors[:maxcolors]
+
+        # Kraken 2024 Elite ring uses Hue 2 direct protocol (0x22), not the
+        # animation protocol (0x2A).  For single-color modes like "fixed", expand
+        # the color across all LEDs and use "super-fixed" which writes via 0x22.
+        if self._hue2_direct_ring and mode == "fixed" and channel == "ring":
+            _LOGGER.debug("redirecting fixed to super-fixed for Hue 2 ring device")
+            colors = colors * _KRAKEN2024_ELITE_RING_LEDS
+            mode = "super-fixed"
 
         sval = _ANIMATION_SPEEDS[speed]
         self._write_colors(cid, mode, colors, sval, direction)
@@ -600,10 +632,11 @@ class KrakenZ3(KrakenX3):
             "NZXT Kraken 2024 Elite RGB",
             {
                 "speed_channels": _SPEED_CHANNELS_KRAKEN2023,
-                "color_channels": _COLOR_CHANNELS_KRAKEN2023,
+                "color_channels": _COLOR_CHANNELS_KRAKEN2024_ELITE,
                 "hwmon_ctrl_mapping": _HWMON_CTRL_MAPPING_KRAKENZ,
                 "bulk_buffer_size": 1024 * 1024 * 2,  # 2 MB
                 "lcd_resolution": (640, 640),
+                "hue2_direct_ring": True,
             },
         ),
         (

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -81,8 +81,18 @@ _COLOR_CHANNELS_KRAKENZ = {
     "external": 0b001,
 }
 
-# Available color channels and IDs for model Z coolers
+# Available color channels and IDs for 2023 models (no RGB support)
 _COLOR_CHANNELS_KRAKEN2023 = {}
+
+# Available color channels and IDs for 2024 Elite models.
+#
+# The firmware always exposes two Hue 2 color channels, regardless of whether
+# the "RGB" fan bundle is attached: channel 0 (0b001) drives the built-in pump
+# ring, and channel 1 (0b010) is the external RGB header where the bundled RGB
+# (radiator) fans connect (and is simply empty when no RGB accessory is plugged
+# in).  "sync" (0b111) addresses both channels at once, mirroring the Kraken X3.
+# The ring/external/sync addresses were verified on real hardware in liquidctl#803.
+_COLOR_CHANNELS_KRAKEN2024_ELITE = {"ring": 0b001, "external": 0b010, "sync": 0b111}
 
 _HWMON_CTRL_MAPPING_KRAKENX = {"pump": 1}
 
@@ -213,6 +223,7 @@ class KrakenX3(UsbHidDriver):
         self._speed_channels = speed_channels
         self._color_channels = color_channels
         self._hwmon_ctrl_mapping = hwmon_ctrl_mapping
+        self._hue2_direct_ring = kwargs.pop("hue2_direct_ring", False)
         self._fw = None
 
     def initialize(self, direct_access=False, **kwargs):
@@ -256,28 +267,52 @@ class KrakenX3(UsbHidDriver):
         self._fw = (msg[0x11], msg[0x12], msg[0x13])
 
     def parse_led_info(self, msg):
+        channels_without_sync = len(self._color_channels) - ("sync" in self._color_channels)
         channel_count = msg[14]
-        assert channel_count == len(self._color_channels) - (
-            "sync" in self._color_channels
-        ), f"Unexpected number of color channels received: {channel_count}"
 
         def find(channel, accessory):
             offset = 15  # offset of first channel/first accessory
             acc_id = msg[offset + channel * HUE2_MAX_ACCESSORIES_IN_CHANNEL + accessory]
             return Hue2Accessory(acc_id) if acc_id else None
 
-        for i in range(HUE2_MAX_ACCESSORIES_IN_CHANNEL):
-            accessory = find(0, i)
-            if not accessory:
-                break
-            self._status.append((f"LED accessory {i + 1}", accessory, ""))
+        def report_accessories(channel):
+            for i in range(HUE2_MAX_ACCESSORIES_IN_CHANNEL):
+                accessory = find(channel, i)
+                if not accessory:
+                    break
+                self._status.append((f"LED accessory {i + 1}", accessory, ""))
 
-        if len(self._color_channels) > 1:
+        if channels_without_sync == 0:
+            # device with no color support (e.g. Kraken 2023 non-Elite)
+            return
+
+        assert channel_count == channels_without_sync, (
+            f"Unexpected number of color channels received: {channel_count}"
+        )
+
+        if "ring" in self._color_channels and "logo" in self._color_channels:
+            # Kraken X3: external (channel 0), ring (channel 1), logo (channel 2)
+            report_accessories(0)
             found_ring = find(1, 0) == Hue2Accessory.KRAKENX_GEN4_RING
             found_logo = find(2, 0) == Hue2Accessory.KRAKENX_GEN4_LOGO
             self._status.append(("Pump Ring LEDs", "detected" if found_ring else "missing", ""))
             self._status.append(("Pump Logo LEDs", "detected" if found_logo else "missing", ""))
             assert found_ring and found_logo, "Pump ring and/or logo were not detected"
+        elif "ring" in self._color_channels:
+            # Kraken 2024 Elite: ring (channel 0), external RGB header (channel 1)
+            ring_acc = find(0, 0)
+            found_ring = ring_acc in (
+                Hue2Accessory.KRAKENX_GEN4_RING,
+                Hue2Accessory.KRAKEN_2024_ELITE_RING,
+            )
+            self._status.append(("Pump Ring LEDs", "detected" if found_ring else "missing", ""))
+            if not found_ring:
+                _LOGGER.warning("pump ring was not detected (got acc_id=%s)", ring_acc)
+            if "external" in self._color_channels:
+                report_accessories(1)
+        else:
+            # external-only devices (e.g. Kraken Z53/Z63/Z73): accessories on channel 0
+            report_accessories(0)
 
     def _get_status_directly(self):
         self.device.clear_enqueued_reports()
@@ -349,6 +384,17 @@ class KrakenX3(UsbHidDriver):
         elif len(colors) > maxcolors:
             _LOGGER.warning("too many colors for mode=%s, dropping to %d", mode, maxcolors)
             colors = colors[:maxcolors]
+
+        # Kraken 2024 Elite ring uses the Hue 2 direct protocol (0x22), not the
+        # animation protocol (0x2A): on this channel the animation "fixed" mode
+        # blinks off periodically (see _STATIC_VALUE).  Redirect "fixed" to
+        # "super-fixed", expanding the single color across every addressable LED
+        # slot so the whole ring is lit (the device ignores slots past its ring).
+        if self._hue2_direct_ring and mode == "fixed" and channel == "ring":
+            _LOGGER.debug("redirecting fixed to super-fixed for Hue 2 ring device")
+            ring_leds = _COLOR_MODES["super-fixed"][4]  # max per-LED colors
+            colors = colors * ring_leds
+            mode = "super-fixed"
 
         sval = _ANIMATION_SPEEDS[speed]
         self._write_colors(cid, mode, colors, sval, direction)
@@ -481,10 +527,15 @@ class KrakenX3(UsbHidDriver):
         color_count = len(colors)
 
         if "super-fixed" == mode or "super-breathing" == mode:
-            color = list(itertools.chain(*colors)) + [0x00, 0x00, 0x00] * (maxcolors - color_count)
+            # Per-LED colors are sent over two reports: the first carries LEDs
+            # 0-19 under sub-command 0x10, the second carries LEDs 20-39 under
+            # 0x11.  Each report must stay within the 64-byte HID frame (4-byte
+            # header + 60 bytes = 20 RGB triplets), so the data cannot be packed
+            # into a single write.
+            leds = list(itertools.chain(*colors)) + [0x00, 0x00, 0x00] * (maxcolors - color_count)
             speed_value = _SPEED_VALUE[speed_scale][sval]
-            self._write([0x22, 0x10, cid, 0x00] + color)
-            self._write([0x22, 0x11, cid, 0x00])
+            self._write([0x22, 0x10, cid, 0x00] + leds[0:60])
+            self._write([0x22, 0x11, cid, 0x00] + leds[60:])
             self._write(
                 [0x22, 0xA0, cid, 0x00, mval]
                 + speed_value
@@ -597,13 +648,14 @@ class KrakenZ3(KrakenX3):
         (
             0x1E71,
             0x3012,
-            "NZXT Kraken 2024 Elite RGB",
+            "NZXT Kraken Elite V2",
             {
                 "speed_channels": _SPEED_CHANNELS_KRAKEN2023,
-                "color_channels": _COLOR_CHANNELS_KRAKEN2023,
+                "color_channels": _COLOR_CHANNELS_KRAKEN2024_ELITE,
                 "hwmon_ctrl_mapping": _HWMON_CTRL_MAPPING_KRAKENZ,
                 "bulk_buffer_size": 1024 * 1024 * 2,  # 2 MB
                 "lcd_resolution": (640, 640),
+                "hue2_direct_ring": True,
             },
         ),
         (

--- a/liquidctl/util.py
+++ b/liquidctl/util.py
@@ -57,6 +57,7 @@ class Hue2Accessory(Enum):
     F140_RGB_CORE = (0x17, 'F140 RGB Core')
     F240_RGB_CORE = (0x1b, 'F240 RGB Core')
     F360_RGB_CORE = (0x1d, 'F360 RGB Core')
+    KRAKEN_2024_ELITE_RING = (0x1e, 'Kraken 2024 Elite Pump Ring')
 
     def __new__(cls, value, pretty_name):
         member = object.__new__(cls)

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -12,6 +12,8 @@ from liquidctl.driver.kraken3 import (
     _SPEED_CHANNELS_KRAKENX,
     _COLOR_CHANNELS_KRAKENZ,
     _SPEED_CHANNELS_KRAKENZ,
+    _COLOR_CHANNELS_KRAKEN2024_ELITE,
+    _SPEED_CHANNELS_KRAKEN2023,
     _HWMON_CTRL_MAPPING_KRAKENX,
     _HWMON_CTRL_MAPPING_KRAKENZ,
 )
@@ -112,10 +114,29 @@ def mock_krakenz3():
     return dev
 
 
+@pytest.fixture
+def mock_kraken2024elite():
+    raw = MockKraken(raw_led_channels=1, ring_only=True)
+    dev = MockKrakenZ3(
+        raw,
+        "Mock Kraken 2024 Elite RGB",
+        speed_channels=_SPEED_CHANNELS_KRAKEN2023,
+        color_channels=_COLOR_CHANNELS_KRAKEN2024_ELITE,
+        hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENZ,
+        bulk_buffer_size=1024 * 1024 * 2,
+        lcd_resolution=(640, 640),
+        hue2_direct_ring=True,
+    )
+
+    dev.connect()
+    return dev
+
+
 class MockKraken(MockHidapiDevice):
-    def __init__(self, raw_led_channels):
+    def __init__(self, raw_led_channels, ring_only=False):
         super().__init__()
         self.raw_led_channels = raw_led_channels
+        self.ring_only = ring_only
 
     def write(self, data):
         reply = bytearray(64)
@@ -124,7 +145,10 @@ class MockKraken(MockHidapiDevice):
         elif data[0:2] == [0x20, 0x03]:
             reply[0:2] = [0x21, 0x03]
             reply[14] = self.raw_led_channels
-            if self.raw_led_channels > 1:
+            if self.ring_only:
+                # Kraken 2024 Elite: ring-only device, 0x1E accessory at channel 0, slot 0
+                reply[15] = Hue2Accessory.KRAKEN_2024_ELITE_RING.value
+            elif self.raw_led_channels > 1:
                 reply[15 + 1 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_RING.value
                 reply[15 + 2 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_LOGO.value
         elif data[0:2] == [0x30, 0x01]:
@@ -558,3 +582,46 @@ def test_krakenz3_screen_not_totally_broken_part2(mock_krakenz3):
     mock_krakenz3.set_screen(
         "lcd", "gif", os.path.join(os.path.dirname(os.path.abspath(__file__)), "rgb.gif")
     )
+
+
+# ── Kraken 2024 Elite RGB Tests ──
+
+
+def test_kraken2024elite_initialize_reports_ring(mock_kraken2024elite):
+    """Initialization detects and reports the pump ring LEDs."""
+    status = mock_kraken2024elite.initialize()
+
+    status_dict = {k: v for k, v, _ in status}
+    assert "Pump Ring LEDs" in status_dict
+    assert status_dict["Pump Ring LEDs"] == "detected"
+
+
+def test_kraken2024elite_set_color_ring_fixed(mock_kraken2024elite):
+    """Fixed on ring redirects to super-fixed via Hue 2 direct protocol (0x22)."""
+    mock_kraken2024elite.initialize()
+    mock_kraken2024elite.device.sent.clear()
+    mock_kraken2024elite.set_color("ring", "fixed", colors=iter([[0xFF, 0x00, 0x00]]))
+
+    # Verify writes used 0x22 (Hue 2 direct), not 0x2A (animation)
+    sent_reports = [report.number for report in mock_kraken2024elite.device.sent]
+    assert 0x22 in sent_reports, "expected 0x22 (Hue 2 direct) writes for ring fixed mode"
+    assert 0x2A not in sent_reports, "0x2A (animation) should not be used for ring fixed mode"
+
+
+def test_kraken2024elite_set_color_ring_spectrum_wave(mock_kraken2024elite):
+    """Setting spectrum-wave on the ring channel does not raise."""
+    mock_kraken2024elite.initialize()
+    mock_kraken2024elite.set_color("ring", "spectrum-wave", colors=iter([]))
+
+
+def test_kraken2024elite_set_color_ring_breathing(mock_kraken2024elite):
+    """Setting breathing mode with a color on the ring channel does not raise."""
+    mock_kraken2024elite.initialize()
+    mock_kraken2024elite.set_color("ring", "breathing", colors=iter([[0x00, 0xFF, 0x00]]))
+
+
+def test_kraken2024elite_set_color_invalid_channel(mock_kraken2024elite):
+    """Setting color on a non-existent channel raises KeyError."""
+    mock_kraken2024elite.initialize()
+    with pytest.raises(KeyError):
+        mock_kraken2024elite.set_color("logo", "fixed", colors=iter([[0xFF, 0x00, 0x00]]))

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -12,6 +12,8 @@ from liquidctl.driver.kraken3 import (
     _SPEED_CHANNELS_KRAKENX,
     _COLOR_CHANNELS_KRAKENZ,
     _SPEED_CHANNELS_KRAKENZ,
+    _COLOR_CHANNELS_KRAKEN2024_ELITE,
+    _SPEED_CHANNELS_KRAKEN2023,
     _HWMON_CTRL_MAPPING_KRAKENX,
     _HWMON_CTRL_MAPPING_KRAKENZ,
 )
@@ -112,10 +114,30 @@ def mock_krakenz3():
     return dev
 
 
+@pytest.fixture
+def mock_kraken2024elite():
+    raw = MockKraken(raw_led_channels=2, ring_only=True)
+    dev = MockKrakenZ3(
+        raw,
+        "Mock Kraken Elite V2",
+        speed_channels=_SPEED_CHANNELS_KRAKEN2023,
+        color_channels=_COLOR_CHANNELS_KRAKEN2024_ELITE,
+        hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENZ,
+        bulk_buffer_size=1024 * 1024 * 2,
+        lcd_resolution=(640, 640),
+        hue2_direct_ring=True,
+    )
+
+    dev.connect()
+    return dev
+
+
 class MockKraken(MockHidapiDevice):
-    def __init__(self, raw_led_channels):
+    def __init__(self, raw_led_channels, ring_only=False, external_accessory=None):
         super().__init__()
         self.raw_led_channels = raw_led_channels
+        self.ring_only = ring_only
+        self.external_accessory = external_accessory
 
     def write(self, data):
         reply = bytearray(64)
@@ -123,10 +145,20 @@ class MockKraken(MockHidapiDevice):
             reply[0:2] = [0x11, 0x01]
         elif data[0:2] == [0x20, 0x03]:
             reply[0:2] = [0x21, 0x03]
-            reply[14] = self.raw_led_channels
-            if self.raw_led_channels > 1:
-                reply[15 + 1 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_RING.value
-                reply[15 + 2 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_LOGO.value
+            if self.ring_only:
+                # Kraken 2024 Elite: the firmware always reports two channels —
+                # the built-in pump ring (0x1E) on channel 0, and an external RGB
+                # header on channel 1 that is empty unless RGB fans are attached.
+                # This matches a real 1e71:3012 lighting-info (0x21 0x03) reply.
+                reply[14] = 2
+                reply[15] = Hue2Accessory.KRAKEN_2024_ELITE_RING.value
+                if self.external_accessory is not None:
+                    reply[15 + 1 * MAX_ACCESSORIES] = self.external_accessory
+            else:
+                reply[14] = self.raw_led_channels
+                if self.raw_led_channels > 1:
+                    reply[15 + 1 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_RING.value
+                    reply[15 + 2 * MAX_ACCESSORIES] = Hue2Accessory.KRAKENX_GEN4_LOGO.value
         elif data[0:2] == [0x30, 0x01]:
             reply[0:2] = [0x31, 0x01]
             reply[0x18] = 50  # lcd brightness
@@ -558,3 +590,117 @@ def test_krakenz3_screen_not_totally_broken_part2(mock_krakenz3):
     mock_krakenz3.set_screen(
         "lcd", "gif", os.path.join(os.path.dirname(os.path.abspath(__file__)), "rgb.gif")
     )
+
+
+# ── Kraken Elite V2 (2024 Elite) Tests ──
+
+
+def test_kraken2024elite_initializes_with_two_channels(mock_kraken2024elite):
+    """The firmware reports two color channels (ring + external); init must not raise.
+
+    Regression for the AssertionError 'Unexpected number of color channels
+    received: 2' that crashed initialize on real 1e71:3012 hardware.
+    """
+    status = mock_kraken2024elite.initialize()
+
+    status_dict = {k: v for k, v, _ in status}
+    assert status_dict.get("Pump Ring LEDs") == "detected"
+
+
+def test_kraken2024elite_initialize_reports_external_fan():
+    """An RGB fan on the external channel is detected and reported."""
+    raw = MockKraken(
+        raw_led_channels=2,
+        ring_only=True,
+        external_accessory=Hue2Accessory.F360_RGB_CORE.value,
+    )
+    dev = MockKrakenZ3(
+        raw,
+        "Mock Kraken Elite V2",
+        speed_channels=_SPEED_CHANNELS_KRAKEN2023,
+        color_channels=_COLOR_CHANNELS_KRAKEN2024_ELITE,
+        hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENZ,
+        bulk_buffer_size=1024 * 1024 * 2,
+        lcd_resolution=(640, 640),
+        hue2_direct_ring=True,
+    )
+    dev.connect()
+
+    status = dev.initialize()
+
+    status_dict = {k: v for k, v, _ in status}
+    assert status_dict.get("Pump Ring LEDs") == "detected"
+    assert status_dict.get("LED accessory 1") == Hue2Accessory.F360_RGB_CORE
+
+
+def test_kraken2024elite_set_color_ring_fixed_lights_every_led(mock_kraken2024elite):
+    """Fixed on the ring redirects to super-fixed and lights *every* LED.
+
+    Regression for the "last LED clockwise stays off" bug: the per-LED colors
+    must be split across the 0x10 (LEDs 0-19) and 0x11 (LEDs 20-39) Hue 2 direct
+    reports.  The buggy version packed everything into the first report and sent
+    an empty 0x11, leaving the trailing LEDs dark.  Each report carries exactly
+    20 RGB triplets (60 bytes) after its 3-byte sub-header.
+    """
+    mock_kraken2024elite.initialize()
+    mock_kraken2024elite.device.sent.clear()
+
+    mock_kraken2024elite.set_color("ring", "fixed", colors=iter([[0xFF, 0x00, 0x00]]))
+
+    writes = mock_kraken2024elite.device.sent
+    # Hue 2 direct (0x22), never the animation protocol (0x2A)
+    assert all(report.number != 0x2A for report in writes)
+
+    chunk_lo = next(r for r in writes if r.number == 0x22 and r.data[0] == 0x10)
+    chunk_hi = next(r for r in writes if r.number == 0x22 and r.data[0] == 0x11)
+
+    # colors are sent in GRB order; 0xFF0000 -> [0x00, 0xFF, 0x00]
+    expected = [0x00, 0xFF, 0x00] * 20
+    assert chunk_lo.data[3:63] == expected, "first 20 LEDs not all lit"
+    assert chunk_hi.data[3:63] == expected, "LEDs 20-39 not all lit (trailing-LED bug)"
+
+    all_leds = chunk_lo.data[3:63] + chunk_hi.data[3:63]
+    assert len(all_leds) == 120
+    assert all(all_leds[i : i + 3] == [0x00, 0xFF, 0x00] for i in range(0, 120, 3))
+
+
+def test_kraken2024elite_set_color_external(mock_kraken2024elite):
+    """The external channel (RGB fan header) is addressable without raising."""
+    mock_kraken2024elite.initialize()
+    mock_kraken2024elite.device.sent.clear()
+
+    mock_kraken2024elite.set_color("external", "fixed", colors=iter([[0x00, 0x00, 0xFF]]))
+
+    assert mock_kraken2024elite.device.sent, "no report written for external channel"
+
+
+def test_kraken2024elite_set_color_sync(mock_kraken2024elite):
+    """The sync channel addresses ring + external together (cid 0b111)."""
+    mock_kraken2024elite.initialize()
+    mock_kraken2024elite.device.sent.clear()
+
+    mock_kraken2024elite.set_color("sync", "spectrum-wave", colors=iter([]))
+
+    # animation writes address the combined channel mask 0b111
+    writes = mock_kraken2024elite.device.sent
+    assert writes, "no report written for sync channel"
+    assert any(0b111 in report.data for report in writes)
+
+
+def test_kraken2024elite_set_color_ring_spectrum_wave(mock_kraken2024elite):
+    """Setting spectrum-wave on the ring channel does not raise."""
+    mock_kraken2024elite.initialize()
+    mock_kraken2024elite.set_color("ring", "spectrum-wave", colors=iter([]))
+
+
+def test_kraken2024elite_set_color_ring_breathing(mock_kraken2024elite):
+    """Setting breathing mode with a color on the ring channel does not raise."""
+    mock_kraken2024elite.initialize()
+    mock_kraken2024elite.set_color("ring", "breathing", colors=iter([[0x00, 0xFF, 0x00]]))
+
+
+def test_kraken2024elite_set_color_invalid_channel(mock_kraken2024elite):
+    """Setting color on a non-existent channel raises KeyError."""
+    mock_kraken2024elite.initialize()
+    with pytest.raises(KeyError):
+        mock_kraken2024elite.set_color("logo", "fixed", colors=iter([[0xFF, 0x00, 0x00]]))


### PR DESCRIPTION
## Summary

Adds RGB ring LED control for the NZXT Kraken 2024 Elite RGB (USB `1e71:3012`).

The 2024 Elite has a 24-LED pump ring on the external channel but no logo LEDs, which differs from earlier Kraken models that have both ring and logo on separate channels.

## Changes

- **`liquidctl/util.py`**: Add `KRAKEN_2024_ELITE_RING` (0x1E) to `Hue2Accessory` enum
- **`liquidctl/driver/kraken3.py`**:
  - Add `_COLOR_CHANNELS_KRAKEN2024_ELITE` mapping: ring on external channel (cid=1)
  - Add `_KRAKEN2024_ELITE_RING_LEDS = 24` constant
  - Set `_hue2_direct_ring` device flag in `__init__` for explicit redirect detection
  - Update `parse_led_info()` to handle ring-only devices (no logo channel)
  - Redirect `fixed` mode to `super-fixed` (Hue 2 direct protocol 0x22) using device flag
- **`tests/test_kraken3.py`**:
  - Add `mock_kraken2024elite` fixture with accurate ring-only mock
  - Test initialization detects pump ring LEDs
  - Test `fixed` on ring uses 0x22 protocol (not 0x2A), with write assertions
  - Test animated modes (spectrum-wave, breathing) work
  - Test invalid channel raises KeyError

## Hardware tested

Verified on real NZXT Kraken 2024 Elite RGB (firmware 1.2.0):

| Capability | Status |
|---|---|
| Ring: fixed (single color) | Working |
| Ring: super-fixed (per-LED) | Working |
| Ring: breathing, fading, pulse | Working |
| Ring: spectrum-wave, rainbow-flow | Working |
| Ring: marquee, alternating, candle | Working |
| Ring: off | Working |
| LCD: liquid temp, static, GIF | Working (unchanged) |
| Pump/fan speed control | Working (unchanged) |
| Monitoring (temp, RPM, duty) | Working (unchanged) |

Closes #800