### PR TITLE
kraken_z: pass vid/pid to list_usb_devices in _find_winusb_device

### DIFF
--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -659,7 +659,7 @@ class KrakenZ3(KrakenX3):
 
     def _find_winusb_device(self, vid, pid, serial):
         winusb_devices = self.bulk_device.list_usb_devices(
-            deviceinterface=True, present=True, findparent=True
+            deviceinterface=True, present=True, findparent=True, vid=vid, pid=pid
         )
         for device in winusb_devices:
             if (


### PR DESCRIPTION
## Summary

On Windows, ` winusbcdc.WinUsbPy.list_usb_devices()` silently returns 0 results when called **without** `vid`/`pid` filters — even for a Kraken Z whose bulk-out interface is correctly bound to the WinUSB driver. As a result `KrakenZ3._find_winusb_device` sets `self.bulk_device = None`, and any subsequent `set lcd screen static|gif` call asserts with:

```
AssertionError: Cannot find bulk out device
```

Passing `vid`/`pid` (which the function already has on hand) into the `list_usb_devices()` call lets winusbcdc enumerate and return the device. One-line change.

## Reproduction

- Hardware: NZXT Kraken Z63 (Z53/Z63/Z73 family), USB `1E71:3008`
- OS: Windows 10 Pro 19045
- Python 3.10.4, liquidctl 1.16.0, winusbcdc 1.7
- WinUSB driver bound via prior NZXT CAM install (the device's `Device Parameters\DeviceInterfaceGUIDS` contains an NZXT-custom GUID rather than the standard WinUSB GUID — but the standard WinUSB device interface IS exposed; that part was a red herring during diagnosis).
- HID-side commands (`brightness`, `orientation`, `liquid` mode) work fine. Only the bulk-transfer path (`static`, `gif`) fails.

Pre-patch:
```
> liquidctl --match kraken set lcd screen gif <path>
ERROR: NZXT Kraken Z (Z53, Z63 or Z73): unexpected error: AssertionError('Cannot find bulk out device')
```

Post-patch: image/gif uploads succeed, LCD displays the content.

Verified the underlying enumeration behavior directly:
```python
>>> w.list_usb_devices(deviceinterface=True, present=True, findparent=True)
[]                                                            # <-- bug
>>> w.list_usb_devices(deviceinterface=True, present=True, findparent=True, vid=0x1E71, pid=0x3008)
[<one device>]                                                # <-- with this PR
```

## Possibly related issues

- #444 — LCD screen on NZXT Kraken Z coolers (general thread)
- #516 — Kraken Z73 not working console lcd command
- #657 — Unable to upload any type of image/gif to Kraken Elite

## Test plan

- [x] `set lcd screen gif <path>` succeeds on Kraken Z63 / Windows 10
- [x] HID-only commands (`brightness`, `orientation`, `liquid`, `status`) still work post-patch (the change is additive — vid/pid filters can only narrow results, never break the existing path)
- [ ] Confirmation on Kraken Z53 / Z73 by other users (encouraged but I only have a Z63)
- [ ] Confirmation that Linux path is unaffected (the change is inside the `sys.platform == "win32"` branch via `_find_winusb_device`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)