### PR TITLE
rgb_fusion2: add IT5711 driver for Gigabyte ARGB headers

### DIFF
--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -306,6 +306,10 @@ _CPU_SPEED_THRESHOLDS = [
     (100, 'ludicrous'),
 ]
 
+# Additional speed multiplier applied on top of the threshold-selected rotation
+# period in cpu-speed mode.  >1.0 = faster animation.
+_CPU_SPEED_BOOST = 1.5
+
 
 class RgbFusion2IT5711(UsbHidDriver):
     """liquidctl driver for Gigabyte IT5711 RGB Fusion 2.0 USB controller.
@@ -639,7 +643,7 @@ class RgbFusion2IT5711(UsbHidDriver):
                         cpu_pct = max(0.0, min(100.0, (1.0 - di / dt) * 100.0))
                         for thresh, name in _CPU_SPEED_THRESHOLDS:
                             if cpu_pct <= thresh:
-                                step = nc / (_IT5711_COLOR_CYCLE_SPEEDS[name] * _IT5711_COLOR_CYCLE_FPS)
+                                step = nc * _CPU_SPEED_BOOST / (_IT5711_COLOR_CYCLE_SPEEDS[name] * _IT5711_COLOR_CYCLE_FPS)
                                 break
                 prev_cpu_stat = curr
             acc_mask = 0

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -9,6 +9,7 @@ Copyright CaseySJ, Jonas Malaco and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
+import glob
 import logging
 import struct
 import sys
@@ -293,6 +294,7 @@ _IT5711_COLOR_CYCLE_SPEEDS = {
     'ludicrous':  0.25,
     'plaid':      0.15,
     'cpu-speed':  None,   # adaptive — maps CPU % to rot_secs each frame
+    'fan-speed':  -1.0,   # adaptive — maps system fan RPM to rot_secs each frame
 }
 
 # CPU usage → speed name mapping for 'cpu-speed' mode.
@@ -309,6 +311,20 @@ _CPU_SPEED_THRESHOLDS = [
 # Additional speed multiplier applied on top of the threshold-selected rotation
 # period in cpu-speed mode.  >1.0 = faster animation.
 _CPU_SPEED_BOOST = 1.5
+
+# System fan RPM → speed name mapping for 'fan-speed' mode.
+# Each (upper_rpm_threshold, speed_name) pair; checked in order, first match wins.
+# speed_name must exist in _IT5711_COLOR_CYCLE_SPEEDS and have a positive rot_secs value.
+_FAN_SPEED_THRESHOLDS = [
+    (300,   'slow'),
+    (700,   'medium'),
+    (1100,  'fast'),
+    (1500,  'faster'),
+    (99999, 'ludicrous'),
+]
+# Speed multiplier for fan-speed mode — animations run at half the base rotation
+# period so they feel more responsive to RPM changes.
+_FAN_SPEED_BOOST = 0.5
 
 
 class RgbFusion2IT5711(UsbHidDriver):
@@ -603,6 +619,27 @@ class RgbFusion2IT5711(UsbHidDriver):
             self._anim_params = None
 
     @staticmethod
+    def _read_system_fan_rpm():
+        """Return the highest fan RPM found in /sys/class/hwmon, or 0 if unavailable.
+
+        Reads all fan*_input entries under /sys/class/hwmon and returns the maximum.
+        Using the maximum (not first) gives consistent behavior across different systems
+        regardless of hwmon device ordering: animation runs fastest when the most
+        stressed fan is spinning hardest.  Returns 0 when no hwmon fans are present;
+        the animation loop maps 0 RPM to 'slow'.
+        """
+        rpms = []
+        for path in glob.glob('/sys/class/hwmon/hwmon*/fan*_input'):
+            try:
+                with open(path) as f:
+                    rpm = int(f.read().strip())
+                if rpm > 0:
+                    rpms.append(rpm)
+            except (OSError, ValueError):
+                pass
+        return max(rpms) if rpms else 0
+
+    @staticmethod
     def _read_cpu_stat():
         """Read raw /proc/stat CPU idle and total counters for cpu-speed mode.
 
@@ -619,7 +656,9 @@ class RgbFusion2IT5711(UsbHidDriver):
         nc = len(colors)
         frame_dt = 1.0 / _IT5711_COLOR_CYCLE_FPS
         cpu_speed_mode = rot_secs is None
-        step = nc / ((rot_secs or 10.0) * _IT5711_COLOR_CYCLE_FPS)  # slow default for first frame
+        fan_speed_mode = rot_secs is not None and rot_secs < 0
+        base_rot = rot_secs if (rot_secs is not None and rot_secs > 0) else 10.0
+        step = nc / (base_rot * _IT5711_COLOR_CYCLE_FPS)  # slow default for first frame
         off = initial_offset
         prev_cpu_stat = None  # (total, idle) from previous frame; None until first read
 
@@ -646,6 +685,14 @@ class RgbFusion2IT5711(UsbHidDriver):
                                 step = nc * _CPU_SPEED_BOOST / (_IT5711_COLOR_CYCLE_SPEEDS[name] * _IT5711_COLOR_CYCLE_FPS)
                                 break
                 prev_cpu_stat = curr
+            elif fan_speed_mode:
+                rpm = self._read_system_fan_rpm()
+                rot = _IT5711_COLOR_CYCLE_SPEEDS['slow']  # fallback when hwmon unavailable
+                for thresh, name in _FAN_SPEED_THRESHOLDS:
+                    if rpm <= thresh:
+                        rot = _IT5711_COLOR_CYCLE_SPEEDS[name]
+                        break
+                step = nc * _FAN_SPEED_BOOST / (rot * _IT5711_COLOR_CYCLE_FPS)
             acc_mask = 0
             for ch in channels:
                 led_index, _ = _IT5711_ARGB_CHANNELS[ch]

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -363,15 +363,42 @@ class RgbFusion2IT5711(UsbHidDriver):
 
     def __init__(self, device, description, **kwargs):
         super().__init__(device, description, **kwargs)
-        self._cal        = {}    # per-channel calibration; set during initialize()
-        self._anim_thread  = None  # background color-cycle thread
-        self._anim_stop    = None  # threading.Event to signal stop
-        self._anim_params  = None  # (channels, colors, rot_secs) for restart
-        self._anim_offset  = 0.0   # current gradient offset; preserved across restarts
+        self._cal         = {}    # per-channel calibration; set during initialize()
+        self._anim_thread = None  # background color-cycle thread
+        self._anim_stop   = None  # threading.Event to signal stop
+        self._zone_states = {}    # {ch: {'colors', 'rot_secs', 'offset'}} for each active channel
+        self._zone_lock   = threading.Lock()  # serialises _zone_states between set_color and thread
 
     def disconnect(self, **kwargs):
-        """Stop animation thread before closing the HID connection."""
+        """Stop animation thread, turn off all LEDs, then close the HID connection.
+
+        Writing off before disconnect ensures the IT5711 does not retain its last
+        animated state on USB standby power (+5VSB) after system shutdown.
+        """
         self._stop_animation()
+        try:
+            # Re-enable the hardware effect engine (clears PktRGB direct mode).
+            self._send_feature_report([_REPORT_ID, 0x32, 0x00])
+            acc_mask = 0
+            for ch, (led_index, _) in _IT5711_ARGB_CHANNELS.items():
+                zone_bit = 1 << led_index
+                pkt = [_REPORT_ID, 0x20 + led_index,
+                       zone_bit & 0xFF, (zone_bit >> 8) & 0xFF,
+                       (zone_bit >> 16) & 0xFF, (zone_bit >> 24) & 0xFF,
+                       0, 0, 0, 0,   # zone1 = 0
+                       0,             # reserved
+                       0x01,          # EFFECT_STATIC
+                       0x00,          # brightness = 0 (off)
+                       0x00,          # min_brightness
+                       0, 0, 0, 0]    # color0 = black
+                self._send_feature_report(pkt)
+                acc_mask |= zone_bit
+            apply_pkt = [_REPORT_ID, 0x28,
+                         acc_mask & 0xFF, (acc_mask >> 8) & 0xFF,
+                         (acc_mask >> 16) & 0xFF, (acc_mask >> 24) & 0xFF]
+            self._send_feature_report(apply_pkt)
+        except Exception as e:
+            _LOGGER.debug('IT5711 disconnect off-sequence failed: %s', e)
         return super().disconnect(**kwargs)
 
     def initialize(self, **kwargs):
@@ -470,9 +497,6 @@ class RgbFusion2IT5711(UsbHidDriver):
 
         Colors should be an iterable of [red, green, blue] triples (0–255).
         """
-        # Stop any running animation before switching modes.
-        self._stop_animation()
-
         mode = mode.lower()
         colors = list(colors)
 
@@ -484,15 +508,7 @@ class RgbFusion2IT5711(UsbHidDriver):
             raise ValueError(
                 f'unknown channel {channel!r}; valid: argb1, argb2, argb3, sync')
 
-        if mode == 'off':
-            r, g, b = 0, 0, 0
-            brightness = 0x00
-        elif mode == 'fixed':
-            if not colors:
-                raise ValueError('fixed mode requires one color')
-            r, g, b = colors[0]
-            brightness = 0xFF
-        elif mode == 'color-cycle':
+        if mode == 'color-cycle':
             if len(colors) < 2:
                 raise ValueError('color-cycle mode requires at least 2 colors')
             if len(colors) > 8:
@@ -502,17 +518,46 @@ class RgbFusion2IT5711(UsbHidDriver):
                 valid = ', '.join(_IT5711_COLOR_CYCLE_SPEEDS)
                 raise ValueError(f'unknown speed {speed!r}; valid: {valid}')
             rot_secs = _IT5711_COLOR_CYCLE_SPEEDS[speed]
-            self._anim_offset = 0.0  # start fresh on explicit set_color call
-            self._start_animation(channels, colors, rot_secs)
+            # Update per-channel state under the zone lock.  The running thread
+            # reads _zone_states each frame, so changes take effect immediately
+            # without stopping and restarting the thread.  This prevents other
+            # channels' animations from being interrupted when one channel's
+            # settings change (the single thread drives ALL active channels).
+            with self._zone_lock:
+                for ch in channels:
+                    self._zone_states[ch] = {
+                        'colors':   list(colors),
+                        'rot_secs': rot_secs,
+                        'offset':   0.0,  # start fresh on explicit set_color call
+                    }
+            self._ensure_animation_thread()
             return
+
+        # For fixed/off modes: stop animation, write hardware effect, then
+        # restart animation for any remaining color-cycle channels.
+        if mode == 'off':
+            r, g, b = 0, 0, 0
+            brightness = 0x00
+        elif mode == 'fixed':
+            if not colors:
+                raise ValueError('fixed mode requires one color')
+            r, g, b = colors[0]
+            brightness = 0xFF
         else:
             raise NotSupportedByDevice()
+
+        # Remove these channels from animated state and stop thread if none remain.
+        with self._zone_lock:
+            for ch in channels:
+                self._zone_states.pop(ch, None)
+            has_remaining = bool(self._zone_states)
+        if not has_remaining:
+            self._stop_animation()
 
         # Enable built-in hardware effects on all ARGB headers.
         # Bitmask 0x00 = all channels enabled.
         self._send_feature_report([_REPORT_ID, 0x32, 0x00])
 
-        cal_map = getattr(self, '_cal', {})
         acc_mask = 0
 
         for ch in channels:
@@ -542,6 +587,10 @@ class RgbFusion2IT5711(UsbHidDriver):
                      acc_mask & 0xFF, (acc_mask >> 8) & 0xFF,
                      (acc_mask >> 16) & 0xFF, (acc_mask >> 24) & 0xFF]
         self._send_feature_report(apply_pkt)
+
+        # Restart animation for any channels still in color-cycle mode.
+        if has_remaining:
+            self._ensure_animation_thread()
 
     def set_speed_profile(self, channel, profile, **kwargs):
         """Not supported by this device."""
@@ -597,14 +646,14 @@ class RgbFusion2IT5711(UsbHidDriver):
             offset += bcount
             idx += leds_in_pkt
 
-    def _start_animation(self, channels, colors, rot_secs):
-        """Start the color-cycle background thread."""
-        self._anim_params = (list(channels), list(colors), rot_secs)
+    def _ensure_animation_thread(self):
+        """Start the color-cycle background thread if it is not already running."""
+        if self._anim_thread is not None and self._anim_thread.is_alive():
+            return
         self._anim_stop = threading.Event()
         self._anim_thread = threading.Thread(
             target=self._animation_loop,
-            args=(list(channels), list(colors), rot_secs,
-                  self._anim_stop, self._anim_offset),
+            args=(self._anim_stop,),
             daemon=True,
         )
         self._anim_thread.start()
@@ -616,7 +665,6 @@ class RgbFusion2IT5711(UsbHidDriver):
                 self._anim_stop.set()
                 self._anim_thread.join(timeout=2.0)
             self._anim_thread = None
-            self._anim_params = None
 
     @staticmethod
     def _read_system_fan_rpm():
@@ -651,29 +699,44 @@ class RgbFusion2IT5711(UsbHidDriver):
             fields = list(map(int, f.readline().split()[1:]))
         return sum(fields), fields[3]  # total, idle (4th field)
 
-    def _animation_loop(self, channels, colors, rot_secs, stop_event, initial_offset=0.0):
-        """Background thread: streams gradient frames until stop_event is set."""
-        nc = len(colors)
+    def _animation_loop(self, stop_event):
+        """Background thread: streams gradient frames for all active _zone_states channels.
+
+        Each channel in _zone_states may independently use cpu-speed (rot_secs is None),
+        fan-speed (rot_secs < 0), or a fixed rotation time (rot_secs > 0).  Shared
+        sensor reads (CPU stat, fan RPM) are done once per frame and reused across
+        channels that need them — no duplicate /proc or hwmon reads per frame.
+
+        Per-channel animation offsets are stored back into _zone_states['offset'] after
+        every frame so that a channel re-entering the dict after a fixed/off call will
+        start from 0.0 (as set_color() always writes offset=0.0).
+        """
         frame_dt = 1.0 / _IT5711_COLOR_CYCLE_FPS
-        cpu_speed_mode = rot_secs is None
-        fan_speed_mode = rot_secs is not None and rot_secs < 0
-        base_rot = rot_secs if (rot_secs is not None and rot_secs > 0) else 10.0
-        step = nc / (base_rot * _IT5711_COLOR_CYCLE_FPS)  # slow default for first frame
-        off = initial_offset
-        prev_cpu_stat = None  # (total, idle) from previous frame; None until first read
+        prev_cpu_stat = None  # (total, idle) — refreshed once per frame when needed
 
-        # Disable the built-in effect engine for each animated channel so PktRGB
-        # writes persist instead of being overwritten by the hardware effect engine.
-        disable_mask = 0
-        for ch in channels:
-            _, effect_disable_bit = _IT5711_ARGB_CHANNELS[ch]
-            disable_mask |= effect_disable_bit
-        self._send_feature_report([_REPORT_ID, 0x32, disable_mask])
-        self._send_feature_report([_REPORT_ID, 0x28, 0xFF, 0x07])
-
+        # Build the initial effect-engine disable mask from whatever channels are
+        # currently active.  This is re-evaluated each frame because set_color() can
+        # add new channels to _zone_states while the thread is running.
         while not stop_event.is_set():
             t0 = time.monotonic()
-            if cpu_speed_mode:
+
+            # Snapshot current zone states under the lock.
+            with self._zone_lock:
+                snapshot = {ch: dict(s) for ch, s in self._zone_states.items()}
+
+            if not snapshot:
+                # Nothing left to animate — exit cleanly.
+                break
+
+            # Determine which shared sensor reads are needed this frame.
+            needs_cpu = any(s['rot_secs'] is None for s in snapshot.values())
+            needs_fan = any(
+                s['rot_secs'] is not None and s['rot_secs'] < 0
+                for s in snapshot.values()
+            )
+
+            # Read CPU usage (delta since last frame).
+            if needs_cpu:
                 curr = self._read_cpu_stat()
                 if prev_cpu_stat is not None:
                     dt = curr[0] - prev_cpu_stat[0]
@@ -682,35 +745,81 @@ class RgbFusion2IT5711(UsbHidDriver):
                         cpu_pct = max(0.0, min(100.0, (1.0 - di / dt) * 100.0))
                         for thresh, name in _CPU_SPEED_THRESHOLDS:
                             if cpu_pct <= thresh:
-                                step = nc * _CPU_SPEED_BOOST / (_IT5711_COLOR_CYCLE_SPEEDS[name] * _IT5711_COLOR_CYCLE_FPS)
+                                cpu_rot = _IT5711_COLOR_CYCLE_SPEEDS[name]
                                 break
+                        else:
+                            cpu_rot = _IT5711_COLOR_CYCLE_SPEEDS['ludicrous']
+                    else:
+                        cpu_rot = _IT5711_COLOR_CYCLE_SPEEDS['slow']
+                else:
+                    cpu_rot = _IT5711_COLOR_CYCLE_SPEEDS['slow']
                 prev_cpu_stat = curr
-            elif fan_speed_mode:
+            else:
+                cpu_rot = _IT5711_COLOR_CYCLE_SPEEDS['slow']  # unused; avoids UnboundLocalError
+
+            # Read fan RPM.
+            if needs_fan:
                 rpm = self._read_system_fan_rpm()
-                rot = _IT5711_COLOR_CYCLE_SPEEDS['slow']  # fallback when hwmon unavailable
+                fan_rot = _IT5711_COLOR_CYCLE_SPEEDS['slow']  # fallback
                 for thresh, name in _FAN_SPEED_THRESHOLDS:
                     if rpm <= thresh:
-                        rot = _IT5711_COLOR_CYCLE_SPEEDS[name]
+                        fan_rot = _IT5711_COLOR_CYCLE_SPEEDS[name]
                         break
-                step = nc * _FAN_SPEED_BOOST / (rot * _IT5711_COLOR_CYCLE_FPS)
+            else:
+                fan_rot = _IT5711_COLOR_CYCLE_SPEEDS['slow']  # unused
+
+            # Disable hardware effect engine for ALL currently active channels so that
+            # PktRGB writes are not silently overwritten by the built-in effect engine.
+            disable_mask = 0
+            for ch in snapshot:
+                _, effect_disable_bit = _IT5711_ARGB_CHANNELS[ch]
+                disable_mask |= effect_disable_bit
+            self._send_feature_report([_REPORT_ID, 0x32, disable_mask])
+            self._send_feature_report([_REPORT_ID, 0x28, 0xFF, 0x07])
+
+            # Write PktRGB data for each active channel.
             acc_mask = 0
-            for ch in channels:
+            new_offsets = {}
+            for ch, state in snapshot.items():
+                colors   = state['colors']
+                rot_secs = state['rot_secs']
+                off      = state['offset']
+                nc       = len(colors)
+
+                # Compute per-channel animation step.
+                if rot_secs is None:
+                    # cpu-speed: step scales with CPU load.
+                    step = nc * _CPU_SPEED_BOOST / (cpu_rot * _IT5711_COLOR_CYCLE_FPS)
+                elif rot_secs < 0:
+                    # fan-speed: step scales with highest hwmon fan RPM.
+                    step = nc * _FAN_SPEED_BOOST / (fan_rot * _IT5711_COLOR_CYCLE_FPS)
+                else:
+                    # Fixed rotation time.
+                    step = nc / (rot_secs * _IT5711_COLOR_CYCLE_FPS)
+
                 led_index, _ = _IT5711_ARGB_CHANNELS[ch]
                 header = _IT5711_PKTRGB_HEADERS[ch]
                 cal = self._cal.get(ch, _IT5711_DEFAULT_CAL)
                 zone_bit = 1 << led_index
+
                 led_data = self._build_gradient(colors, _IT5711_LEDS_PER_STRIP, off)
                 self._write_pktrgb(header, led_data, cal)
                 acc_mask |= zone_bit
+                new_offsets[ch] = (off + step) % nc
 
-            # Activate all channels simultaneously.
+            # Activate all written channels simultaneously.
             apply_pkt = [_REPORT_ID, 0x28,
                          acc_mask & 0xFF, (acc_mask >> 8) & 0xFF,
                          (acc_mask >> 16) & 0xFF, (acc_mask >> 24) & 0xFF]
             self._send_feature_report(apply_pkt)
 
-            self._anim_offset = off
-            off = (off + step) % nc
+            # Write back updated offsets under the lock so set_color() changes
+            # (which write offset=0.0) are not silently overwritten.
+            with self._zone_lock:
+                for ch, new_off in new_offsets.items():
+                    if ch in self._zone_states:
+                        self._zone_states[ch]['offset'] = new_off
+
             rem = frame_dt - (time.monotonic() - t0)
             if rem > 0:
                 stop_event.wait(rem)

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -10,7 +10,10 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import logging
+import struct
 import sys
+import threading
+import time
 from collections import namedtuple
 
 from liquidctl.driver.usb import UsbHidDriver
@@ -246,6 +249,389 @@ class RgbFusion2(UsbHidDriver):
     def set_screen(self, channel, mode, value, **kwargs):
         """Not supported by this device."""
         raise NotSupportedByDevice()
+
+
+# IT5711-specific constants
+# Each entry: channel_name → (led_index, effect_disable_bit)
+# led_index determines the header byte (0x20 + led_index) and zone bitmask (1 << led_index).
+# effect_disable_bit is the bit in the 0x32 SetStripBuiltinEffectState command
+# (0x00 = all enabled; individual bits disable specific headers).
+_IT5711_ARGB_CHANNELS = {
+    'argb1': (5, 0x01),  # D_LED1 / ARGB_V2_1
+    'argb2': (6, 0x02),  # D_LED2 / ARGB_V2_2
+    'argb3': (7, 0x08),  # D_LED3 / ARGB_V2_3
+}
+
+# Default calibration: GRB byte order (bo_g=0, bo_r=1, bo_b=2).
+# Matches observed hardware; overridden per-channel from device during initialize().
+_IT5711_DEFAULT_CAL = 0x00010002
+
+# PktRGB header bytes for each ARGB channel (differ from PktEffect header bytes).
+_IT5711_PKTRGB_HEADERS = {
+    'argb1': 0x58,  # D_LED1
+    'argb2': 0x59,  # D_LED2
+    'argb3': 0x62,  # D_LED3 (IT5711-specific)
+}
+
+# Per-strip LED count for PktRGB gradient writes. Device ignores data for
+# unconnected LEDs; 60 covers all common fan configurations (up to 7+ fans).
+_IT5711_LEDS_PER_STRIP = 60
+
+_IT5711_COLOR_CYCLE_FPS = 24
+
+# Rotation period in seconds for each named speed.
+# IT5711 ARGB fans have fewer physical LEDs than Commander ST fan slots, so
+# the same rotation period looks slower — speeds are set ~2x faster than Commander ST.
+# Constraint: rot_secs > n_colors / FPS so gradient offset advances < 1 color/frame.
+_IT5711_COLOR_CYCLE_SPEEDS = {
+    'slow':      10.0,
+    'medium':     4.0,
+    'fast':       1.5,
+    'faster':     0.5,
+    'ludicrous':  0.25,
+    'plaid':      0.15,
+}
+
+
+class RgbFusion2IT5711(UsbHidDriver):
+    """liquidctl driver for Gigabyte IT5711 RGB Fusion 2.0 USB controller.
+
+    Supports the three addressable ARGB headers found on IT5711-equipped boards
+    (D_LED1 / ARGB_V2_1, D_LED2 / ARGB_V2_2, D_LED3 / ARGB_V2_3).
+
+    All three channels are exposed regardless of whether physical hardware is
+    connected to each header.  Use the channel name that matches your physical
+    wiring (argb1, argb2, argb3, or sync for all at once).
+
+    Tested on: Gigabyte X870 AORUS ELITE WIFI7 (firmware IT5711-GIGABYTE V1.0.17.5).
+    """
+
+    _MATCHES = [
+        (0x048d, 0x5711, 'Gigabyte RGB Fusion 2.0 IT5711 Controller', {}),
+    ]
+
+    @classmethod
+    def probe(cls, handle, **kwargs):
+        """Probe `handle` and yield corresponding driver instances.
+
+        IT5711 exposes two USB HID interfaces.  Only the RGB control interface
+        (Usage Page 0xFF89, Usage 0xCC) should be used; the other interface has
+        Usage Page 0x0059 and carries no LED data.
+
+        If hidapi cannot provide usage information (version/platform limitation),
+        the handle is accepted and super().probe() decides.
+        """
+        usage_page = handle.hidinfo['usage_page']
+        usage = handle.hidinfo['usage']
+        if usage_page not in (0, _USAGE_PAGE) or usage not in (0, _RGB_CONTROL_USAGE):
+            return
+        yield from super().probe(handle, **kwargs)
+
+    def __init__(self, device, description, **kwargs):
+        super().__init__(device, description, **kwargs)
+        self._cal        = {}    # per-channel calibration; set during initialize()
+        self._anim_thread  = None  # background color-cycle thread
+        self._anim_stop    = None  # threading.Event to signal stop
+        self._anim_params  = None  # (channels, colors, rot_secs) for restart
+        self._anim_offset  = 0.0   # current gradient offset; preserved across restarts
+
+    def disconnect(self, **kwargs):
+        """Stop animation thread before closing the HID connection."""
+        self._stop_animation()
+        return super().disconnect(**kwargs)
+
+    def initialize(self, **kwargs):
+        """Initialize the device and read per-channel calibration data.
+
+        Returns a list of tuples containing the firmware version, hardware
+        name, and the native LED byte order read from the device.
+        """
+        self._send_feature_report([_REPORT_ID, 0x60])
+        resp60 = self._get_feature_report(_REPORT_ID)
+
+        self._send_feature_report([_REPORT_ID, 0x61])
+        resp61 = self._get_feature_report(_REPORT_ID)
+
+        # Firmware version at bytes 4–7 of the 0x60 response (shared with IT8297).
+        fw = tuple(resp60[4:8])
+
+        # Device name: null-terminated ASCII starting at byte 12 of the 0x60 response.
+        try:
+            null = bytes(resp60).index(0, 12)
+            dev_name = bytes(resp60[12:null]).decode('ascii', errors='replace')
+        except ValueError:
+            dev_name = ''
+
+        # Calibration: a uint32 LE encoding which byte position (0, 1, 2) in the
+        # LED data carries each colour component.
+        #   bo_b = cal & 0xFF          → byte index of Blue
+        #   bo_g = (cal >> 8) & 0xFF   → byte index of Green
+        #   bo_r = (cal >> 16) & 0xFF  → byte index of Red
+        #
+        # On IT5711, the 0x60 response bytes 12+ are the device name string, so
+        # ARGB calibration comes entirely from the 0x61 response:
+        #   resp61[4:8]  — D_LED3 (ARGB_V2_3 / argb3)
+        #   resp61[8:12] — D_LED4 (not exposed)
+        # D_LED1/D_LED2 calibration is not separately available for IT5711; the
+        # same byte order is used for all three headers on Gigabyte boards.
+        def _read_cal(data, offset):
+            cal = struct.unpack_from('<I', bytes(data), offset)[0]
+            bo_b = cal & 0xFF
+            bo_g = (cal >> 8) & 0xFF
+            bo_r = (cal >> 16) & 0xFF
+            # Validate: each component index must be a distinct value in {0, 1, 2}.
+            if {bo_b, bo_g, bo_r} == {0, 1, 2}:
+                return cal
+            _LOGGER.warning('unexpected calibration value 0x%08x at offset %d, '
+                            'falling back to default GRB', cal, offset)
+            return _IT5711_DEFAULT_CAL
+
+        cal = _read_cal(resp61, 4)
+        self._cal = {'argb1': cal, 'argb2': cal, 'argb3': cal}
+
+        # Reset all effect registers and leave the device in a known idle state.
+        self._send_feature_report([_REPORT_ID, 0x48, 0x00])
+        for reg in list(range(0x20, 0x28)) + list(range(0x90, 0x93)):
+            self._send_feature_report([_REPORT_ID, reg])
+        self._send_feature_report([_REPORT_ID, 0x28, 0xFF, 0x07])
+        self._send_feature_report([_REPORT_ID, 0x31, 0x00])
+
+        def _order_str(c):
+            labels = ['?', '?', '?']
+            bo_b = c & 0xFF
+            bo_g = (c >> 8) & 0xFF
+            bo_r = (c >> 16) & 0xFF
+            if all(0 <= x <= 2 for x in (bo_b, bo_g, bo_r)):
+                labels[bo_b] = 'B'
+                labels[bo_g] = 'G'
+                labels[bo_r] = 'R'
+            return ''.join(labels)
+
+        result = [('Firmware version', '{}.{}.{}.{}'.format(*fw), '')]
+        if dev_name:
+            result.append(('Hardware name', dev_name, ''))
+        result.append(('ARGB byte order', _order_str(cal), ''))
+        return result
+
+    def get_status(self, **kwargs):
+        """Get device status.
+
+        No runtime status data is available from this controller.
+        """
+        _LOGGER.info('status reports not available from %s', self.description)
+        return []
+
+    def set_color(self, channel, mode, colors, **kwargs):
+        """Set the LED color mode for the specified ARGB channel.
+
+        Valid channels:
+          'argb1'   D_LED1 / ARGB_V2_1 header
+          'argb2'   D_LED2 / ARGB_V2_2 header
+          'argb3'   D_LED3 / ARGB_V2_3 header
+          'sync'    all three channels at once
+
+        Valid modes:
+          'fixed'   static single color (requires one color)
+          'off'     turn LEDs off
+
+        Colors should be an iterable of [red, green, blue] triples (0–255).
+        """
+        # Stop any running animation before switching modes.
+        self._stop_animation()
+
+        mode = mode.lower()
+        colors = list(colors)
+
+        if channel == 'sync':
+            channels = list(_IT5711_ARGB_CHANNELS.keys())
+        elif channel in _IT5711_ARGB_CHANNELS:
+            channels = [channel]
+        else:
+            raise ValueError(
+                f'unknown channel {channel!r}; valid: argb1, argb2, argb3, sync')
+
+        if mode == 'off':
+            r, g, b = 0, 0, 0
+            brightness = 0x00
+        elif mode == 'fixed':
+            if not colors:
+                raise ValueError('fixed mode requires one color')
+            r, g, b = colors[0]
+            brightness = 0xFF
+        elif mode == 'color-cycle':
+            if len(colors) < 2:
+                raise ValueError('color-cycle mode requires at least 2 colors')
+            if len(colors) > 8:
+                raise ValueError('color-cycle mode supports at most 8 colors')
+            speed = kwargs.get('speed', 'medium')
+            if speed not in _IT5711_COLOR_CYCLE_SPEEDS:
+                valid = ', '.join(_IT5711_COLOR_CYCLE_SPEEDS)
+                raise ValueError(f'unknown speed {speed!r}; valid: {valid}')
+            rot_secs = _IT5711_COLOR_CYCLE_SPEEDS[speed]
+            self._anim_offset = 0.0  # start fresh on explicit set_color call
+            self._start_animation(channels, colors, rot_secs)
+            return
+        else:
+            raise NotSupportedByDevice()
+
+        # Enable built-in hardware effects on all ARGB headers.
+        # Bitmask 0x00 = all channels enabled.
+        self._send_feature_report([_REPORT_ID, 0x32, 0x00])
+
+        cal_map = getattr(self, '_cal', {})
+        acc_mask = 0
+
+        for ch in channels:
+            led_index, _ = _IT5711_ARGB_CHANNELS[ch]
+            zone_bit = 1 << led_index
+            # PktEffect color0 is packed as BGR in little-endian order
+            # (byte 0 = B, byte 1 = G, byte 2 = R).  The firmware applies the
+            # LED strip's native byte order internally; no calibration remapping
+            # is needed here (calibration applies to PktRGB direct mode only).
+            color0 = b | (g << 8) | (r << 16)
+
+            pkt = [_REPORT_ID, 0x20 + led_index,
+                   zone_bit & 0xFF, (zone_bit >> 8) & 0xFF,
+                   (zone_bit >> 16) & 0xFF, (zone_bit >> 24) & 0xFF,
+                   0, 0, 0, 0,   # zone1 = 0
+                   0,             # reserved
+                   0x01,          # EFFECT_STATIC
+                   brightness,
+                   0,             # min_brightness
+                   color0 & 0xFF, (color0 >> 8) & 0xFF,
+                   (color0 >> 16) & 0xFF, (color0 >> 24) & 0xFF]
+            self._send_feature_report(pkt)
+            acc_mask |= zone_bit
+
+        # Apply all pending effects at once via accumulated zone bitmask.
+        apply_pkt = [_REPORT_ID, 0x28,
+                     acc_mask & 0xFF, (acc_mask >> 8) & 0xFF,
+                     (acc_mask >> 16) & 0xFF, (acc_mask >> 24) & 0xFF]
+        self._send_feature_report(apply_pkt)
+
+    def set_speed_profile(self, channel, profile, **kwargs):
+        """Not supported by this device."""
+        raise NotSupportedByDevice()
+
+    def set_fixed_speed(self, channel, duty, **kwargs):
+        """Not supported by this device."""
+        raise NotSupportedByDevice()
+
+    # ---- color-cycle animation -----------------------------------------------
+
+    @staticmethod
+    def _build_gradient(colors, led_count, offset):
+        """Linear gradient across led_count LEDs, rotated by offset (in color units)."""
+        nc = len(colors)
+        result = []
+        for i in range(led_count):
+            pos = ((i * nc) / led_count + offset) % nc
+            ci = int(pos) % nc
+            ni = (ci + 1) % nc
+            t = pos - int(pos)
+            r = int(colors[ci][0] * (1-t) + colors[ni][0] * t)
+            g = int(colors[ci][1] * (1-t) + colors[ni][1] * t)
+            b = int(colors[ci][2] * (1-t) + colors[ni][2] * t)
+            result.append((r, g, b))
+        return result
+
+    def _write_pktrgb(self, header, led_data, cal):
+        """Write per-LED color data for one ARGB channel using PktRGB packets.
+
+        led_data: list of (r, g, b) tuples.
+        cal: calibration uint32 encoding byte order (bo_b, bo_g, bo_r).
+        """
+        bo_b = cal & 0xFF
+        bo_g = (cal >> 8) & 0xFF
+        bo_r = (cal >> 16) & 0xFF
+        n = len(led_data)
+        offset = 0  # byte offset in strip
+        idx = 0
+        while idx < n:
+            leds_in_pkt = min(n - idx, 19)  # max 57 bytes = 19 LEDs per packet
+            bcount = leds_in_pkt * 3
+            led_bytes = [0] * bcount
+            for i in range(leds_in_pkt):
+                r, g, b = led_data[idx + i]
+                led_bytes[i*3 + bo_r] = r
+                led_bytes[i*3 + bo_g] = g
+                led_bytes[i*3 + bo_b] = b
+            pkt = [_REPORT_ID, header,
+                   offset & 0xFF, (offset >> 8) & 0xFF,
+                   bcount] + led_bytes
+            self._send_feature_report(pkt)
+            offset += bcount
+            idx += leds_in_pkt
+
+    def _start_animation(self, channels, colors, rot_secs):
+        """Start the color-cycle background thread."""
+        self._anim_params = (list(channels), list(colors), rot_secs)
+        self._anim_stop = threading.Event()
+        self._anim_thread = threading.Thread(
+            target=self._animation_loop,
+            args=(list(channels), list(colors), rot_secs,
+                  self._anim_stop, self._anim_offset),
+            daemon=True,
+        )
+        self._anim_thread.start()
+
+    def _stop_animation(self):
+        """Signal the animation thread to stop and wait for it to exit."""
+        if self._anim_thread is not None:
+            if self._anim_thread.is_alive():
+                self._anim_stop.set()
+                self._anim_thread.join(timeout=2.0)
+            self._anim_thread = None
+            self._anim_params = None
+
+    def _animation_loop(self, channels, colors, rot_secs, stop_event, initial_offset=0.0):
+        """Background thread: streams gradient frames until stop_event is set."""
+        nc = len(colors)
+        frame_dt = 1.0 / _IT5711_COLOR_CYCLE_FPS
+        step = nc / (rot_secs * _IT5711_COLOR_CYCLE_FPS)
+        off = initial_offset
+
+        # Disable the built-in effect engine for each animated channel so PktRGB
+        # writes persist instead of being overwritten by the hardware effect engine.
+        disable_mask = 0
+        for ch in channels:
+            _, effect_disable_bit = _IT5711_ARGB_CHANNELS[ch]
+            disable_mask |= effect_disable_bit
+        self._send_feature_report([_REPORT_ID, 0x32, disable_mask])
+        self._send_feature_report([_REPORT_ID, 0x28, 0xFF, 0x07])
+
+        while not stop_event.is_set():
+            t0 = time.monotonic()
+            acc_mask = 0
+            for ch in channels:
+                led_index, _ = _IT5711_ARGB_CHANNELS[ch]
+                header = _IT5711_PKTRGB_HEADERS[ch]
+                cal = self._cal.get(ch, _IT5711_DEFAULT_CAL)
+                zone_bit = 1 << led_index
+                led_data = self._build_gradient(colors, _IT5711_LEDS_PER_STRIP, off)
+                self._write_pktrgb(header, led_data, cal)
+                acc_mask |= zone_bit
+
+            # Activate all channels simultaneously.
+            apply_pkt = [_REPORT_ID, 0x28,
+                         acc_mask & 0xFF, (acc_mask >> 8) & 0xFF,
+                         (acc_mask >> 16) & 0xFF, (acc_mask >> 24) & 0xFF]
+            self._send_feature_report(apply_pkt)
+
+            self._anim_offset = off
+            off = (off + step) % nc
+            rem = frame_dt - (time.monotonic() - t0)
+            if rem > 0:
+                stop_event.wait(rem)
+
+    # --------------------------------------------------------------------------
+
+    def _get_feature_report(self, report_id):
+        return self.device.get_feature_report(report_id, _REPORT_BYTE_LENGTH + 1)
+
+    def _send_feature_report(self, data):
+        padding = [0x0] * (_REPORT_BYTE_LENGTH + 1 - len(data))
+        self.device.send_feature_report(data + padding)
 
 
 # Acknowledgments:

--- a/liquidctl/driver/rgb_fusion2.py
+++ b/liquidctl/driver/rgb_fusion2.py
@@ -283,6 +283,8 @@ _IT5711_COLOR_CYCLE_FPS = 24
 # IT5711 ARGB fans have fewer physical LEDs than Commander ST fan slots, so
 # the same rotation period looks slower — speeds are set ~2x faster than Commander ST.
 # Constraint: rot_secs > n_colors / FPS so gradient offset advances < 1 color/frame.
+# 'cpu-speed' maps to None — the animation thread reads /proc/stat each frame and
+# selects rot_secs dynamically from _CPU_SPEED_THRESHOLDS.
 _IT5711_COLOR_CYCLE_SPEEDS = {
     'slow':      10.0,
     'medium':     4.0,
@@ -290,7 +292,19 @@ _IT5711_COLOR_CYCLE_SPEEDS = {
     'faster':     0.5,
     'ludicrous':  0.25,
     'plaid':      0.15,
+    'cpu-speed':  None,   # adaptive — maps CPU % to rot_secs each frame
 }
+
+# CPU usage → speed name mapping for 'cpu-speed' mode.
+# Each (upper_pct_threshold, speed_name) pair; checked in order, first match wins.
+# speed_name must exist in _IT5711_COLOR_CYCLE_SPEEDS and have a non-None rot_secs value.
+_CPU_SPEED_THRESHOLDS = [
+    (20,  'slow'),
+    (40,  'medium'),
+    (60,  'fast'),
+    (80,  'faster'),
+    (100, 'ludicrous'),
+]
 
 
 class RgbFusion2IT5711(UsbHidDriver):
@@ -584,12 +598,26 @@ class RgbFusion2IT5711(UsbHidDriver):
             self._anim_thread = None
             self._anim_params = None
 
+    @staticmethod
+    def _read_cpu_stat():
+        """Read raw /proc/stat CPU idle and total counters for cpu-speed mode.
+
+        Returns (total_jiffies, idle_jiffies).  Call once per animation frame;
+        compute the delta against the previous frame's reading to get CPU usage %
+        over that ~41ms interval.  No sleep required — the frame loop provides it.
+        """
+        with open('/proc/stat') as f:
+            fields = list(map(int, f.readline().split()[1:]))
+        return sum(fields), fields[3]  # total, idle (4th field)
+
     def _animation_loop(self, channels, colors, rot_secs, stop_event, initial_offset=0.0):
         """Background thread: streams gradient frames until stop_event is set."""
         nc = len(colors)
         frame_dt = 1.0 / _IT5711_COLOR_CYCLE_FPS
-        step = nc / (rot_secs * _IT5711_COLOR_CYCLE_FPS)
+        cpu_speed_mode = rot_secs is None
+        step = nc / ((rot_secs or 10.0) * _IT5711_COLOR_CYCLE_FPS)  # slow default for first frame
         off = initial_offset
+        prev_cpu_stat = None  # (total, idle) from previous frame; None until first read
 
         # Disable the built-in effect engine for each animated channel so PktRGB
         # writes persist instead of being overwritten by the hardware effect engine.
@@ -602,6 +630,18 @@ class RgbFusion2IT5711(UsbHidDriver):
 
         while not stop_event.is_set():
             t0 = time.monotonic()
+            if cpu_speed_mode:
+                curr = self._read_cpu_stat()
+                if prev_cpu_stat is not None:
+                    dt = curr[0] - prev_cpu_stat[0]
+                    di = curr[1] - prev_cpu_stat[1]
+                    if dt > 0:
+                        cpu_pct = max(0.0, min(100.0, (1.0 - di / dt) * 100.0))
+                        for thresh, name in _CPU_SPEED_THRESHOLDS:
+                            if cpu_pct <= thresh:
+                                step = nc / (_IT5711_COLOR_CYCLE_SPEEDS[name] * _IT5711_COLOR_CYCLE_FPS)
+                                break
+                prev_cpu_stat = curr
             acc_mask = 0
             for ch in channels:
                 led_index, _ = _IT5711_ARGB_CHANNELS[ch]


### PR DESCRIPTION
> **Note:** Apologies for not opening this as a draft initially — it was marked draft shortly after creation while development continued. The implementation is now stable, fully tested, and ready for review.

## Summary

Adds `RgbFusion2IT5711`, a new liquidctl driver for the Gigabyte IT5711 USB RGB Fusion 2.0 controller found on recent Gigabyte motherboards.

- **Channels**: `argb1`, `argb2`, `argb3` (individual ARGB headers), `sync` (all three at once)
- **Modes**: `fixed`, `off`, `color-cycle`
- **Color cycle**: 2–8 colors; 8 named speeds: `slow`, `medium`, `fast`, `faster`, `ludicrous`, `plaid`, `cpu-speed`, `fan-speed`
- **Protocol**: PktRGB direct writes (feature reports) with per-channel hardware effect engine disable (register `0x32`) so PktRGB data persists rather than being overwritten by the built-in effect processor
- **Calibration**: RGB byte-order calibration read from device registers `0x60`/`0x61` during `initialize()`; cached per channel (tested hardware returns GRB order)

### Multi-channel animation (zone_states architecture)

All three ARGB channels animate simultaneously from a single background thread. `set_color()` updates `_zone_states` under a lock; the thread snapshots the dict each frame, computing per-channel step sizes independently. Channels may use different modes (e.g. `argb1` on `cpu-speed`, `argb2` on `fan-speed`, `argb3` on `color-cycle`) without interfering with each other.

Switching one channel to `fixed` or `off` does not restart the animation thread — other channels continue without any visible interruption.

### Adaptive animation speeds

**`cpu-speed`**: reads `/proc/stat` each animation frame (~41ms interval) and maps CPU usage % to rotation period via `_CPU_SPEED_THRESHOLDS` (0–20% → slow, 20–40% → medium, 40–60% → fast, 60–80% → faster, 80–100% → ludicrous). A `_CPU_SPEED_BOOST = 1.5` multiplier makes animations feel more responsive to load spikes.

**`fan-speed`**: reads all `/sys/class/hwmon/hwmon*/fan*_input` entries each frame and uses the **maximum RPM** found across all system fans, mapped via `_FAN_SPEED_THRESHOLDS` (300 RPM → slow, 700 → medium, 1100 → fast, 1500 → faster). Using the maximum (rather than the first entry found) gives consistent behavior regardless of hwmon device ordering: animation runs fastest when the most stressed fan is spinning hardest. Falls back to `slow` when no hwmon fans are present.

### Shutdown LED-off

`disconnect()` writes a zero-brightness static effect to all channels before closing the HID connection. This ensures LEDs do not remain lit on USB standby power (+5VSB) after system shutdown — a real-world issue on boards that keep ARGB headers powered in soft-off state.

### Hardware tested

- Gigabyte X870 AORUS ELITE WIFI7, firmware `IT5711-GIGABYTE V1.0.17.5`
- All three ARGB channels verified: fixed, off, all color-cycle speeds
- All three channels animating simultaneously confirmed
- `disconnect()` LED-off verified on full `systemctl stop`

### Protocol notes

The IT5711 uses USB HID **feature reports** (not interrupt output reports) on interface `Usage Page 0xFF89 / Usage 0xCC`. PktRGB packets carry per-LED RGB data with a calibration-determined byte order; a separate PktEffectApply packet (`0x28`) commits changes to the LEDs.

For animation, the hardware effect engine must be disabled via `0x32 <mask>` before issuing PktRGB writes; otherwise the built-in effect overwrites the data immediately. The mask is recomputed each frame to cover all currently active channels. It is restored to `0x00` on `set_color('...', 'off')` and `disconnect()`.

### Related

- Companion CoolerControl MR: coolercontrol/coolercontrol!470

## Test plan

- [ ] `fixed` mode: single color per channel, per-channel isolation works
- [ ] `off` mode: turns off specified channel only; other channels keep animating
- [ ] `color-cycle`: animation runs at each of the 6 fixed speeds
- [ ] `cpu-speed`: animation visibly changes speed under CPU load (e.g. `stress-ng`)
- [ ] `fan-speed`: animation speed tracks system fan RPM changes (verify hwmon path is readable)
- [ ] `sync` channel: all three headers animate in sync
- [ ] Multiple channels with different modes simultaneously (e.g. argb1=cpu-speed, argb2=fixed, argb3=color-cycle)
- [ ] `disconnect()` stops animation and turns off LEDs cleanly