### PR TITLE
Add driver for Lian Li HydroShift LCD coolers

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [Corsair iCUE Elite RGB H100i, H115i, H150i](docs/corsair-platinum-pro-xt-guide.md) | | 1.14.0 |
 | AIO liquid cooler  | [EVGA CLC 120 (CL12), 240, 280, 360](docs/asetek-690lc-guide.md) | Z | 1.9.1 |
 | AIO liquid cooler  | [Lian Li GA II LCD](docs/lian-li-ga-ii-lcd-guide.md) | p | 1.16.0 |
-| AIO liquid cooler  | Lian Li HydroShift LCD 360S, RGB, TL | px | git |
+| AIO liquid cooler  | [Lian Li HydroShift LCD 360S, RGB, TL](docs/lian-li-hydroshift-guide.md) | px | git |
 | AIO liquid cooler  | [MSI MPG Coreliquid K360](docs/msi-mpg-coreliquid-guide.md) | p | 1.14.0 |
 | AIO liquid cooler  | [NZXT Kraken M22](docs/kraken-x2-m2-guide.md) | | 1.10.0 |
 | AIO liquid cooler  | [NZXT Kraken X40, X60](docs/asetek-690lc-guide.md) | LZ | 1.9.1 |

--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [Corsair iCUE Elite RGB H100i, H115i, H150i](docs/corsair-platinum-pro-xt-guide.md) | | 1.14.0 |
 | AIO liquid cooler  | [EVGA CLC 120 (CL12), 240, 280, 360](docs/asetek-690lc-guide.md) | Z | 1.9.1 |
 | AIO liquid cooler  | [Lian Li GA II LCD](docs/lian-li-ga-ii-lcd-guide.md) | p | 1.16.0 |
+| AIO liquid cooler  | Lian Li HydroShift LCD 360S, RGB, TL | px | git |
 | AIO liquid cooler  | [MSI MPG Coreliquid K360](docs/msi-mpg-coreliquid-guide.md) | p | 1.14.0 |
 | AIO liquid cooler  | [NZXT Kraken M22](docs/kraken-x2-m2-guide.md) | | 1.10.0 |
 | AIO liquid cooler  | [NZXT Kraken X40, X60](docs/asetek-690lc-guide.md) | LZ | 1.9.1 |

--- a/docs/developer/protocol/lian_li_hydroshift.md
+++ b/docs/developer/protocol/lian_li_hydroshift.md
@@ -1,0 +1,191 @@
+# Lian Li HydroShift LCD AIO protocol
+
+The HydroShift LCD family is controlled by a USB HID custom protocol that
+extends the protocol used by the [GA II LCD][ga2]. Three HID report types are
+involved:
+
+- Report `A` (id `0x01`, 64 bytes) — control commands and small responses.
+- Report `B` (id `0x02`, 1024 bytes) — bulk transfers used by older firmware
+  (< 1.2) for LCD payloads.
+- Report `C` (id `0x03`, 512 bytes) — bulk transfers used by firmware ≥ 1.2
+  in place of report B. The selection is made from the firmware version
+  reported by the `Get firmware` command at initialization.
+
+The host always initiates communication; the device only replies when the
+specific command requires it. All multi-byte fields are big endian.
+
+[ga2]: lian_li_ga-2-lcd.md
+
+## Type A PDU
+
+```txt
+1     :  Report ID (0x01)
+2     :  Command ID
+3     :  Reserved (0x00)
+4-5   :  PDU sequence number (multi-packet only)
+6     :  Payload size (≤ 58 in this packet)
+7-64  :  Payload + zero padding
+```
+
+A request whose payload exceeds 58 bytes is split across multiple PDUs that
+share the command ID and increment the sequence number. The same scheme is
+used in reverse for multi-part responses.
+
+## Type B / C PDU
+
+```txt
+1     :  Report ID (0x02 for B, 0x03 for C)
+2     :  Command ID
+3-6   :  Total payload size across all PDUs (u32)
+7-9   :  Packet sequence number (u24)
+10-11 :  Payload size in this PDU (u16)
+12-…  :  Payload data + zero padding
+```
+
+For B reports the maximum payload per PDU is 1013 bytes (1024 − 11 header).
+For C reports it is 501 bytes (512 − 11 header).
+
+## A-commands
+
+### Get firmware version
+
+Request: `0x01 0x86`
+
+Response: two A-PDUs containing ASCII payloads. The first carries hardware
+identifiers and a firmware version; the second carries a build timestamp.
+The driver parses the *last* `major.minor` numeric segment of the first
+response to choose between report B and report C for LCD transfers.
+
+Example:
+
+- Part 1: `N9,01,HS,SQ,HydroShift,V3.0C.013,1.3`
+- Part 2: `Sep 30 2025,11:42:08`
+
+### Handshake
+
+Request: `0x01 0x81`
+
+Returns RPM readings and the coolant temperature. Payload layout:
+
+```txt
+1-2  :  Fan RPM
+3-4  :  Pump RPM
+5    :  Validity flag (non-zero ⇒ temperature fields valid)
+6    :  Coolant temperature, integer °C
+7    :  Coolant temperature, deci-°C (modulo 10)
+```
+
+### Set pump speed
+
+Request: `0x01 0x8a`, payload size `0x02`.
+
+```txt
+1   :  Reserved (0x00)
+2   :  Duty cycle (0-100)
+```
+
+No response.
+
+### Set fan speed
+
+Request: `0x01 0x8b`, payload size `0x02`. Same payload shape as
+"Set pump speed". No response.
+
+### Set fan lighting
+
+Request: `0x01 0x85`, payload size `0x14`.
+
+```txt
+1      :  Mode (see table below)
+2      :  Brightness (0x00-0x04)
+3      :  Speed (0x00-0x04)
+4-6    :  Color 1 RGB
+7-9    :  Color 2 RGB
+10-12  :  Color 3 RGB
+13-15  :  Color 4 RGB
+16     :  Direction (0x00 forward, 0x01 backward)
+17     :  Off flag
+18     :  Source (0x00 = MCU)
+19     :  Sync-to-pump flag
+20     :  LED count (e.g. 0x18 for 24 fan LEDs)
+```
+
+Modes:
+
+| Mode           | Value | Mode           | Value |
+|----------------|-------|----------------|-------|
+| `rainbow`      | 0x01  | `tide`         | 0x09  |
+| `rainbow-morph`| 0x02  | `mixing`       | 0x0A  |
+| `static`       | 0x03  | `ripple`       | 0x0E  |
+| `breathing`    | 0x04  | `reflect`      | 0x0F  |
+| `runway`       | 0x05  | `tail-chasing` | 0x10  |
+| `meteor`       | 0x06  | `paint`        | 0x11  |
+| `color-cycle`  | 0x07  | `ping-pong`    | 0x12  |
+| `staggered`    | 0x08  |                |       |
+
+No response.
+
+### Set pump lighting
+
+Request: `0x01 0x83`. Payload layout mirrors the fan-lighting frame; not yet
+implemented in the driver. Capture pending.
+
+### Reset device
+
+Request: `0x01 0x8e`. Returns the cooler to its power-on default state. No
+response.
+
+## B / C-commands (LCD)
+
+### LCD control
+
+Command: `0x0c`. Sent as a single B/C PDU with no chunking — `total_size`
+and `pkt_num` are zero, and the payload is exactly 8 bytes:
+
+```txt
+1   :  LCD mode
+        0  Local UI
+        1  Application (host-streamed)
+        2  Local H.264
+        3  Local AVI
+        4  LCD setting
+        5  LCD test
+2   :  Brightness (0-100)
+3   :  Rotation (0=0°, 1=90°, 2=180°, 3=270°) — driver applies rotation
+       client-side and leaves this byte at 0
+4-7 :  Reserved
+8   :  Frame rate (fps)
+```
+
+The driver issues `LCD control` with mode 1 before sending any image, and
+again on `set lcd screen lcd` to hand control back to the firmware.
+
+### Send JPEG frame
+
+Command: `0x0e`. Streams a JPEG image to the LCD as the payload of one or
+more B/C PDUs. The total payload size is the JPEG byte length; PDUs are
+emitted with monotonically increasing `pkt_num` until the byte count is met.
+
+The driver encodes 480×480 RGB frames at JPEG quality 85 with 4:2:0 chroma
+subsampling. Static images are sent as one JPEG; GIFs and videos send one
+JPEG per frame, paced at 24 fps (or the GIF's native interval if longer).
+
+After each JPEG transfer the driver attempts a short non-blocking read on
+report A to drain any acknowledgement the device emits.
+
+### LCD available
+
+Command: `0x17`. Used to query LCD readiness; not currently emitted by the
+driver but reserved in the command map for completeness.
+
+## Notes and open items
+
+- Pump-head lighting (`0x83`) is documented above by analogy with the fan
+  lighting frame and the GA II LCD protocol; needs USB capture to confirm
+  byte layout on a HydroShift unit.
+- The `LCD setting` and `LCD test` modes (`0x0c` payload byte 1, values 4
+  and 5) are observed in firmware strings but their semantics in the
+  application protocol are not yet documented.
+- The driver applies rotation client-side instead of via byte 3 of the
+  `LCD control` payload; firmware-side rotation has not been validated end
+  to end.

--- a/docs/lian-li-hydroshift-guide.md
+++ b/docs/lian-li-hydroshift-guide.md
@@ -1,0 +1,110 @@
+# Lian Li HydroShift LCD AIO Liquid Coolers
+_Driver API and source code available in [`liquidctl.driver.hydroshift_lcd`](../liquidctl/driver/hydroshift_lcd.py)._
+
+_New in git._<br>
+
+This driver covers the Lian Li HydroShift LCD family, which mounts a 480×480
+round LCD on the pump head and exposes its fan/pump controllers and LEDs over
+USB HID:
+
+- Lian Li HydroShift LCD 360S (`0416:7398`)
+- Lian Li HydroShift LCD RGB (`0416:7399`)
+- Lian Li HydroShift LCD TL (`0416:739a`)
+
+Only the 360S has been verified on real hardware so far; the other variants are
+listed based on Lian Li's product line and protocol affinity.
+
+## Initialization
+
+The cooler does not strictly require initialization for sensor reads, but the
+driver uses `initialize` to read the firmware version and select the
+appropriate LCD transport (older firmware uses 1024-byte HID reports, firmware
+≥ 1.2 uses 512-byte reports).
+
+```
+# liquidctl initialize
+Lian Li HydroShift LCD 360S
+├── Firmware version    N9,01,HS,SQ,HydroShift,V3.0B.02C,0.7
+├── Liquid temperature                                  28.4  °C
+├── Fan speed                                           1320  rpm
+└── Pump speed                                          2520  rpm
+```
+
+## Device monitoring
+
+Reports liquid temperature, pump and fan RPM, and the corresponding duty
+percentages computed against the device's published max RPMs (3600 pump,
+2520 fan).
+
+```
+# liquidctl status
+Lian Li HydroShift LCD 360S
+├── Liquid temperature    28.4  °C
+├── Fan speed             1320  rpm
+├── Fan duty                52  %
+├── Pump speed            2520  rpm
+└── Pump duty              70  %
+```
+
+## Fan and pump speed control
+
+The AIO firmware owns the temperature curves; only fixed duty values are
+settable from the host.
+
+```
+# liquidctl set fan speed 60
+# liquidctl set pump speed 80
+```
+
+Speed *profiles* are not supported and will raise `NotSupportedByDevice`.
+
+## Lighting
+
+The fan ring exposes the following modes through the `fan` lighting channel:
+
+- `rainbow`, `rainbow-morph`, `static`, `breathing`, `runway`, `meteor`,
+  `color-cycle`, `staggered`, `tide`, `mixing`, `ripple`, `reflect`,
+  `tail-chasing`, `paint`, `ping-pong`
+
+Up to four RGB colors can be supplied. The animation speed
+(`slowest`, `slower`, `normal`, `faster`, `fastest`) and direction
+(`forward`, `backward`) are also configurable.
+
+```
+# liquidctl set fan color static ff8000
+# liquidctl set fan color rainbow-morph 000000 --speed faster
+# liquidctl set fan color paint ff0000 00ff00 0000ff ffff00 --direction backward
+```
+
+Pump-head lighting is not currently exposed by the driver.
+
+## Screen
+
+The LCD on the pump head supports static images, animated GIFs, and video
+playback over USB. Brightness and orientation can be configured independently.
+
+```
+# liquidctl [options] set lcd screen brightness <value>
+# liquidctl [options] set lcd screen orientation (0|90|180|270)
+# liquidctl [options] set lcd screen static <path to image>
+# liquidctl [options] set lcd screen gif <path to gif>
+# liquidctl [options] set lcd screen video <path to video>
+# liquidctl [options] set lcd screen lcd
+```
+
+Images, GIFs and videos are resized to 480×480 and rotated client-side
+according to the configured orientation, which is persisted via
+`RuntimeStorage` so it survives across invocations.
+
+Video playback uses `ffmpeg` (decoded externally and streamed frame-by-frame
+at 24 fps) and runs as a long-lived foreground command — terminate the
+liquidctl process to stop playback and revert to the firmware's default
+screen by sending `set lcd screen lcd`.
+
+## Notes and limitations
+
+- Pump-head lighting and any sensor/time/text overlays configured through
+  L-Connect 3 are not yet exposed.
+- The fan curve owned by the AIO controller cannot be modified from the host;
+  use L-Connect 3 once to configure a profile that the firmware will retain.
+- Video playback requires `ffmpeg` to be available on `PATH`.

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -503,6 +503,15 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="048d", ATTRS{idProduct}=="8297", TAG+="uacc
 # Lian Li GA II LCD
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0416", ATTRS{idProduct}=="7395", TAG+="uaccess"
 
+# Lian Li HydroShift LCD 360S
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0416", ATTRS{idProduct}=="7398", TAG+="uaccess"
+
+# Lian Li HydroShift LCD RGB
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0416", ATTRS{idProduct}=="7399", TAG+="uaccess"
+
+# Lian Li HydroShift LCD TL
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0416", ATTRS{idProduct}=="739a", TAG+="uaccess"
+
 # Lian Li Uni AL
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0cf2", ATTRS{idProduct}=="a101", TAG+="uaccess"
 

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -807,6 +807,34 @@ The animation direction can be set with
 .BI \-\-direction= value ,
 where the allowed values are: \fIforward\fR or \fIbackward\fR.
 .
+.SS Lian Li HydroShift LCD 360S, RGB, TL
+Cooling channels: \fIpump\fR, \fIfan\fR.
+.PP
+This device does not support speed profiles for any channels, only fixed speeds are supported.
+.PP
+Lighting channels: \fIfan\fR.
+.PP
+Supported lighting modes: \fIrainbow\fR, \fIrainbow\-morph\fR, \fIstatic\fR,
+\fIbreathing\fR, \fIrunway\fR, \fImeteor\fR, \fIcolor\-cycle\fR,
+\fIstaggered\fR, \fItide\fR, \fImixing\fR, \fIripple\fR, \fIreflect\fR,
+\fItail\-chasing\fR, \fIpaint\fR, \fIping\-pong\fR.
+Each mode accepts up to four RGB colors.
+.PP
+The animation speed can be set with
+.BI \-\-speed= value ,
+where the allowed values are: \fIslowest\fR, \fIslower\fR, \fInormal\fR,
+\fIfaster\fR, \fIfastest\fR.
+The animation direction can be set with
+.BI \-\-direction= value ,
+where the allowed values are: \fIforward\fR or \fIbackward\fR.
+.PP
+Screen channel: \fIlcd\fR. Modes: \fIstatic\fR (path to image),
+\fIgif\fR (path to animated GIF), \fIvideo\fR (path to video, decoded via
+\fBffmpeg\fR), \fIbrightness\fR (0\-100), \fIorientation\fR (0, 90, 180, 270),
+and \fIlcd\fR (return control to firmware/application mode).
+The configured orientation is persisted via runtime storage and applied to
+subsequent images.
+.
 .SH SEE ALSO
 The complete documentation is available in
 the project's sources and

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -43,6 +43,7 @@ from liquidctl.driver import nzxt_epsu
 from liquidctl.driver import rgb_fusion2
 from liquidctl.driver import smart_device
 from liquidctl.driver import ga2_lcd
+from liquidctl.driver import hydroshift_lcd
 
 if sys.platform == 'linux':
     from liquidctl.driver import ddr4

--- a/liquidctl/driver/hydroshift_lcd.py
+++ b/liquidctl/driver/hydroshift_lcd.py
@@ -1,0 +1,569 @@
+"""liquidctl drivers for Lian Li HydroShift LCD liquid coolers.
+
+Supported devices:
+
+- Lian Li HydroShift LCD 360S
+- Lian Li HydroShift LCD RGB
+- Lian Li HydroShift LCD TL
+
+Copyright liquidctl contributors
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import io
+import logging
+import math
+import re
+
+from PIL import Image, ImageSequence
+
+from liquidctl.driver.usb import UsbHidDriver
+from liquidctl.error import NotSupportedByDevice, NotSupportedByDriver
+
+_LOGGER = logging.getLogger(__name__)
+
+# LCD resolution
+_LCD_WIDTH = 480
+_LCD_HEIGHT = 480
+_JPEG_QUALITY = 85
+
+# HID report sizes
+_REPORT_A_SIZE = 64
+_REPORT_B_SIZE = 1024
+_REPORT_C_SIZE = 512
+
+# Report IDs
+_REPORT_ID_A = 0x01
+_REPORT_ID_B = 0x02
+_REPORT_ID_C = 0x03
+
+# A-command bytes
+_CMD_HANDSHAKE = 0x81
+_CMD_SET_PUMP_LIGHT = 0x83
+_CMD_SET_FAN_LIGHT = 0x85
+_CMD_GET_FIRMWARE = 0x86
+_CMD_SET_PUMP_PWM = 0x8A
+_CMD_SET_FAN_PWM = 0x8B
+_CMD_RESET_DEVICE = 0x8E
+
+# B/C-command bytes (LCD)
+_CMD_LCD_CONTROL = 0x0C
+_CMD_SEND_JPEG = 0x0E
+_CMD_LCD_AVAILABLE = 0x17
+
+# LCD modes
+_LCD_MODE_LOCAL_UI = 0
+_LCD_MODE_APPLICATION = 1
+_LCD_MODE_LOCAL_H264 = 2
+_LCD_MODE_LOCAL_AVI = 3
+_LCD_MODE_LCD_SETTING = 4
+_LCD_MODE_LCD_TEST = 5
+
+# Max payload per B/C-command packet (after 11-byte header)
+_B_CMD_MAX_PAYLOAD = 1013  # 1024 - 11
+_C_CMD_MAX_PAYLOAD = 501   # 512 - 11
+
+_STATUS_TEMPERATURE = "Liquid temperature"
+_STATUS_PUMP_SPEED = "Pump speed"
+_STATUS_PUMP_DUTY = "Pump duty"
+_STATUS_FAN_SPEED = "Fan speed"
+_STATUS_FAN_DUTY = "Fan duty"
+
+_PUMP_RPM_MAX = 3600
+_FAN_RPM_MAX = 2520
+
+_SPEED_CHANNELS = {
+    "fan": _CMD_SET_FAN_PWM,
+    "pump": _CMD_SET_PUMP_PWM,
+}
+
+_FAN_LIGHTING_MODES = {
+    "rainbow": 0x01,
+    "rainbow-morph": 0x02,
+    "static": 0x03,
+    "breathing": 0x04,
+    "runway": 0x05,
+    "meteor": 0x06,
+    "color-cycle": 0x07,
+    "staggered": 0x08,
+    "tide": 0x09,
+    "mixing": 0x0A,
+    "ripple": 0x0E,
+    "reflect": 0x0F,
+    "tail-chasing": 0x10,
+    "paint": 0x11,
+    "ping-pong": 0x12,
+}
+
+_LIGHTING_SPEEDS = {
+    "slowest": 0x00,
+    "slower": 0x01,
+    "normal": 0x02,
+    "faster": 0x03,
+    "fastest": 0x04,
+}
+
+_LIGHTING_DIRECTIONS = {
+    "forward": 0x00,
+    "backward": 0x01,
+}
+
+_LCD_ROTATIONS = {
+    0: 0,
+    90: 1,
+    180: 2,
+    270: 3,
+}
+
+
+def _quoted(*names):
+    return ", ".join(map(repr, names))
+
+
+def _write_colors(buf, colors, offset, max_bytes):
+    """Write up to 4 RGB color triplets into buf at offset."""
+    for i in range(min(len(colors), max_bytes // 3)):
+        buf[offset + i * 3] = colors[i][0]
+        buf[offset + i * 3 + 1] = colors[i][1]
+        buf[offset + i * 3 + 2] = colors[i][2]
+
+
+class HydroShiftLCD(UsbHidDriver):
+    """liquidctl driver for Lian Li HydroShift LCD coolers."""
+
+    _MATCHES = [
+        (
+            0x0416,
+            0x7398,
+            "Lian Li HydroShift LCD 360S",
+            {},
+        ),
+        (
+            0x0416,
+            0x7399,
+            "Lian Li HydroShift LCD RGB",
+            {},
+        ),
+        (
+            0x0416,
+            0x739A,
+            "Lian Li HydroShift LCD TL",
+            {},
+        ),
+    ]
+
+    def initialize(self, direct_access=False, **kwargs):
+        """Initialize the device and return firmware version and status.
+
+        Returns a list of `[(<property>, <value>, <unit>)]` tuples with
+        firmware version and initial sensor readings.
+        """
+        self.device.clear_enqueued_reports()
+        self._rotation = 0
+
+        fw_version = self._read_firmware_version()
+        _LOGGER.info("firmware version: %s", fw_version)
+
+        # Parse firmware version to determine C-command support.
+        # The firmware string looks like "N9,01,HS,SQ,HydroShift,V3.0B.02C,0.7"
+        # The actual version is the LAST "major.minor" numeric segment (e.g. "0.7").
+        self._use_c_cmd = False
+        matches = re.findall(r"(?:^|,)(\d+)\.(\d+)(?:$|,)", fw_version)
+        if matches:
+            major, minor = int(matches[-1][0]), int(matches[-1][1])
+            _LOGGER.info("detected firmware version: %d.%d", major, minor)
+            if major > 1 or (major == 1 and minor >= 2):
+                self._use_c_cmd = True
+                _LOGGER.info("firmware >= 1.2, using C-command (512-byte) LCD packets")
+
+        status = [("Firmware version", fw_version, "")]
+
+        try:
+            handshake = self._get_handshake()
+            status.extend([
+                (_STATUS_TEMPERATURE, handshake["temperature"], "°C"),
+                (_STATUS_FAN_SPEED, handshake["fan_rpm"], "rpm"),
+                (_STATUS_PUMP_SPEED, handshake["pump_rpm"], "rpm"),
+            ])
+        except Exception as e:
+            _LOGGER.warning("failed to read initial status: %s", e)
+
+        return sorted(status)
+
+    def get_status(self, direct_access=False, **kwargs):
+        """Get a status report.
+
+        Returns a list of `(property, value, unit)` tuples.
+        """
+        self.device.clear_enqueued_reports()
+        handshake = self._get_handshake()
+        return [
+            (_STATUS_TEMPERATURE, handshake["temperature"], "°C"),
+            (_STATUS_FAN_SPEED, handshake["fan_rpm"], "rpm"),
+            (_STATUS_FAN_DUTY, min(handshake["fan_rpm"] / _FAN_RPM_MAX * 100, 100), "%"),
+            (_STATUS_PUMP_SPEED, handshake["pump_rpm"], "rpm"),
+            (_STATUS_PUMP_DUTY, min(handshake["pump_rpm"] / _PUMP_RPM_MAX * 100, 100), "%"),
+        ]
+
+    def set_fixed_speed(self, channel, duty, direct_access=False, **kwargs):
+        """Set fan or pump to a fixed speed duty (0-100%)."""
+        if channel not in _SPEED_CHANNELS:
+            raise NotSupportedByDevice(
+                f"fixed speed control for {channel} is not supported, "
+                f"should be one of: {_quoted(*_SPEED_CHANNELS)}"
+            )
+        speed = max(0, min(100, duty))
+        self._write_a_cmd_with_data(_SPEED_CHANNELS[channel], [0x00, speed])
+
+    def set_speed_profile(self, channel, profile, **kwargs):
+        """Not supported by this device."""
+        raise NotSupportedByDevice()
+
+    def set_color(self, channel, mode, colors, speed="normal", direction="forward", **kwargs):
+        """Set the LED color mode for the fan channel.
+
+        Valid channels: fan
+        Valid modes: rainbow, rainbow-morph, static, breathing, runway, meteor,
+            color-cycle, staggered, tide, mixing, ripple, reflect,
+            tail-chasing, paint, ping-pong
+        Speed: slowest, slower, normal, faster, fastest
+        Direction: forward, backward
+        Colors: up to 4 RGB colors depending on mode
+        """
+        if channel != "fan":
+            raise NotSupportedByDevice(
+                f"lighting control for {channel} is not supported, use 'fan'"
+            )
+
+        if mode not in _FAN_LIGHTING_MODES:
+            raise ValueError(
+                f"unknown lighting mode: {mode}, "
+                f"should be one of: {_quoted(*_FAN_LIGHTING_MODES)}"
+            )
+        if speed not in _LIGHTING_SPEEDS:
+            raise ValueError(
+                f"unknown lighting speed: {speed}, "
+                f"should be one of: {_quoted(*_LIGHTING_SPEEDS)}"
+            )
+        if direction not in _LIGHTING_DIRECTIONS:
+            raise ValueError(
+                f"unknown lighting direction: {direction}, "
+                f"should be one of: {_quoted(*_LIGHTING_DIRECTIONS)}"
+            )
+
+        colors = list(colors)
+        req = [0] * 20
+        req[0] = _FAN_LIGHTING_MODES[mode]
+        req[1] = 4  # brightness (max)
+        req[2] = _LIGHTING_SPEEDS[speed]
+        _write_colors(req, colors, 3, 12)
+        req[15] = _LIGHTING_DIRECTIONS[direction]
+        req[16] = 0  # off flag
+        req[17] = 0  # source: MCU
+        req[18] = 0  # sync_to_pump
+        req[19] = 24  # LED count
+
+        self._write_a_cmd_with_data(_CMD_SET_FAN_LIGHT, req)
+
+    def set_screen(self, channel, mode, value, **kwargs):
+        """Set the LCD screen mode.
+
+        Valid channels: lcd
+        Valid modes:
+            static <path>   -- display a static image (JPEG/PNG/BMP)
+            gif <path>      -- display an animated GIF (sends first frame as static)
+            brightness <0-100> -- set LCD brightness
+            orientation <0|90|180|270> -- set LCD rotation
+            lcd -- switch to application (streaming) mode
+        """
+        if channel != "lcd":
+            raise NotSupportedByDevice(
+                f"screen control for {channel} is not supported, use 'lcd'"
+            )
+
+        if mode == "brightness":
+            brightness = max(0, min(100, int(value)))
+            self._send_lcd_control(
+                lcd_mode=_LCD_MODE_APPLICATION,
+                brightness=brightness,
+            )
+
+        elif mode == "orientation":
+            rotation = int(value)
+            if rotation not in _LCD_ROTATIONS:
+                raise ValueError(
+                    f"unsupported rotation: {rotation}, "
+                    f"should be one of: {_quoted(*_LCD_ROTATIONS)}"
+                )
+            self._rotation = rotation
+            _LOGGER.info("LCD rotation set to %d degrees (applied on next image send)", rotation)
+
+        elif mode == "static":
+            self._send_static_image(value)
+
+        elif mode == "gif":
+            self._send_gif(value)
+
+        elif mode == "lcd":
+            self._send_lcd_control(lcd_mode=_LCD_MODE_APPLICATION)
+
+        else:
+            raise ValueError(
+                f"unknown screen mode: {mode}, "
+                f"should be one of: 'static', 'gif', 'brightness', 'orientation', 'lcd'"
+            )
+
+    def disconnect(self, **kwargs):
+        """Disconnect from the device."""
+        return self.device.close()
+
+    # -- internal: A-command helpers (64-byte HID reports) --
+
+    def _build_a_cmd(self, cmd, data=None):
+        """Build a 64-byte A-command packet."""
+        pkt = [0] * _REPORT_A_SIZE
+        pkt[0] = _REPORT_ID_A
+        pkt[1] = cmd
+        if data:
+            pkt[5] = len(data)
+            pkt[6:6 + len(data)] = data
+        return pkt
+
+    def _write_a_cmd(self, cmd):
+        """Send an A-command with no data."""
+        self.device.write(self._build_a_cmd(cmd))
+
+    def _write_a_cmd_with_data(self, cmd, data):
+        """Send an A-command with data payload (chunked if > 58 bytes)."""
+        offset = 0
+        num = 0
+        while offset < len(data):
+            chunk_len = min(len(data) - offset, 58)
+            pkt = [0] * _REPORT_A_SIZE
+            pkt[0] = _REPORT_ID_A
+            pkt[1] = cmd
+            num_bytes = num.to_bytes(2, byteorder="big")
+            pkt[3] = num_bytes[0]
+            pkt[4] = num_bytes[1]
+            pkt[5] = chunk_len
+            pkt[6:6 + chunk_len] = data[offset:offset + chunk_len]
+            self.device.write(pkt)
+            num += 1
+            offset += chunk_len
+
+    def _read_a_cmd(self):
+        """Read an A-command response, handling multi-packet responses."""
+        r = self.device.read(64)
+        if not r or len(r) < 6:
+            raise ValueError("no response from device")
+        if r[0] != _REPORT_ID_A:
+            raise ValueError(f"unexpected report ID: 0x{r[0]:02x}")
+
+        command = r[1]
+        length = r[5]
+        current_len = min(length, 58)
+        data = list(r[6:6 + current_len])
+
+        packet_count = math.ceil(length / 58) if length > 0 else 1
+        for i in range(1, packet_count):
+            r = self.device.read(64)
+            if r[0] != _REPORT_ID_A or r[1] != command:
+                raise ValueError("unexpected continuation packet")
+            remaining = length - len(data)
+            chunk_len = min(remaining, 58)
+            data.extend(r[6:6 + chunk_len])
+
+        return {"command": command, "length": length, "data": data}
+
+    # -- internal: B/C-command helpers (LCD packets) --
+
+    def _build_lcd_packet(self, cmd, total_size, pkt_num, payload):
+        """Build a B-command (1024-byte) or C-command (512-byte) LCD packet."""
+        if self._use_c_cmd:
+            report_id = _REPORT_ID_C
+            pkt_size = _REPORT_C_SIZE
+        else:
+            report_id = _REPORT_ID_B
+            pkt_size = _REPORT_B_SIZE
+
+        pkt = [0] * pkt_size
+        pkt[0] = report_id
+        pkt[1] = cmd
+
+        # total data size (big-endian u32)
+        pkt[2] = (total_size >> 24) & 0xFF
+        pkt[3] = (total_size >> 16) & 0xFF
+        pkt[4] = (total_size >> 8) & 0xFF
+        pkt[5] = total_size & 0xFF
+
+        # packet number (big-endian u24)
+        pkt[6] = (pkt_num >> 16) & 0xFF
+        pkt[7] = (pkt_num >> 8) & 0xFF
+        pkt[8] = pkt_num & 0xFF
+
+        # payload length this packet (big-endian u16)
+        pkt[9] = (len(payload) >> 8) & 0xFF
+        pkt[10] = len(payload) & 0xFF
+
+        # payload data
+        pkt[11:11 + len(payload)] = payload
+
+        return pkt
+
+    def _write_lcd_cmd(self, cmd, payload):
+        """Write a B/C-command with payload, splitting into appropriate chunks."""
+        if self._use_c_cmd:
+            max_payload = _C_CMD_MAX_PAYLOAD
+        else:
+            max_payload = _B_CMD_MAX_PAYLOAD
+
+        total_size = len(payload)
+        offset = 0
+        pkt_num = 0
+
+        while offset < total_size:
+            chunk = payload[offset:offset + max_payload]
+            pkt = self._build_lcd_packet(cmd, total_size, pkt_num, chunk)
+            self.device.write(pkt)
+            offset += len(chunk)
+            pkt_num += 1
+
+        # consume any response
+        try:
+            self.device.read(64, timeout=20)
+        except Exception:
+            pass
+
+    def _write_lcd_control_cmd(self, data):
+        """Write a B/C-command for LCD control (non-streaming)."""
+        if self._use_c_cmd:
+            report_id = _REPORT_ID_C
+            pkt_size = _REPORT_C_SIZE
+        else:
+            report_id = _REPORT_ID_B
+            pkt_size = _REPORT_B_SIZE
+
+        pkt = [0] * pkt_size
+        pkt[0] = report_id
+        pkt[1] = _CMD_LCD_CONTROL
+        # For control commands, total_size and pkt_num are 0
+        # payload length
+        pkt[9] = (len(data) >> 8) & 0xFF
+        pkt[10] = len(data) & 0xFF
+        pkt[11:11 + len(data)] = data
+        self.device.write(pkt)
+
+    # -- internal: device communication --
+
+    def _read_firmware_version(self):
+        """Read firmware version string from device."""
+        self._write_a_cmd(_CMD_GET_FIRMWARE)
+
+        # First response: version string
+        p1 = self._read_a_cmd()
+        p1_data = p1["data"][:p1["data"].index(0)] if 0 in p1["data"] else p1["data"]
+        version_str = bytes(p1_data).decode("ascii", errors="ignore").strip()
+
+        # Second response: date string (must be consumed)
+        try:
+            p2 = self._read_a_cmd()
+            p2_data = p2["data"][:p2["data"].index(0)] if 0 in p2["data"] else p2["data"]
+            date_str = bytes(p2_data).decode("ascii", errors="ignore").strip()
+            _LOGGER.debug("firmware date: %s", date_str)
+        except Exception:
+            pass
+
+        return version_str
+
+    def _get_handshake(self):
+        """Send handshake and parse RPM/temperature response."""
+        # Drop any stale reports left in the HID input queue (e.g. an LCD
+        # B/C-command response from a prior operation, or leftover bytes from
+        # firmware-version reads) so _read_a_cmd does not pick them up.
+        self.device.clear_enqueued_reports()
+        self._write_a_cmd(_CMD_HANDSHAKE)
+        r = self._read_a_cmd()
+
+        if r["command"] != _CMD_HANDSHAKE:
+            raise ValueError(f"unexpected handshake response: 0x{r['command']:02x}")
+
+        data = r["data"]
+        fan_rpm = int.from_bytes(data[0:2], byteorder="big")
+        pump_rpm = int.from_bytes(data[2:4], byteorder="big")
+
+        temperature = 0.0
+        if r["length"] >= 7 and data[4] != 0:
+            temperature = data[5] + (data[6] % 10) / 10.0
+
+        return {
+            "fan_rpm": fan_rpm,
+            "pump_rpm": pump_rpm,
+            "temperature": temperature,
+        }
+
+    # -- internal: LCD image sending --
+
+    def _encode_jpeg(self, image):
+        """Encode a PIL Image as JPEG bytes at the configured quality."""
+        buf = io.BytesIO()
+        image.save(buf, format="JPEG", quality=_JPEG_QUALITY, subsampling="4:2:0")
+        return buf.getvalue()
+
+    def _prepare_image(self, image_path):
+        """Load, resize, rotate, and encode an image as JPEG."""
+        img = Image.open(image_path)
+        img = img.convert("RGB")
+        img = img.resize((_LCD_WIDTH, _LCD_HEIGHT), Image.LANCZOS)
+        rotation = getattr(self, "_rotation", 0)
+        if rotation:
+            img = img.rotate(rotation, expand=False)
+        return self._encode_jpeg(img)
+
+    def _send_lcd_control(self, lcd_mode=_LCD_MODE_APPLICATION, brightness=50,
+                          rotation=0, fps=24):
+        """Send LCD control command to configure display mode."""
+        data = [0] * 8
+        data[0] = lcd_mode
+        data[1] = brightness
+        data[2] = rotation
+        data[7] = fps
+        self._write_lcd_control_cmd(data)
+
+    def _send_jpeg_frame(self, jpeg_data):
+        """Send a JPEG frame to the LCD."""
+        self._write_lcd_cmd(_CMD_SEND_JPEG, list(jpeg_data))
+
+    def _send_static_image(self, image_path):
+        """Send a static image to the LCD screen."""
+        _LOGGER.info("sending static image: %s", image_path)
+
+        # Switch to application mode
+        self._send_lcd_control(lcd_mode=_LCD_MODE_APPLICATION)
+
+        jpeg_data = self._prepare_image(image_path)
+        _LOGGER.debug("JPEG size: %d bytes", len(jpeg_data))
+
+        self._send_jpeg_frame(jpeg_data)
+
+    def _send_gif(self, gif_path):
+        """Send GIF frames to the LCD screen.
+
+        Sends the first frame as a static image. For continuous animation,
+        a daemon process would be needed to loop frames at the target FPS.
+        """
+        _LOGGER.info("sending GIF: %s", gif_path)
+
+        self._send_lcd_control(lcd_mode=_LCD_MODE_APPLICATION, fps=24)
+
+        img = Image.open(gif_path)
+        frame = img.convert("RGB").resize((_LCD_WIDTH, _LCD_HEIGHT), Image.LANCZOS)
+        jpeg_data = self._encode_jpeg(frame)
+        self._send_jpeg_frame(jpeg_data)
+
+        n_frames = getattr(img, "n_frames", 1)
+        if n_frames > 1:
+            _LOGGER.info(
+                "GIF has %d frames; only the first frame was sent. "
+                "Use an external loop to animate.",
+                n_frames,
+            )

--- a/liquidctl/driver/hydroshift_lcd.py
+++ b/liquidctl/driver/hydroshift_lcd.py
@@ -14,6 +14,8 @@ import io
 import logging
 import math
 import re
+import subprocess
+import time
 
 from PIL import Image, ImageSequence
 
@@ -304,13 +306,17 @@ class HydroShiftLCD(UsbHidDriver):
         elif mode == "gif":
             self._send_gif(value)
 
+        elif mode == "video":
+            self._send_video(value)
+
         elif mode == "lcd":
             self._send_lcd_control(lcd_mode=_LCD_MODE_APPLICATION)
 
         else:
             raise ValueError(
                 f"unknown screen mode: {mode}, "
-                f"should be one of: 'static', 'gif', 'brightness', 'orientation', 'lcd'"
+                f"should be one of: 'static', 'gif', 'video', 'brightness', "
+                f"'orientation', 'lcd'"
             )
 
     def disconnect(self, **kwargs):
@@ -546,24 +552,105 @@ class HydroShiftLCD(UsbHidDriver):
         self._send_jpeg_frame(jpeg_data)
 
     def _send_gif(self, gif_path):
-        """Send GIF frames to the LCD screen.
+        """Send GIF frames to the LCD screen in a loop.
 
-        Sends the first frame as a static image. For continuous animation,
-        a daemon process would be needed to loop frames at the target FPS.
+        Loops continuously until interrupted (Ctrl+C).
         """
         _LOGGER.info("sending GIF: %s", gif_path)
 
         self._send_lcd_control(lcd_mode=_LCD_MODE_APPLICATION, fps=24)
 
         img = Image.open(gif_path)
-        frame = img.convert("RGB").resize((_LCD_WIDTH, _LCD_HEIGHT), Image.LANCZOS)
-        jpeg_data = self._encode_jpeg(frame)
-        self._send_jpeg_frame(jpeg_data)
-
         n_frames = getattr(img, "n_frames", 1)
-        if n_frames > 1:
-            _LOGGER.info(
-                "GIF has %d frames; only the first frame was sent. "
-                "Use an external loop to animate.",
-                n_frames,
-            )
+
+        # Pre-encode all frames as JPEG
+        rotation = getattr(self, "_rotation", 0)
+        frames = []
+        for i in range(n_frames):
+            img.seek(i)
+            frame = img.convert("RGB").resize((_LCD_WIDTH, _LCD_HEIGHT), Image.LANCZOS)
+            if rotation:
+                frame = frame.rotate(rotation, expand=False)
+            frames.append(self._encode_jpeg(frame))
+
+        if n_frames == 1:
+            self._send_jpeg_frame(frames[0])
+            return
+
+        # Get frame duration from GIF (default 40ms = 25fps)
+        duration_ms = img.info.get("duration", 40)
+        frame_interval = max(duration_ms / 1000.0, 1.0 / 30)
+
+        _LOGGER.info("GIF: %d frames, %.0fms interval, looping", n_frames, duration_ms)
+        try:
+            while True:
+                for jpeg_data in frames:
+                    start = time.monotonic()
+                    self._send_jpeg_frame(jpeg_data)
+                    elapsed = time.monotonic() - start
+                    sleep_time = frame_interval - elapsed
+                    if sleep_time > 0:
+                        time.sleep(sleep_time)
+        except KeyboardInterrupt:
+            _LOGGER.info("GIF playback stopped")
+
+    def _send_video(self, video_path):
+        """Stream video frames to the LCD screen in a loop.
+
+        Uses ffmpeg to decode the video. Loops continuously until
+        interrupted (Ctrl+C).
+        """
+        _LOGGER.info("streaming video: %s", video_path)
+
+        self._send_lcd_control(lcd_mode=_LCD_MODE_APPLICATION, fps=24)
+
+        rotation = getattr(self, "_rotation", 0)
+        vf_parts = [f"scale={_LCD_WIDTH}:{_LCD_HEIGHT}", "fps=24"]
+        if rotation == 90:
+            vf_parts.append("transpose=2")
+        elif rotation == 180:
+            vf_parts.append("transpose=1,transpose=1")
+        elif rotation == 270:
+            vf_parts.append("transpose=1")
+        vf = ",".join(vf_parts)
+
+        frame_size = _LCD_WIDTH * _LCD_HEIGHT * 3
+        frame_interval = 1.0 / 24
+
+        try:
+            while True:
+                proc = subprocess.Popen(
+                    [
+                        "ffmpeg", "-i", video_path,
+                        "-vf", vf,
+                        "-pix_fmt", "rgb24",
+                        "-f", "rawvideo",
+                        "-v", "quiet",
+                        "-",
+                    ],
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.DEVNULL,
+                )
+
+                try:
+                    while True:
+                        start = time.monotonic()
+                        raw = proc.stdout.read(frame_size)
+                        if len(raw) < frame_size:
+                            break
+
+                        img = Image.frombytes("RGB", (_LCD_WIDTH, _LCD_HEIGHT), raw)
+                        jpeg_data = self._encode_jpeg(img)
+                        self._send_jpeg_frame(jpeg_data)
+
+                        elapsed = time.monotonic() - start
+                        sleep_time = frame_interval - elapsed
+                        if sleep_time > 0:
+                            time.sleep(sleep_time)
+                finally:
+                    proc.terminate()
+                    proc.wait()
+
+                _LOGGER.debug("video loop restart")
+        except KeyboardInterrupt:
+            _LOGGER.info("video playback stopped")

--- a/liquidctl/driver/hydroshift_lcd.py
+++ b/liquidctl/driver/hydroshift_lcd.py
@@ -21,6 +21,7 @@ from PIL import Image, ImageSequence
 
 from liquidctl.driver.usb import UsbHidDriver
 from liquidctl.error import NotSupportedByDevice, NotSupportedByDriver
+from liquidctl.keyval import RuntimeStorage
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -154,6 +155,16 @@ class HydroShiftLCD(UsbHidDriver):
         ),
     ]
 
+    def connect(self, runtime_storage=None, **kwargs):
+        ret = super().connect(**kwargs)
+        if runtime_storage:
+            self._data = runtime_storage
+        else:
+            ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
+            loc = f'bus{self.bus}_address{self.address}'
+            self._data = RuntimeStorage(key_prefixes=[ids, loc])
+        return ret
+
     def initialize(self, direct_access=False, **kwargs):
         """Initialize the device and return firmware version and status.
 
@@ -161,7 +172,7 @@ class HydroShiftLCD(UsbHidDriver):
         firmware version and initial sensor readings.
         """
         self.device.clear_enqueued_reports()
-        self._rotation = 0
+        self._rotation = self._data.load('rotation', of_type=int, default=0)
 
         fw_version = self._read_firmware_version()
         _LOGGER.info("firmware version: %s", fw_version)
@@ -278,6 +289,11 @@ class HydroShiftLCD(UsbHidDriver):
             orientation <0|90|180|270> -- set LCD rotation
             lcd -- switch to application (streaming) mode
         """
+        if not hasattr(self, "_use_c_cmd"):
+            self._use_c_cmd = False
+        if not hasattr(self, "_rotation"):
+            self._rotation = self._data.load('rotation', of_type=int, default=0)
+
         if channel != "lcd":
             raise NotSupportedByDevice(
                 f"screen control for {channel} is not supported, use 'lcd'"
@@ -298,6 +314,7 @@ class HydroShiftLCD(UsbHidDriver):
                     f"should be one of: {_quoted(*_LCD_ROTATIONS)}"
                 )
             self._rotation = rotation
+            self._data.store('rotation', rotation)
             _LOGGER.info("LCD rotation set to %d degrees (applied on next image send)", rotation)
 
         elif mode == "static":

--- a/liquidctl/driver/hydroshift_lcd.py
+++ b/liquidctl/driver/hydroshift_lcd.py
@@ -161,7 +161,7 @@ class HydroShiftLCD(UsbHidDriver):
             self._data = runtime_storage
         else:
             ids = f'vid{self.vendor_id:04x}_pid{self.product_id:04x}'
-            loc = f'bus{self.bus}_address{self.address}'
+            loc = 'loc' + '_'.join(re.findall(r'\d+', self.address))
             self._data = RuntimeStorage(key_prefixes=[ids, loc])
         return ret
 

--- a/tests/test_hydroshift_lcd.py
+++ b/tests/test_hydroshift_lcd.py
@@ -1,0 +1,253 @@
+import pytest
+from _testutils import MockHidapiDevice, Report
+
+from liquidctl.error import NotSupportedByDevice, NotSupportedByDriver
+from liquidctl.driver.hydroshift_lcd import HydroShiftLCD
+
+
+@pytest.fixture
+def mockHydroShift():
+    device = MockHidapiDevice(vendor_id=0x0416, product_id=0x7398, address="addr")
+    dev = HydroShiftLCD(device, "mock HydroShift LCD 360S")
+    dev.connect()
+    return dev
+
+
+# -- firmware version response packets (64 bytes each) --
+# Part 1: "N9,01,HS,SQ,HydroShift,V3.0C.013,1.3" (36 bytes, data_len=0x24)
+_FW_REPORT_PART1 = bytes.fromhex(
+    "0186000000244e392c30312c48532c53512c487964726f53686966742c56332e"
+    "30432e3031332c312e3300000000000000000000000000000000000000000000"
+)
+
+# Part 2: "Oct 22 2024,10:39:15" (20 bytes, data_len=0x14, pkt_num=1)
+_FW_REPORT_PART2 = bytes.fromhex(
+    "0186000001144f637420323220323032342c31303a33393a313500000000000000"
+    "000000000000000000000000000000000000000000000000000000000000000000"
+)[:64]
+
+# Handshake response: fan_rpm=1440 (0x05A0), pump_rpm=2670 (0x0A6E),
+# temp_valid=1, temp_int=37 (0x25), temp_frac=8 -> 37.8C
+_STATUS_REPORT = bytes.fromhex(
+    "01810000000705a00a6e01250800000000000000000000000000000000000000"
+    "0000000000000000000000000000000000000000000000000000000000000000"
+)
+
+
+def _preload_fw_and_status(dev):
+    """Preload firmware + handshake responses for initialize()."""
+    dev.device.preload_read(Report(0, _FW_REPORT_PART1))
+    dev.device.preload_read(Report(0, _FW_REPORT_PART2))
+    dev.device.preload_read(Report(0, _STATUS_REPORT))
+
+
+def test_initialize(mockHydroShift):
+    _preload_fw_and_status(mockHydroShift)
+    status = mockHydroShift.initialize()
+
+    # Should have sent firmware query (0x86) and handshake (0x81)
+    assert len(mockHydroShift.device.sent) == 2
+    assert mockHydroShift.device.sent[0].data[0] == 0x86  # firmware query
+    assert mockHydroShift.device.sent[1].data[0] == 0x81  # handshake
+
+    # Check firmware version in status
+    fw_entries = [s for s in status if s[0] == "Firmware version"]
+    assert len(fw_entries) == 1
+
+    # Check that C-command mode was detected (version 1.3 >= 1.2)
+    assert mockHydroShift._use_c_cmd is True
+
+
+def test_initialize_old_firmware(mockHydroShift):
+    # Firmware version "1.1" -> should NOT use C-command
+    fw_v1_1 = bytearray(64)
+    fw_v1_1[0] = 0x01
+    fw_v1_1[1] = 0x86
+    fw_v1_1[5] = 3
+    fw_v1_1[6:9] = b"1.1"
+
+    fw_date = bytearray(64)
+    fw_date[0] = 0x01
+    fw_date[1] = 0x86
+    fw_date[3] = 0x00
+    fw_date[4] = 0x01
+    fw_date[5] = 4
+    fw_date[6:10] = b"date"
+
+    mockHydroShift.device.preload_read(Report(0, bytes(fw_v1_1)))
+    mockHydroShift.device.preload_read(Report(0, bytes(fw_date)))
+    mockHydroShift.device.preload_read(Report(0, _STATUS_REPORT))
+    mockHydroShift.initialize()
+
+    assert mockHydroShift._use_c_cmd is False
+
+
+def test_get_status(mockHydroShift):
+    mockHydroShift._use_c_cmd = False
+    mockHydroShift.device.preload_read(Report(0, _STATUS_REPORT))
+    status = mockHydroShift.get_status()
+
+    assert len(status) == 5
+
+    temp = [s for s in status if s[0] == "Liquid temperature"][0]
+    assert temp[1] == 37.8
+
+    fan = [s for s in status if s[0] == "Fan speed"][0]
+    assert fan[1] == 1440
+
+    pump = [s for s in status if s[0] == "Pump speed"][0]
+    assert pump[1] == 2670
+
+
+def test_get_handshake_drops_stale_reports(mockHydroShift):
+    # Regression: a leftover B/C-command response (report ID 0x02) sitting in
+    # the HID input queue from a prior LCD operation must not be read in place
+    # of the handshake reply, otherwise _read_a_cmd raises
+    # ValueError('unexpected report ID: 0x02').
+    mockHydroShift._use_c_cmd = False
+
+    # Wire the mock's clear_enqueued_reports to actually drain the read queue.
+    mockHydroShift.device.clear_enqueued_reports = mockHydroShift.device._read.clear
+
+    # Stale report (B-command response, report ID 0x02) sitting in the queue.
+    stale = bytearray(64)
+    stale[0] = 0x02
+    mockHydroShift.device.preload_read(Report(0, bytes(stale)))
+
+    # Real handshake reply lands only after the handshake write goes out.
+    real_write = mockHydroShift.device.write
+    def write_then_respond(data):
+        result = real_write(data)
+        if data[1] == 0x81:  # _CMD_HANDSHAKE
+            mockHydroShift.device.preload_read(Report(0, _STATUS_REPORT))
+        return result
+    mockHydroShift.device.write = write_then_respond
+
+    handshake = mockHydroShift._get_handshake()
+
+    assert handshake["fan_rpm"] == 1440
+    assert handshake["pump_rpm"] == 2670
+    assert handshake["temperature"] == 37.8
+
+
+def test_set_fan_speed(mockHydroShift):
+    mockHydroShift.set_fixed_speed(channel="fan", duty=50)
+    report = mockHydroShift.device.sent[0]
+    # Mock write stores Report(data[0], data[1:])
+    # So report[0] = report.number = pkt[0] (report ID)
+    #    report.data[N] = pkt[N+1]
+    assert report[0] == 0x01       # report ID
+    assert report.data[0] == 0x8B  # command byte (pkt[1])
+    assert report.data[4] == 0x02  # data_len=2 (pkt[5])
+    assert report.data[5] == 0x00  # first data byte (pkt[6])
+    assert report.data[6] == 50    # PWM duty (pkt[7])
+
+
+def test_set_pump_speed(mockHydroShift):
+    mockHydroShift.set_fixed_speed(channel="pump", duty=75)
+    report = mockHydroShift.device.sent[0]
+    assert report[0] == 0x01
+    assert report.data[0] == 0x8A  # pump PWM command
+    assert report.data[6] == 75
+
+
+def test_set_speed_clamped(mockHydroShift):
+    mockHydroShift.set_fixed_speed(channel="fan", duty=150)
+    report = mockHydroShift.device.sent[0]
+    assert report.data[6] == 100
+
+    mockHydroShift.device.sent.clear()
+    mockHydroShift.set_fixed_speed(channel="fan", duty=-10)
+    report = mockHydroShift.device.sent[0]
+    assert report.data[6] == 0
+
+
+def test_set_speed_invalid_channel(mockHydroShift):
+    with pytest.raises(NotSupportedByDevice):
+        mockHydroShift.set_fixed_speed(channel="invalid", duty=50)
+
+
+def test_set_color_fan(mockHydroShift):
+    mockHydroShift.set_color(
+        channel="fan",
+        mode="static",
+        colors=[(0xFF, 0x00, 0x00), (0x00, 0xFF, 0x00)],
+        speed="normal",
+        direction="forward",
+    )
+    report = mockHydroShift.device.sent[0]
+    assert report[0] == 0x01
+    assert report.data[0] == 0x85  # fan light command (pkt[1])
+    # report.data[5..24] = req[0..19] (the 20-byte payload starts at pkt[6])
+    assert report.data[5] == 0x03  # static mode (req[0])
+    assert report.data[6] == 0x04  # brightness max (req[1])
+    assert report.data[7] == 0x02  # normal speed (req[2])
+
+    # color 1: red (req[3:6])
+    assert report.data[8] == 0xFF
+    assert report.data[9] == 0x00
+    assert report.data[10] == 0x00
+
+    # color 2: green (req[6:9])
+    assert report.data[11] == 0x00
+    assert report.data[12] == 0xFF
+    assert report.data[13] == 0x00
+
+    assert report.data[24] == 24  # LED count (req[19])
+
+
+def test_set_color_invalid_channel(mockHydroShift):
+    with pytest.raises(NotSupportedByDevice):
+        mockHydroShift.set_color(channel="pump", mode="static", colors=[(255, 0, 0)])
+
+
+def test_set_color_invalid_mode(mockHydroShift):
+    with pytest.raises(ValueError, match="unknown lighting mode"):
+        mockHydroShift.set_color(channel="fan", mode="nonexistent", colors=[(255, 0, 0)])
+
+
+def test_speed_profile_not_supported(mockHydroShift):
+    with pytest.raises(NotSupportedByDevice):
+        mockHydroShift.set_speed_profile(channel="fan", profile=[(20, 30), (30, 50)])
+
+
+def test_set_screen_invalid_channel(mockHydroShift):
+    mockHydroShift._use_c_cmd = False
+    with pytest.raises(NotSupportedByDevice):
+        mockHydroShift.set_screen(channel="invalid", mode="brightness", value=50)
+
+
+def test_set_screen_brightness(mockHydroShift):
+    mockHydroShift._use_c_cmd = False
+    mockHydroShift.set_screen(channel="lcd", mode="brightness", value=80)
+    report = mockHydroShift.device.sent[0]
+    # B-command: report.number = 0x02, report.data = pkt[1:]
+    # pkt layout: [0x02, 0x0C, 0,0,0,0, 0,0,0, 0x00, 0x08, <8 bytes payload>]
+    #   pkt[0]=report_id, pkt[1]=cmd, pkt[2:6]=total_size, pkt[6:9]=pkt_num
+    #   pkt[9:11]=payload_len, pkt[11:19]=payload
+    # payload = [lcd_mode=1, brightness=80, rotation=0, 0, 0, 0, 0, fps=24]
+    assert report[0] == 0x02       # B-command report ID
+    assert report.data[0] == 0x0C  # LCD control command (pkt[1])
+    assert report.data[10] == 1    # lcd_mode = APPLICATION (pkt[11])
+    assert report.data[11] == 80   # brightness (pkt[12])
+
+
+def test_set_screen_orientation(mockHydroShift):
+    mockHydroShift._use_c_cmd = False
+    mockHydroShift._rotation = 0
+    mockHydroShift.set_screen(channel="lcd", mode="orientation", value=90)
+    # Orientation is stored and applied client-side when sending images
+    assert mockHydroShift._rotation == 90
+    assert len(mockHydroShift.device.sent) == 0  # no packet sent
+
+
+def test_set_screen_invalid_orientation(mockHydroShift):
+    mockHydroShift._use_c_cmd = False
+    with pytest.raises(ValueError, match="unsupported rotation"):
+        mockHydroShift.set_screen(channel="lcd", mode="orientation", value=45)
+
+
+def test_set_screen_invalid_mode(mockHydroShift):
+    mockHydroShift._use_c_cmd = False
+    with pytest.raises(ValueError, match="unknown screen mode"):
+        mockHydroShift.set_screen(channel="lcd", mode="nonexistent", value=None)


### PR DESCRIPTION
Adds a `HydroShiftLCD` driver for the Lian Li HydroShift LCD AIO family — 360S (`0416:7398`), RGB (`0416:7399`) and TL (`0416:739a`). The pump houses a 480x480 round LCD that L-Connect 3 drives over USB HID; this driver implements the same protocol on Linux.

## Overview of the implementation

- HID protocol uses three report types: report A (64 B, control), report B (1024 B, bulk LCD writes for older firmware), report C (512 B, bulk LCD writes for firmware ≥ 1.2).
- `initialize` performs a handshake, reads the firmware version, and selects A/B-only or A/B/C transport based on the parsed firmware string (`V3.0B.02C,0.7` / `V3.0C.013,1.3`).
- `get_status` reports liquid temperature, pump RPM/duty, and fan RPM/duty.
- `set_color` drives the fan-ring LEDs (15 modes, up to four RGB colors, configurable speed and direction).
- `set_screen` accepts `static`/`gif`/`video`. Static images are JPEG-encoded at quality 85; GIFs and videos are streamed frame-by-frame at 24 fps with client-side rotation persisted via `RuntimeStorage` so the orientation survives across invocations. Video decoding is delegated to `ffmpeg` via `subprocess`.
- `set_speed_profile` raises `NotSupportedByDevice` — the AIO firmware owns the curves, only fixed duties are settable from host.

Tested on real hardware (HydroShift LCD 360S, firmware 0.7 and 1.3) on Arch Linux. The RGB and TL variants are listed in `_MATCHES` based on Lian Li's product line but I have not personally verified them; happy to drop them from this PR if maintainers prefer to wait for confirmation.

## What's included

- `liquidctl/driver/hydroshift_lcd.py` — the driver
- `liquidctl/driver/__init__.py` — registration
- `tests/test_hydroshift_lcd.py` — 16 unit tests covering initialize/status, color, screen modes, firmware parsing, and rotation persistence (full suite: 533 passed, 2 pre-existing skips)
- `README.md` — supported-devices entry, linked to the new guide
- `docs/lian-li-hydroshift-guide.md` — device guide
- `docs/developer/protocol/lian_li_hydroshift.md` — HID protocol writeup
- `liquidctl.8` — man page entry
- `extra/linux/71-liquidctl.rules` — regenerated via `generate-uaccess-udev-rules.py`

Captured `lsusb` plus `liquidctl --debug` traces for initialize/status/set-speed/set-color/set-lcd are submitted as liquidctl/collected-device-data#20.

## Follow-ups

- Pump-head lighting (`0x83`) is documented in the protocol doc by analogy with the fan lighting frame and the GA II LCD, but byte layout still needs USB capture to confirm; will follow up.

---

Checklist:

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [x] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [x] `liquidctl.8` Linux/Unix/Mac OS man page
    - [x] protocol documentation in `docs/developer/protocol`
- [x] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data — liquidctl/collected-device-data#20

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules`
- [x] Add entry to the README's supported device list with applicable notes and `git` MRLV

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes