### PR TITLE
Added support for Corsair Hydro H100i RGB PRO XT (0x0c2d)

### DIFF
--- a/liquidctl/driver/hydro_platinum.py
+++ b/liquidctl/driver/hydro_platinum.py
@@ -12,6 +12,7 @@ Supported devices:
 - Corsair iCUE H100i Elite RGB
 - Corsair iCUE H115i Elite RGB
 - Corsair iCUE H150i Elite RGB
+- Corsair Hydro H100i RGB PRO XT
 
 Copyright Jonas Malaco and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
@@ -125,6 +126,8 @@ class HydroPlatinum(UsbHidDriver):
             {'fan_count': 2, 'fan_leds': 0}),
         (0x1b1c, 0x0c20, 'Corsair Hydro H100i Pro XT',
             {'fan_count': 2, 'fan_leds': 0}),
+        (0x1b1c, 0x0c2d, 'Corsair Hydro H100i RGB PRO XT',
+            {'fan_count': 2, 'fan_leds': 16}),  # fan_leds: 16 for RGB variant
         (0x1b1c, 0x0c21, 'Corsair Hydro H115i Pro XT',
             {'fan_count': 2, 'fan_leds': 0}),
         (0x1b1c, 0x0c22, 'Corsair Hydro H150i Pro XT',


### PR DESCRIPTION
Adds support for Corsair Hydro H100i RGB Pro XT

I have this cooler in my server. I added this change to enable liquidctl to work on my Proxmox server. The fans on the H100i were running at 85% pretty much all the time. After adding, i was able to add a fan curve that dropped the fan speeds down considerably to 49%:

~$ sudo /opt/liquidctl-venv/bin/liquidctl status
Corsair Hydro H100i RGB PRO XT
├── Liquid temperature    29.4  °C
├── Fan 1 speed           1363  rpm
├── Fan 1 duty              49  %
├── Fan 2 speed           1320  rpm
├── Fan 2 duty              49  %
├── Pump speed            2420  rpm
└── Pump duty               75  %

Other Information:
USB vendor/product ID: 1b1c:0c2d
Firmware version: 2.0.9
I think this AIO cooler has 16 total fan LEDS but I don't remember, I used to have it in a desktop years ago. Since they're in a server now they're inactive.

If the implementation is not trivial, please also include a short overview.

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: <!-- #number of issue (implies Closes tag) or commit SHA -->
Closes:
Related: #442  

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [ ] Adhere to the [development process]
- [ ] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [ ] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [ ] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
