### PR TITLE
Add ASUS Aura 0x1B29 controller support

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | AIO liquid cooler  | [NZXT Kraken 2023 Standard, Elite](docs/kraken-x3-z3-guide.md) | p | 1.14.0 |
 | AIO liquid cooler  | [NZXT Kraken 2024 Elite RGB](docs/kraken-x3-z3-guide.md) | p | 1.15.0 |
 | AIO liquid cooler  | [NZXT Kraken 2024 Plus](docs/kraken-x3-z3-guide.md) | | 1.16.0 |
+| AIO liquid cooler RGB | [ASUS ROG Strix LC III 360](docs/asus-aura-led-guide.md) | p | git |
 | Pump controller    | [Aquacomputer D5 Next](docs/aquacomputer-d5next-guide.md) | hp | 1.15.0 |
 | Fan/LED controller | [Aquacomputer Farbwerk](docs/aquacomputer-farbwerk-guide.md) | hp | 1.16.0 |
 | Fan/LED controller | [Aquacomputer Farbwerk 360](docs/aquacomputer-farbwerk360-guide.md) | hp | 1.15.0 |

--- a/docs/asus-aura-led-guide.md
+++ b/docs/asus-aura-led-guide.md
@@ -2,6 +2,7 @@
 _Driver API and source code available in [`liquidctl.driver.aura_led`](../liquidctl/driver/aura_led.py)._
 
 _New in 1.10.0._<br>
+_Changed in git: add support for the `0x1B29` controller used by ASUS ROG Strix LC III 360 liquid coolers._<br>
 
 This driver supports ASUS Aura USB-based lighting controllers that appear in various ASUS Z490, Z590, and Z690 motherboards. These controllers operate in either (a) direct mode or (b) effect mode. _Direct_ mode is employed by Aura Crate in Windows. It requires the application to send a continuous stream of commands to the controller in order to modulate lighting effects on each addressable LED. The other mode is _effect_ mode in which the controller itself modulates lighting effects on each addressable LED. Effect mode requires the application to issue a single set of command codes to the controller in order to initiate the given effect. The controller continues to process that effect until the application sends a different command.
 
@@ -9,13 +10,14 @@ This driver employs the _effect_ mode (fire and forget). The selected lighting m
 
 The disadvantage, however, is the inability to set different lighting modes to different lighting channels. All channels remain synchronized.
 
-There are three known variants of the Aura LED USB-based controller:
+There are four known variants of the Aura LED USB-based controller:
 
 - Device `0x19AF`: found in ASUS ProArt Z690-Creator WiFi
 - Device `0x1939` [^1]
 - Device `0x18F3`[^1]: found in ASUS ROG Maximus Z690 Formula
+- Device `0x1B29`[^1]: found in ASUS ROG Strix LC III 360 liquid coolers
 
-[^1]: Support for devices `0x1939` and `0x18F3` may not be sufficiently developed so users are asked to experiment and provide feedback. [Wireshark USB traffic capture](./developer/capturing-usb-traffic.md), in particular, will be very helpful.
+[^1]: Support for devices `0x1939`, `0x18F3` and `0x1B29` may not be sufficiently developed so users are asked to experiment and provide feedback. [Wireshark USB traffic capture](./developer/capturing-usb-traffic.md), in particular, will be very helpful.
 
 
 ## Initialization

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -334,6 +334,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1939", TAG+="uacc
 # ASUS Aura LED Controller
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="18f3", TAG+="uaccess"
 
+# ASUS Aura LED Controller
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1b29", TAG+="uaccess"
+
 # ASUS Ryujin II 360
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="0b05", ATTRS{idProduct}=="1988", TAG+="uaccess"
 

--- a/liquidctl/driver/aura_led.py
+++ b/liquidctl/driver/aura_led.py
@@ -10,6 +10,7 @@ Additional controllers (requires user testing and feedback):
 
 - idVendor=0x0B05, idProduct=0x1939
 - idVendor=0x0B05, idProduct=0x18F3
+- idVendor=0x0B05, idProduct=0x1B29
 
 These controllers have not been sufficiently tested. Users are asked to test and
 report issues.
@@ -135,14 +136,15 @@ class AuraLed(UsbHidDriver):
     liquidctl driver for ASUS Aura LED USB controllers.
     This driver only supports 'effect' mode, hence no speed/color channels
 
-    Devices 0x1939 and 0x18F3 are not fully supported at this time; users are asked
-    to experiment with this driver and provide feedback
+    Devices 0x1939, 0x18F3 and 0x1B29 are not fully supported at this time; users
+    are asked to experiment with this driver and provide feedback
     """
 
     _MATCHES = [
         (0x0B05, 0x19AF, "ASUS Aura LED Controller", {}),
         (0x0B05, 0x1939, "ASUS Aura LED Controller", {}),
         (0x0B05, 0x18F3, "ASUS Aura LED Controller", {}),
+        (0x0B05, 0x1B29, "ASUS Aura LED Controller", {}),
     ]
 
     def initialize(self, **kwargs):

--- a/tests/test_aura_led.py
+++ b/tests/test_aura_led.py
@@ -25,6 +25,12 @@ def mockAuraLed_19AFDevice():
     return dev
 
 
+def test_aura_led_matches_1B29_device():
+    matches = {(vid, pid) for vid, pid, _desc, _kwargs in AuraLed._MATCHES}
+
+    assert (0x0B05, 0x1B29) in matches
+
+
 def test_aura_led_19AF_device_command_format(mockAuraLed_19AFDevice):
     mockAuraLed_19AFDevice.device.preload_read(_INIT_19AF_FIRMWARE)
     mockAuraLed_19AFDevice.device.preload_read(_INIT_19AF_CONFIG)


### PR DESCRIPTION
Adds USB PID `0x1B29` to the existing ASUS Aura LED driver.

This controller is found as the RGB lighting controller in ASUS ROG Strix LC III 360 liquid coolers. I verified it on real hardware where it enumerates as:

- vendor/product: `0b05:1b29`
- hidraw address: `/dev/hidraw1`
- firmware reported by `liquidctl initialize`: `ALCA3-AR32-0102`
- status reported by `liquidctl status`: `1` ARGB channel and `1` RGB channel

The existing Aura LED effect-mode commands work for the device in my setup:

```console
# liquidctl --product 1b29 initialize
ASUS Aura LED Controller
└── Firmware version    ALCA3-AR32-0102

# liquidctl --product 1b29 status
ASUS Aura LED Controller
├── ARGB channels: 1
└──  RGB channels: 1

# liquidctl --product 1b29 set sync color off
# liquidctl --product 1b29 set sync color static 000000
```

This also updates the ASUS Aura LED guide, README supported-device table, udev rules, and adds a focused test that the new PID is matched by the driver.

Related: https://github.com/liquidctl/liquidctl/issues?q=1b29

---

Checklist:

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [x] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

Focused validation run locally:

```console
$ python3 -m pytest tests/test_aura_led.py
10 passed in 0.05s
```

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
