### PR TITLE
commander_core: fix set_fixed_speed/set_speed_profile for firmware 2.x

### DIFF
--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -43,6 +43,12 @@ _MODE_HW_SPEED_MODE = (0x60, 0x6d)
 _MODE_HW_FIXED_PERCENT = (0x61, 0x6d)
 _MODE_HW_CURVE_PERCENT = (0x62, 0x6d)
 
+# Firmware 2.x shifted the hardware-profile endpoint IDs by one position.
+# Data types and payload formats are unchanged between firmware versions.
+_MODE_HW_SPEED_MODE_V2    = (0x61, 0x6d)
+_MODE_HW_FIXED_PERCENT_V2 = (0x62, 0x6d)
+_MODE_HW_CURVE_PERCENT_V2 = (0x64, 0x6d)
+
 _DATA_TYPE_SPEEDS = (0x06, 0x00)
 _DATA_TYPE_LED_COUNT = (0x0f, 0x00)
 _DATA_TYPE_TEMPS = (0x10, 0x00)
@@ -67,6 +73,7 @@ class CommanderCore(UsbHidDriver):
     def __init__(self, device, description, has_pump, **kwargs):
         super().__init__(device, description, **kwargs)
         self._has_pump = has_pump
+        self._fw_major = None
 
     def initialize(self, **kwargs):
         """Initialize the device and get the fan modes."""
@@ -75,6 +82,7 @@ class CommanderCore(UsbHidDriver):
             # Get Firmware
             res = self._send_command(_CMD_GET_FIRMWARE)
             fw_version = (res[3], res[4], res[5])
+            self._fw_major = fw_version[0]
 
             status = [('Firmware version', '{}.{}.{}'.format(*fw_version), '')]
 
@@ -144,6 +152,12 @@ class CommanderCore(UsbHidDriver):
     def set_color(self, channel, mode, colors, **kwargs):
         raise NotSupportedByDriver
 
+    def _ensure_fw_version(self):
+        """Fetch and cache firmware major version. Must be called inside a wake context."""
+        if self._fw_major is None:
+            res = self._send_command(_CMD_GET_FIRMWARE)
+            self._fw_major = res[3]
+
     def set_speed_profile(self, channel, profile, **kwargs):
         channels = self._parse_channels(channel)
         curve_points = list(profile)
@@ -153,18 +167,22 @@ class CommanderCore(UsbHidDriver):
             ValueError('a maximum of 7 speed curve points may be configured.')
 
         with self._wake_device_context():
+            self._ensure_fw_version()
+            mode_ep  = _MODE_HW_SPEED_MODE_V2   if self._fw_major >= 2 else _MODE_HW_SPEED_MODE
+            curve_ep = _MODE_HW_CURVE_PERCENT_V2 if self._fw_major >= 2 else _MODE_HW_CURVE_PERCENT
+
             # Set hardware speed mode
-            res = self._read_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE)
+            res = self._read_data(mode_ep, _DATA_TYPE_HW_SPEED_MODE)
             device_count = res[0]
 
             data = bytearray(res[0:device_count + 1])
             for chan in channels:
                 data[chan + 1] = _FAN_MODE_CURVE_PERCENT
-            self._write_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE, data)
+            self._write_data(mode_ep, _DATA_TYPE_HW_SPEED_MODE, data)
 
 
             # Read in data and split by device
-            res = self._read_data(_MODE_HW_CURVE_PERCENT, _DATA_TYPE_HW_CURVE_PERCENT)
+            res = self._read_data(curve_ep, _DATA_TYPE_HW_CURVE_PERCENT)
             device_count = res[0]
             data_by_device = []
 
@@ -195,30 +213,34 @@ class CommanderCore(UsbHidDriver):
                 data_by_device[chan] = b''.join(new_data)
 
             out = bytes([device_count]) + b''.join(data_by_device)
-            self._write_data(_MODE_HW_CURVE_PERCENT, _DATA_TYPE_HW_CURVE_PERCENT, out)
+            self._write_data(curve_ep, _DATA_TYPE_HW_CURVE_PERCENT, out)
 
     def set_fixed_speed(self, channel, duty, **kwargs):
         channels = self._parse_channels(channel)
 
         with self._wake_device_context():
+            self._ensure_fw_version()
+            mode_ep  = _MODE_HW_SPEED_MODE_V2   if self._fw_major >= 2 else _MODE_HW_SPEED_MODE
+            fixed_ep = _MODE_HW_FIXED_PERCENT_V2 if self._fw_major >= 2 else _MODE_HW_FIXED_PERCENT
+
             # Set hardware speed mode
-            res = self._read_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE)
+            res = self._read_data(mode_ep, _DATA_TYPE_HW_SPEED_MODE)
             device_count = res[0]
 
             data = bytearray(res[0:device_count + 1])
             for chan in channels:
                 data[chan + 1] = _FAN_MODE_FIXED_PERCENT
-            self._write_data(_MODE_HW_SPEED_MODE, _DATA_TYPE_HW_SPEED_MODE, data)
+            self._write_data(mode_ep, _DATA_TYPE_HW_SPEED_MODE, data)
 
             # Set speed
-            res = self._read_data(_MODE_HW_FIXED_PERCENT, _DATA_TYPE_HW_FIXED_PERCENT)
+            res = self._read_data(fixed_ep, _DATA_TYPE_HW_FIXED_PERCENT)
             device_count = res[0]
             data = bytearray(res[0:device_count * 2 + 1])
             duty_le = int.to_bytes(clamp(duty, 0, 100), length=2, byteorder="little", signed=False)
             for chan in channels:
                 i = chan * 2 + 1
                 data[i: i + 2] = duty_le  # Update the device speed
-            self._write_data(_MODE_HW_FIXED_PERCENT, _DATA_TYPE_HW_FIXED_PERCENT, data)
+            self._write_data(fixed_ep, _DATA_TYPE_HW_FIXED_PERCENT, data)
 
     @classmethod
     def probe(cls, handle, **kwargs):

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -89,28 +89,53 @@ class MockCommanderCoreDevice:
                     else:
                         raise NotImplementedError(f'Read for {mode.hex(":")}')
                 elif mode[1] == 0x6d:
-                    if mode[0] == 0x60:
-                        data.extend([0x03, 0x00])
-                        data.append(len(self.speeds_mode))
-                        for i in self.speeds_mode:
-                            data.append(i)
-                    elif mode[0] == 0x61:
-                        data.extend([0x04, 0x00])
-                        data.append(len(self.fixed_speeds))
-                        for i in self.fixed_speeds:
-                            data.extend(int_to_le(i))
-                    elif mode[0] == 0x62:
-                        data.extend([0x05, 0x00]) # data type
-                        num_ports = len(self.curve_points_by_device)
-                        data.append(num_ports)
-                        for i in range(num_ports):
-                            data.append(0) # temp sensor
-                            data.append(len(self.curve_points_by_device[i])) # num curve points
-                            for (temp, duty) in self.curve_points_by_device[i]:
-                                data.extend(int_to_le(temp * 10)) # temperature
-                                data.extend(int_to_le(duty)) # duty
+                    fw_major = self.firmware_version[0]
+                    if fw_major >= 2:
+                        if mode[0] == 0x61:  # Speed mode (fw 2.x)
+                            data.extend([0x03, 0x00])
+                            data.append(len(self.speeds_mode))
+                            for i in self.speeds_mode:
+                                data.append(i)
+                        elif mode[0] == 0x62:  # Fixed speeds (fw 2.x)
+                            data.extend([0x04, 0x00])
+                            data.append(len(self.fixed_speeds))
+                            for i in self.fixed_speeds:
+                                data.extend(int_to_le(i))
+                        elif mode[0] == 0x64:  # Curve (fw 2.x)
+                            data.extend([0x05, 0x00])
+                            num_ports = len(self.curve_points_by_device)
+                            data.append(num_ports)
+                            for i in range(num_ports):
+                                data.append(0)  # temp sensor
+                                data.append(len(self.curve_points_by_device[i]))  # num curve points
+                                for (temp, duty) in self.curve_points_by_device[i]:
+                                    data.extend(int_to_le(temp * 10))
+                                    data.extend(int_to_le(duty))
+                        else:
+                            raise NotImplementedError(f'Read for {mode.hex(":")}')
                     else:
-                        raise NotImplementedError(f'Read for {mode.hex(":")}')
+                        if mode[0] == 0x60:  # Speed mode (fw 1.x)
+                            data.extend([0x03, 0x00])
+                            data.append(len(self.speeds_mode))
+                            for i in self.speeds_mode:
+                                data.append(i)
+                        elif mode[0] == 0x61:  # Fixed speeds (fw 1.x)
+                            data.extend([0x04, 0x00])
+                            data.append(len(self.fixed_speeds))
+                            for i in self.fixed_speeds:
+                                data.extend(int_to_le(i))
+                        elif mode[0] == 0x62:  # Curve (fw 1.x)
+                            data.extend([0x05, 0x00])
+                            num_ports = len(self.curve_points_by_device)
+                            data.append(num_ports)
+                            for i in range(num_ports):
+                                data.append(0)  # temp sensor
+                                data.append(len(self.curve_points_by_device[i]))  # num curve points
+                                for (temp, duty) in self.curve_points_by_device[i]:
+                                    data.extend(int_to_le(temp * 10))
+                                    data.extend(int_to_le(duty))
+                        else:
+                            raise NotImplementedError(f'Read for {mode.hex(":")}')
                 else:
                     raise NotImplementedError(f'Read for {mode.hex(":")}')
             elif self._last_write[2] == 0x09:  # Get more data
@@ -161,11 +186,15 @@ class MockCommanderCoreDevice:
 
             if data[2] == 0x06 or data[2] == 0x07:
                 if mode[1] == 0x6d:
-                    if mode[0] == 0x60 and list(self.written_data_type) == [0x03, 0x00]:
+                    fw_major = self.firmware_version[0]
+                    speed_mode_ep  = 0x61 if fw_major >= 2 else 0x60
+                    fixed_speed_ep = 0x62 if fw_major >= 2 else 0x61
+                    curve_ep       = 0x64 if fw_major >= 2 else 0x62
+                    if mode[0] == speed_mode_ep and list(self.written_data_type) == [0x03, 0x00]:
                         self.speeds_mode = tuple(self.written_data[i+1] for i in range(0, self.written_data[0]))
-                    elif mode[0] == 0x61 and list(self.written_data_type) == [0x04, 0x00]:
+                    elif mode[0] == fixed_speed_ep and list(self.written_data_type) == [0x04, 0x00]:
                         self.fixed_speeds = tuple(u16le_from(self.written_data[i*2+1:i*2+3]) for i in range(0, self.written_data[0]))
-                    elif mode[0] == 0x62 and list(self.written_data_type) == [0x05, 0x00]:
+                    elif mode[0] == curve_ep and list(self.written_data_type) == [0x05, 0x00]:
                         curve_index = 1
                         for port_index in range(0, self.written_data[0]):
                             self.curve_points_by_device[port_index] = []
@@ -402,3 +431,52 @@ def test_parse_channels_error_commander_core():
     core = CommanderCore(MockCommanderCoreDevice(), 'Corsair Commander Core', True)
     with pytest.raises(ValueError):
         core._parse_channels('fan')
+
+
+@pytest.fixture
+def commander_core_device_fw2():
+    device = MockCommanderCoreDevice()
+    device.firmware_version = (0x02, 0x00, 0x13)  # fw 2.0.19 — matches Corsair Commander ST in the wild
+    core = CommanderCore(device, 'Corsair Commander ST', True)
+    core.connect()
+    return core
+
+
+def test_set_fixed_speed_fan2_commander_core_fw2(commander_core_device_fw2):
+    """Firmware 2.x: set_fixed_speed uses shifted endpoint IDs (0x61,6d) and (0x62,6d)"""
+    commander_core_device_fw2.device.speeds_mode = (1, 2, 3, 4, 5, 6, 7)
+    commander_core_device_fw2.device.fixed_speeds = (8, 9, 10, 11, 12, 13, 14)
+
+    commander_core_device_fw2.set_fixed_speed('fan2', 95)
+
+    assert commander_core_device_fw2.device.speeds_mode == (1, 2, 0, 4, 5, 6, 7)
+    assert commander_core_device_fw2.device.fixed_speeds == (8, 9, 95, 11, 12, 13, 14)
+    assert not commander_core_device_fw2.device._awake
+
+
+def test_set_fixed_speed_fans_commander_core_fw2(commander_core_device_fw2):
+    """Firmware 2.x: set_fixed_speed for all fans uses shifted endpoint IDs"""
+    commander_core_device_fw2.device.speeds_mode = (1, 2, 3, 4, 5, 6, 7)
+    commander_core_device_fw2.device.fixed_speeds = (8, 9, 10, 11, 12, 13, 14)
+
+    commander_core_device_fw2.set_fixed_speed('fans', 61)
+
+    assert commander_core_device_fw2.device.speeds_mode == (1, 0, 0, 0, 0, 0, 0)
+    assert commander_core_device_fw2.device.fixed_speeds == (8, 61, 61, 61, 61, 61, 61)
+    assert not commander_core_device_fw2.device._awake
+
+
+def test_set_speed_profile_fans_commander_core_fw2(commander_core_device_fw2):
+    """Firmware 2.x: set_speed_profile uses shifted endpoint IDs (0x61,6d) and (0x64,6d)"""
+    commander_core_device_fw2.device.speeds_mode = (0, 0, 0, 0, 0, 0, 0)
+
+    commander_core_device_fw2.set_speed_profile('fans', [
+        (22, 0), (32, 25), (34, 50), (36, 75), (38, 85), (40, 95), (42, 100)
+    ])
+
+    assert commander_core_device_fw2.device.speeds_mode == (0, 2, 2, 2, 2, 2, 2)
+    for i in range(1, 7):
+        assert commander_core_device_fw2.device.curve_points_by_device[i] == [
+            (22, 0), (32, 25), (34, 50), (36, 75), (38, 85), (40, 95), (42, 100)
+        ]
+    assert not commander_core_device_fw2.device._awake


### PR DESCRIPTION
## Problem

On devices running firmware 2.x (confirmed: Commander ST 0x0c32, fw 2.0.19), every call to `set_fixed_speed` or `set_speed_profile` raises `ExpectationNotMet('device returned incorrect data type')`. This is the root cause of the failures tracked in #753.

## Root cause

Corsair shifted the hardware-profile endpoint IDs by one position in firmware 2.x. The driver was opening the old fw 1.x IDs and always received a mismatched data type in the response:

| Purpose | fw 1.x endpoint | fw 2.x endpoint | Data type (unchanged) |
|---|---|---|---|
| Speed mode selector | `(0x60, 0x6d)` | `(0x61, 0x6d)` | `(0x03, 0x00)` |
| Fixed % values | `(0x61, 0x6d)` | `(0x62, 0x6d)` | `(0x04, 0x00)` |
| Speed curves | `(0x62, 0x6d)` | `(0x64, 0x6d)` | `(0x05, 0x00)` |

Data types and payload formats are **identical** between firmware versions — only the endpoint IDs differ. `get_status` and `initialize` are unaffected (they use different endpoints that did not shift).

This was determined by exhaustively probing all hardware-profile endpoints via raw USB HID while coolercontrold was stopped, then confirmed by live write tests: after writing 100% duty to the correct fw 2.x endpoints and sending SLEEP, fan 1 ramped from ~1100 RPM to ~2300 RPM (+1163 RPM).

## Fix

- Added `_MODE_HW_SPEED_MODE_V2`, `_MODE_HW_FIXED_PERCENT_V2`, and `_MODE_HW_CURVE_PERCENT_V2` constants for the fw 2.x endpoint IDs.
- The firmware major version is fetched and cached on first call to `set_fixed_speed` or `set_speed_profile` (via `_ensure_fw_version()`), or earlier if `initialize()` was called first.
- `set_fixed_speed` and `set_speed_profile` select the appropriate endpoint tuple based on firmware major version. Devices on fw 1.x are unaffected.

## Testing

All 12 existing tests continue to pass. Three new tests cover the fw 2.x paths:
- `test_set_fixed_speed_fan2_commander_core_fw2`
- `test_set_fixed_speed_fans_commander_core_fw2`
- `test_set_speed_profile_fans_commander_core_fw2`

The fix has been confirmed working end-to-end on a live Commander ST (0x0c32, fw 2.0.19) under coolercontrold — no more 502 errors and fan profiles apply correctly.

Fixes #753