### PR TITLE
feature: add support for Corsair Commander Duo (ARGB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | Fan/LED controller | [Aquacomputer Quadro](docs/aquacomputer-quadro-guide.md) | hp | 1.15.0 |
 | Fan/LED controller | [Corsair Commander Pro](docs/corsair-commander-guide.md) | h | 1.11.1 |
 | Fan/LED controller | [Corsair Commander Core, Core XT, ST](docs/corsair-commander-core-guide.md) | Bp | 1.14.0 |
+| Fan/LED controller | [Corsair Commander DUO](docs/corsair-commander-duo-guide.md) | p | git |
 | Fan/LED controller | [Corsair Lighting Node Core, Pro](docs/corsair-commander-guide.md) | | 1.8.1 |
 | Fan/LED controller | [Corsair Obsidian 1000D](docs/corsair-commander-guide.md) | | 1.9.1 |
 | Fan/LED controller | [Lian Li Uni SL, SL v2, AL, AL v2, SL-Infinity](docs/lianli-uni-guide.md) | | 1.16.0 |

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,6 +23,7 @@ Device guides
 - [Asetek 690LC liquid coolers](asetek-690lc-guide.md)
 - [Asetek Pro liquid coolers](asetek-pro-guide.md)
 - [Corsair Commander Core and Core XT](corsair-commander-core-guide.md)
+- [Corsair Commander DUO](corsair-commander-duo-guide.md)
 - [Corsair Commander Pro, Obsidian 1000D and Lighting Node Pro/Core](corsair-commander-guide.md)
 - [Corsair HXi and RMi series PSUs](corsair-hxi-rmi-psu-guide.md)
 - [Corsair Hydro Platinum, Pro XT and Elite RGB all-in-one liquidctl coolers](corsair-platinum-pro-xt-guide.md)

--- a/docs/corsair-commander-duo-guide.md
+++ b/docs/corsair-commander-duo-guide.md
@@ -1,0 +1,127 @@
+# Corsair Commander DUO
+_Driver API available in [`liquidctl.driver.commander_duo`](../liquidctl/driver/commander_duo.py)._
+
+_New in git._<br>
+
+The Corsair Commander DUO is a USB HID fan, temperature, and ARGB controller
+with two PWM fan ports, two temperature-probe ports, and two ARGB lighting
+ports.
+
+This driver is for the Commander DUO's PWM fan and standard 5 V ARGB ports. It
+does not support Corsair iCUE LINK devices or the iCUE LINK ecosystem.
+
+The currently supported functionality is documented below.
+
+Firmware `0.10.112` or later is required.  Earlier firmware versions were
+observed to have unreliable fan and ARGB detection and did not reliably apply
+software fan control.
+
+## Initializing the device
+
+The device should be initialized every time it is powered on. Initialization
+reports firmware version, fan-port connectivity, temperature-probe connectivity,
+and detected ARGB LED counts.
+
+```
+# liquidctl initialize
+Corsair Commander DUO
+├── Firmware version                 0.10.112
+├── Fan port 1 connected                  Yes
+├── Fan port 2 connected                   No
+├── Temperature sensor 1 connected        Yes
+├── Temperature sensor 2 connected         No
+├── ARGB port 1 LED count                  15
+└── ARGB port 2 LED count                   0
+```
+
+The Commander DUO requires SATA power before it will enumerate on USB.
+
+## Retrieving fan speeds and temperatures
+
+The Commander DUO can report current fan speeds and connected temperature
+probes.
+
+```
+# liquidctl status - (connected only)
+Corsair Commander DUO
+├── Fan speed 1     456  rpm
+├── Fan speed 2       0  rpm
+└── Temperature 1   29.2  °C
+```
+
+Disconnected temperature probes are not reported in status output.
+
+## Programming the fan speeds
+
+### Fixed duty cycle
+
+The connected fans can be set to a fixed duty cycle.
+
+```
+# liquidctl set fan1 speed 58
+                ^^^^       ^^
+               channel    duty
+```
+
+Valid channel values are `fan1` and `fan2`.
+
+The Commander DUO intentionally remains in software mode after fixed-speed
+commands.  Returning it to hardware mode immediately after a write prevents the
+new fan speed from taking effect, so this differs from some other Corsair
+Commander drivers.
+
+### Speed curve profiles
+
+Speed curve profiles are not currently implemented for the Commander DUO.
+
+## Controlling the LEDs
+
+The Commander DUO has two ARGB lighting channels, specified as `argb1` and
+`argb2`.  The aliases `argb`, `led1`, `led2`, `led`, and `sync` are also
+accepted for compatibility with other Corsair controller naming conventions.
+
+Currently supported lighting modes are:
+
+| Mode | Num colors |
+| ---- | ---------- |
+| `off` | 0 |
+| `fixed` | 1 |
+| `rainbow` | 0, Device Memory only |
+
+For example:
+
+```
+# liquidctl set argb1 color fixed ff0000 --maximum-leds 15
+# liquidctl set argb1 color off --maximum-leds 15
+```
+
+The `--maximum-leds` option can be used to configure the number of LEDs to send
+to a channel, especially when automatic detection reports zero LEDs for a
+connected ARGB device.
+
+The fixed and off lighting modes use the controller's software color endpoint.
+They are volatile: on tested firmware, a one-shot color write can fall back to
+the stored Device Memory lighting after a short idle period.  Re-sending the
+same fixed color periodically keeps the software color active.
+
+Passing `--non-volatile` writes the fixed, off, or rainbow mode to the Commander
+DUO's Device Memory lighting endpoint instead of streaming a software RGB frame:
+
+```
+# liquidctl set argb1 color fixed ff0000 --non-volatile
+# liquidctl set argb1 color off --non-volatile
+# liquidctl set sync color rainbow --non-volatile
+```
+
+The Device Memory write is based on iCUE captures for the DUO's static hardware
+lighting profile and must be sent while the controller is awake; the driver then
+returns the controller to hardware mode so the stored color becomes active.
+Hardware mode stores one global lighting profile for the controller; it does not
+support independent persistent colors per ARGB port.  The channel argument is
+still validated for consistency with normal color commands.  Fixed/off Device
+Memory color writes use a static global color, and rainbow writes use the
+captured hardware rainbow effect payload.  Per-LED hardware effects, direction,
+speed, two-color palettes, and custom Device Memory profile management are not
+currently supported by this driver.
+
+Other advanced RGB effects are not currently supported by this driver.

--- a/docs/developer/protocol/commander_duo.md
+++ b/docs/developer/protocol/commander_duo.md
@@ -1,0 +1,514 @@
+# Corsair Commander DUO Protocol
+
+## Compatible devices
+
+| Device Name | USB ID | LED channels | Fan channels | Temperature channels |
+|:-----------:|:------:|:------------:|:------------:|:--------------------:|
+| Commander DUO | `1b1c:0c56` | 2 | 2 | 2 |
+
+The Commander DUO is a compact USB HID fan, temperature, and ARGB
+controller.  The device requires SATA power before it enumerates on USB.
+
+This protocol is similar to the Commander Core protocol, but several values and
+state transitions differ.  In particular, the Commander DUO may return the
+useful response to a read command in any response frame from the close, open,
+read, or final close sequence.  Implementations should scan each response for
+the expected data type instead of assuming the final close response contains the
+payload.
+
+Unless stated otherwise, multi-byte integer values are little endian.
+
+## Firmware notes
+
+The protocol has been tested with firmware versions `0.8.105` and `0.10.112`.
+For software fixed-speed fan control, the device must remain in software mode
+after the write.  Sending the sleep/hardware-mode command immediately after a
+fixed-speed write prevents or cancels the fan response.
+For fixed/off Device Memory lighting, the endpoint write must instead be sent
+while the device is awake, then followed by sleep/hardware mode; direct hardware
+testing showed that the same `65 6d` write can briefly preview the color and
+revert if it is sent without first waking the controller.
+
+## Command formats
+
+Host to device reports use 96-byte HID reports on the tested firmware versions.
+The following table describes the command body; existing liquidctl HID transport
+code sends this body after the OS-level HID report ID.
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x08` |
+| `0x01` | Command |
+| `0x02` | Channel or subcommand |
+| `0x03-...` | Data |
+
+Device to host responses use the following layout.
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x00` |
+| `0x01` | Command |
+| `0x02` | `0x00` |
+| `0x03-...` | Data |
+
+## Global commands
+
+### `0x01` - Wake up / Sleep
+
+The wake command places the device in software mode.  The sleep command returns
+the device to hardware mode.
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x08` |
+| `0x01` | `0x01` |
+| `0x02` | `0x03` |
+| `0x03` | `0x00` |
+| `0x04` | `0x01` for sleep, `0x02` for wake up |
+
+### `0x02` - Get Firmware Version
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x08` |
+| `0x01` | `0x02` |
+| `0x02` | `0x13` |
+
+Response:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x00` |
+| `0x01` | `0x02` |
+| `0x02` | `0x00` |
+| `0x03` | Major version |
+| `0x04` | Minor version |
+| `0x05, 0x06` | Patch version as a little-endian u16 |
+
+For firmware `0.8.105`, the observed response body is:
+
+```text
+00 02 00 00 08 69 00
+```
+
+This is parsed as major `0x00`, minor `0x08`, and patch `0x0069`.
+
+### `0x05` - Close Endpoint
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x08` |
+| `0x01` | `0x05` |
+| `0x02` | `0x01` |
+| `0x03-...` | Endpoint bytes |
+
+For normal read operations, the endpoint is closed with channel `0x00`.  For
+write operations, iCUE and liquidctl close with channel `0x01` followed by the
+endpoint bytes.
+
+### `0x0d` - Open Endpoint
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x08` |
+| `0x01` | `0x0d` |
+| `0x02` | Channel |
+| `0x03-...` | Endpoint or mode bytes |
+
+Normal read and color operations use channel `0x00`.  Endpoint write
+transactions use channel `0x01`.
+
+## Mode commands
+
+### `0x06` - Write
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x08` |
+| `0x01` | `0x06` |
+| `0x02` | Channel |
+| `0x03, 0x04` | Data length, including the data type bytes |
+| `0x05, 0x06` | Reserved, normally `0x00 0x00` |
+| `0x07, 0x08` | Data type |
+| `0x09-...` | Data |
+
+Channel `0x01` is used for endpoint writes such as fixed-speed fan control.
+Channel `0x00` is used for color endpoint writes.
+
+### `0x07` - Write More
+
+Used for continuation data when a write payload does not fit in a single report.
+The Commander DUO uses this for large RGB or hardware profile payloads.
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x08` |
+| `0x01` | `0x07` |
+| `0x02` | Channel |
+| `0x03-...` | Continuation data |
+
+### `0x08` - Read Initial / More / Final
+
+The Commander DUO uses the same read command family as the Commander Core for
+the normal data modes listed below.
+
+Command:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x08` |
+| `0x01` | `0x08` |
+| `0x02` | `0x00` |
+| `0x03` | `0x01` for initial, `0x02` for more, `0x03` for final |
+
+Matching response frames contain the data type at bytes `0x03, 0x04` and the
+payload starting at byte `0x05`.
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x00` |
+| `0x01` | `0x08` |
+| `0x02` | `0x00` |
+| `0x03, 0x04` | Data type |
+| `0x05-...` | Payload |
+
+The response carrying the expected data type can appear in the initial, more,
+final, or close response.  Implementations should inspect every response in the
+full transaction.
+
+### `0x09` - Read Metadata
+
+iCUE uses command `0x09 0x01` when reading the Device Memory and hardware
+profile endpoints described below.  The response includes length-like metadata
+for the following `0x08 0x01` payload read.  This command has not been needed for
+the normal status, fixed-speed, or software RGB paths.
+
+## Modes
+
+### `0x17` - Current Fan Speeds
+
+Data Type: `0x06 0x00`
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | Number of fan ports, normally `0x02` |
+| `0x01, 0x02` | Fan 1 speed, RPM |
+| `0x03, 0x04` | Fan 2 speed, RPM |
+
+### `0x1a` - Connected Fan Devices
+
+Data Type: `0x09 0x00`
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | Number of fan ports |
+| `0x01` | Fan 1 connection state |
+| `0x02` | Fan 2 connection state |
+
+Observed Commander DUO fan connection states:
+
+| State | Description |
+| ----- | ----------- |
+| `0x03` | Connected fan |
+| other | Not connected or not confirmed for Commander DUO |
+
+FanControl.CorsairLink also uses a DUO-specific connected state value of
+`0x03` for this device.
+
+### `0x18` - Set Fixed Fan Speed
+
+Data Type: `0x07 0x00`
+
+Fixed-speed fan writes use endpoint mode `0x18`, not the Commander Core
+hardware fixed-speed mode `0x61`.  The write transaction is:
+
+1. wake the device;
+2. close endpoint `0x18` with command `0x05 0x01 0x01 0x18`;
+3. open endpoint `0x18` with command `0x0d 0x01`;
+4. write command `0x06 0x01` with data type `0x07 0x00`;
+5. close endpoint `0x18` with command `0x05 0x01 0x01 0x18`.
+
+Payload format after the `0x06 0x01` command bytes:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00, 0x01` | Data length, including the data type bytes |
+| `0x02, 0x03` | Reserved, normally `0x00 0x00` |
+| `0x04, 0x05` | Data type `0x07 0x00` |
+| `0x06` | Number of speed records |
+| `0x07` | Fan channel index |
+| `0x08` | Speed mode, `0x00` for fixed percentage |
+| `0x09` | Fixed speed percentage |
+| `0x0a` | Reserved, normally `0x00` |
+
+For example, setting FAN1 to 61% sends the speed data:
+
+```text
+01 00 00 3d 00
+```
+
+wrapped as:
+
+```text
+07 00 00 00 07 00 01 00 00 3d 00
+```
+
+iCUE USBPcap captures confirmed the same packet shape for several presets:
+58%, 92%, 27%, and 22% were all sent as single fixed-speed records for FAN1.
+
+The fixed-speed command does not take effect if the device is immediately put
+back into hardware mode after the write.  The device must remain in software
+mode for the software fan speed to apply.
+
+### `0x20` - Connected LEDs
+
+Data Type: `0x0f 0x00`
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | Number of ARGB ports, normally `0x02` |
+| `0x01, 0x02` | Port 1 state, `0x0002` when connected |
+| `0x03, 0x04` | Port 1 LED count |
+| `0x05, 0x06` | Port 2 state, `0x0002` when connected |
+| `0x07, 0x08` | Port 2 LED count |
+
+Example payload:
+
+```text
+02 02 00 0f 00 02 00 00 00
+```
+
+This reports two ports, port 1 connected with 15 LEDs, and port 2 connected with
+zero detected LEDs.
+
+### `0x21` - Get Temperatures
+
+Data Type: `0x10 0x00`
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | Number of temperature sensors |
+| `0x01` | Sensor 1 connection, `0x00` connected, `0x01` not connected |
+| `0x02, 0x03` | Sensor 1 temperature in Celsius × 10 |
+| `0x04` | Sensor 2 connection |
+| `0x05, 0x06` | Sensor 2 temperature in Celsius × 10 |
+
+For example, temperature bytes `3b 01` are `0x013b`, or `31.5 °C`.
+
+## Lighting control
+
+Commander DUO lighting is handled through a DUO-specific color endpoint.  The
+Commander Pro and Lighting Node Pro direct LED commands (`0x33`, `0x34`,
+`0x35`, `0x37`, and `0x38`) are not sufficient for this device.
+
+### LED port setup
+
+The DUO color path uses setup commands before color data is written.
+
+| Command bytes | Purpose |
+| ------------- | ------- |
+| `0x1e ...` | Configure enabled LED ports |
+| `0x1d ...` | Configure LED counts per port |
+| `0x15 0x01` | Reset LED power / refresh LED detection |
+
+Port enable payload for two ports:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x0d` |
+| `0x01` | `0x00` |
+| `0x02` | Number of ports, normally `0x02` |
+| `0x03` | Port 1 marker, `0x01` |
+| `0x04` | Port 1 enabled, `0x01` enabled or `0x00` disabled |
+| `0x05` | Port 2 marker, `0x01` |
+| `0x06` | Port 2 enabled, `0x01` enabled or `0x00` disabled |
+
+LED count payload for two ports:
+
+| Byte index | Description |
+| ---------- | ----------- |
+| `0x00` | `0x0c` |
+| `0x01` | `0x00` |
+| `0x02` | Number of ports, normally `0x02` |
+| `0x03, 0x04` | Port 1 LED count |
+| `0x05, 0x06` | Port 2 LED count |
+
+If auto-detection reports zero LEDs, software can leave the port disabled or
+use an explicit user-supplied LED count.
+
+### `0x22` - Set Color Data
+
+Data Type: `0x12 0x00`
+
+Color data is written after opening the color endpoint with `0x0d 0x00 0x22`.
+The first color report uses command `0x06 0x00`; additional color data uses
+command `0x07 0x00`.
+
+Captured iCUE color writes for a 15-LED strip use this frame shape:
+
+```text
+08 06 00 2f 00 00 00 12 00 <45 bytes of RGB data>
+```
+
+This is command `0x06 0x00`, length `0x002f`, reserved `0x0000`, data type
+`0x12 0x00`, and 15 RGB triples.  Direction and animation speed changes in the
+captured iCUE actions changed the sequence of RGB triples sent over this same
+endpoint.
+
+These `0x12 0x00` captures are not sufficient to describe the complete Device
+Memory profile format.  A color saved with iCUE Device Memory Mode can persist
+after iCUE exits and the device is returned to Linux, so the controller does
+have a persistent profile store.  The repeated `0x12 0x00` frames only describe
+the observed RGB frame stream while iCUE was controlling or previewing lighting.
+On tested firmware, a single static software color frame may later fall back to
+the stored Device Memory color when no more color frames are sent.  Re-sending
+the same `0x12 0x00` frame periodically kept the software color active in live
+testing; a 20 second refresh interval was sufficient in the tested setup.
+
+## Device Memory endpoint observations
+
+iCUE Device Memory operations were observed using additional endpoint modes
+ending in `0x6d`.  Their complete semantics are not yet characterized, and
+liquidctl only uses the minimal color write described below for fixed/off
+Device Memory lighting.  Normal status, software fixed-speed fan control, and
+volatile RGB streaming do not use these endpoints.
+
+| Open mode | Data type | Observed purpose |
+| --------- | --------- | ---------------- |
+| `65 6d` | `7e 20` | Static Device Memory lighting color |
+| `65 6d` | `02 a4` | Rainbow Device Memory lighting effect |
+| `61 6d` | `03 00` | Hardware cooling/profile mode data |
+| `62 6d` | `04 00` | Hardware cooling/profile fixed data |
+| `63 6d` | `05 00` | Hardware cooling/profile curve data |
+
+A captured Device Memory off sequence wrote these endpoints and was accepted by
+the device, but did not immediately change fan speed or RGB output by itself.
+Subsequent normal fixed-speed writes through mode `0x18` still actuated the fan.
+
+The implemented fixed/off Device Memory lighting path writes endpoint `65 6d`
+with data type `7e 20`.  The packet captured while iCUE committed fixed color
+`112233` was the endpoint transaction below; liquidctl wraps it in
+`08 01 03 00 02` before the write and `08 01 03 00 01` after the write.
+
+```text
+08 0d 01 65 6d
+08 09 01
+08 06 01 0e 00 00 00 7e 20 09 00 00 00 01 ff 33 22 11 02 00 01
+08 05 01 01
+```
+
+The `0x000e` length includes the two data-type bytes, so the data payload is 12
+bytes:
+
+```text
+09 00 00 00 01 ff bb gg rr 02 00 01
+```
+
+The first `ff` appears to be a fixed brightness/value byte.  Focused commit and
+readback captures for fixed color `112233` showed the remaining color bytes as
+`33 22 11`, so liquidctl maps an input RGB color `(rr, gg, bb)` to
+`ff bb gg rr` in this payload.  For `off`, liquidctl writes zero value/color
+bytes:
+
+```text
+09 00 00 00 01 00 00 00 00 02 00 01
+```
+
+This is intentionally narrower than full Device Memory profile management: the
+remaining bytes are preserved from the capture, hardware mode uses one global
+lighting profile rather than per-port color settings, and direction, speed, and
+palette data are not inferred from the available traces.
+
+The implemented rainbow Device Memory lighting path uses the same `65 6d` mode
+with data type `02 a4`.  The focused rainbow commit capture wrote:
+
+```text
+08 0d 01 65 6d
+08 09 01
+08 06 01 0a 00 00 00 02 a4 08 04 00 00 00 02 00 01
+08 05 01 01
+```
+
+The `0x000a` length includes the two data-type bytes, so the data payload is 8
+bytes:
+
+```text
+08 04 00 00 00 02 00 01
+```
+
+The exact meaning of those fields is not yet known; the driver only replays this
+observed global rainbow payload for `rainbow --non-volatile`.
+
+Additional Device Memory captures in May 2026 provided these negative/limiting
+observations:
+
+* Applying a saved static red profile wrote the same `65 6d` payload shape,
+  specifically `09 00 00 00 01 ff 00 00 ff 02 00 01`.  A later focused commit
+  and readback for fixed `112233` confirmed the non-symmetric color order as
+  `ff bb gg rr`.
+* Captures intended to save fixed `aa55cc`, off, global red, direction, speed,
+  and two-color palette changes did not contain additional lighting-profile
+  endpoint writes.  Those operations were observed as live RGB frames over
+  endpoint `0x22` with data type `0x12 0x00`, so they only describe
+  preview/software streaming behavior.
+  iCUE appears to preview Device Memory lighting changes before committing
+  them; the persistent endpoint writes may only be emitted when hardware mode is
+  disabled, saved, or otherwise applied.
+* Save/apply and after-replug captures wrote `65 6d` followed by `61 6d`,
+  `62 6d`, and `63 6d`.  The latter three payloads match hardware cooling
+  profile shapes seen on Commander-class devices (`03 00` mode selection,
+  `04 00` fixed value, and `05 00` curve data), so liquidctl deliberately does
+  not emit them as part of lighting control.
+* LED-count changes used endpoints `1e` (`0d 00`) and `1d` (`0c 00`) plus the
+  existing LED power reset command.  No evidence currently links those topology
+  writes to Device Memory lighting effects or global persistent color data.
+
+iCUE reads these endpoints with the sequence:
+
+```text
+08 0d 01 <endpoint bytes>
+08 09 01
+08 08 01
+08 05 01 01 <endpoint bytes>
+```
+
+Live reads of endpoint `65 6d 00 00 00` returned a payload containing the bytes
+`ff 41 3d` after that color had been stored through iCUE Device Memory Mode.
+Changing the current software RGB color did not change that readback, and the
+stored color remained visible without iCUE or Windows retaining control of the
+USB device.  This is a useful reference for future Device Memory support, but it
+is not a current software RGB frame readback.
+
+## Differences from Commander Core
+
+| Aspect | Commander Core | Commander DUO |
+| ------ | -------------- | ------------- |
+| Product ID | `0x0c1c` | `0x0c56` |
+| Fan channels | 6 | 2 |
+| LED channels | 7 | 2 |
+| Temperature sensors | 2 | 2 |
+| Data response | Typically final close response | Matching payload may appear in any response |
+| Connected fan state | Core-specific values | `0x03` confirmed for DUO |
+| Software fixed fan speed | Not this path | mode `0x18`, dtype `0x07 0x00` |
+| Lighting control | Not exposed by liquidctl Core driver | volatile `0x22`; Device Memory `65 6d` |
+
+## Confirmed implementation scope
+
+The implemented liquidctl driver uses the read paths above for fan speeds, fan
+connection state, temperature probes, and LED counts.  It implements fixed fan
+speed through mode `0x18`, volatile fixed/off RGB through the `0x22` color
+endpoint, and fixed/off/rainbow Device Memory lighting writes through endpoint
+`65 6d`.  Custom fan profiles, other advanced RGB effects, and broader Device
+Memory profile management are not implemented.

--- a/extra/linux/71-liquidctl.rules
+++ b/extra/linux/71-liquidctl.rules
@@ -377,6 +377,9 @@ SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c1c", TAG+="uacc
 # Corsair Commander Core XT (broken)
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c2a", TAG+="uaccess"
 
+# Corsair Commander DUO
+SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c56", TAG+="uaccess"
+
 # Corsair Commander Pro
 SUBSYSTEMS=="usb", ATTRS{idVendor}=="1b1c", ATTRS{idProduct}=="0c10", TAG+="uaccess"
 

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -259,6 +259,23 @@ Cooling channels: \fIfans\fR, \fIfan\fR. There is only a single fan channel.
 Cooling channels: \fIfans\fR, \fIfan[1\-6]\fR; (only non-XT/Elite Capellix:) \fIpump\fR.
 .PP
 Lighting channels: not yet supported.
+.SS Corsair Commander DUO
+Cooling channels: \fIfan[1\-2]\fR.
+.PP
+Lighting channels: \fIargb\fR, \fIargb[1\-2]\fR, \fIled\fR, \fIled[1\-2]\fR, \fIsync\fR.
+.TS
+l c
+---
+l c .
+Mode	#colors
+\fIoff\fR	0
+\fIfixed\fR	1
+\fIrainbow\fR	0, Device Memory only
+.TE
+.PP
+Device Memory lighting can be configured with \fB\-\-non\-volatile\fR for
+\fIoff\fR, \fIfixed\fR, and \fIrainbow\fR.  Speed profiles and other advanced
+lighting modes are not yet supported.
 .SS Corsair Commander Pro
 .SS Corsair Lighting Node Pro
 .SS Corsair Lighting Node Core

--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -30,6 +30,7 @@ from liquidctl.driver import asus_ryujin
 from liquidctl.driver import asus_ryuo
 from liquidctl.driver import aura_led
 from liquidctl.driver import commander_core
+from liquidctl.driver import commander_duo
 from liquidctl.driver import commander_pro
 from liquidctl.driver import control_hub
 from liquidctl.driver import coolit
@@ -66,7 +67,10 @@ def find_liquidctl_devices(pick=None, **kwargs):
                    key=lambda x: (x.__module__, x.__name__))
     num = 0
     for bus_cls in buses:
-        for dev in bus_cls().find_devices(**kwargs):
+        devices = bus_cls().find_devices(**kwargs)
+        if devices is None:
+            continue
+        for dev in devices:
             if pick is not None:
                 if num == pick:
                     yield dev

--- a/liquidctl/driver/commander_duo.py
+++ b/liquidctl/driver/commander_duo.py
@@ -1,0 +1,449 @@
+"""liquidctl driver for Corsair Commander DUO.
+
+Supported devices:
+
+- Corsair Commander DUO
+
+Copyright liquidctl contributors
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+# uses the psf/black style
+
+import time
+from contextlib import contextmanager
+
+from liquidctl.driver.usb import UsbHidDriver
+from liquidctl.error import ExpectationNotMet, NotSupportedByDriver, Timeout
+from liquidctl.util import clamp, u16le_from
+
+_REPORT_LENGTH = 96
+_RESPONSE_LENGTH = 96
+
+_INTERFACE_NUMBER = 0
+
+_CMD_WAKE = (0x01, 0x03, 0x00, 0x02)
+_CMD_SLEEP = (0x01, 0x03, 0x00, 0x01)
+_CMD_GET_FIRMWARE = (0x02, 0x13)
+_CMD_CLOSE_ENDPOINT = (0x05, 0x01, 0x00)
+_CMD_CLOSE_WRITE_ENDPOINT = (0x05, 0x01, 0x01)
+_CMD_OPEN_ENDPOINT = (0x0D, 0x00)
+_CMD_OPEN_WRITE_ENDPOINT = (0x0D, 0x01)
+_CMD_OPEN_COLOR_ENDPOINT = (0x0D, 0x00)
+_CMD_READ_INITIAL = (0x08, 0x00, 0x01)
+_CMD_READ_MORE = (0x08, 0x00, 0x02)
+_CMD_READ_FINAL = (0x08, 0x00, 0x03)
+_CMD_READ_METADATA = (0x09, 0x01)
+_CMD_WRITE_ENDPOINT = (0x06, 0x01)
+_CMD_WRITE_COLOR = (0x06, 0x00)
+_CMD_WRITE_COLOR_MORE = (0x07, 0x00)
+_CMD_RESET_LED_POWER = (0x15, 0x01)
+
+_MODE_LED_COUNT = (0x20,)
+_MODE_GET_SPEEDS = (0x17,)
+_MODE_GET_TEMPS = (0x21,)
+_MODE_CONNECTED_SPEEDS = (0x1A,)
+_MODE_SET_SPEED = (0x18,)
+_MODE_SET_COLOR = (0x22,)
+_MODE_SET_LED_PORTS = (0x1E,)
+_MODE_SET_LED_DATA = (0x1D,)
+_MODE_DEVICE_MEMORY_COLOR = (0x65, 0x6D)
+
+_DATA_TYPE_LED_COUNT = (0x0F, 0x00)
+_DATA_TYPE_SPEEDS = (0x06, 0x00)
+_DATA_TYPE_TEMPS = (0x10, 0x00)
+_DATA_TYPE_CONNECTED_SPEEDS = (0x09, 0x00)
+_DATA_TYPE_SET_SPEED = (0x07, 0x00)
+_DATA_TYPE_SET_COLOR = (0x12, 0x00)
+_DATA_TYPE_DEVICE_MEMORY_COLOR = (0x7E, 0x20)
+_DATA_TYPE_DEVICE_MEMORY_EFFECT = (0x02, 0xA4)
+
+_LED_PORT_COUNT = 2
+_MAX_LEDS = 204
+_MAX_COLOR_WRITE_CHUNK = 61
+
+_MODES = {
+    "off": 0x04,
+    "fixed": 0x04,
+}
+
+_DEVICE_MEMORY_EFFECTS = {
+    "rainbow": bytes([0x08, 0x04, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01]),
+}
+
+
+class CommanderDuo(UsbHidDriver):
+    """Corsair Commander DUO."""
+
+    _MATCHES = [
+        (0x1B1C, 0x0C56, "Corsair Commander DUO", {}),
+    ]
+
+    def __init__(self, device, description, **kwargs):
+        super().__init__(device, description, **kwargs)
+        self._fan_count = 2
+        self._temp_sensor_count = 2
+        self._led_count = [0] * _LED_PORT_COUNT
+
+    def initialize(self, **kwargs):
+        res = self._send_command(_CMD_GET_FIRMWARE)
+        fw_version = (res[3], res[4], u16le_from(res, offset=5))
+        status = [("Firmware version", "{}.{}.{}".format(*fw_version), "")]
+
+        with self._software_mode_context(restore_hardware_mode=True):
+            connected = self._get_connected_fans()
+            for i in range(self._fan_count):
+                status += [(f"Fan port {i + 1} connected", connected[i], "")]
+
+            temps = self._get_temps()
+            for i in range(self._temp_sensor_count):
+                status += [(f"Temperature sensor {i + 1} connected", temps[i] is not None, "")]
+
+            led_counts = self._get_led_counts()
+            for i in range(_LED_PORT_COUNT):
+                status += [(f"ARGB port {i + 1} LED count", led_counts[i], "")]
+
+        return status
+
+    def get_status(self, **kwargs):
+        status = []
+        with self._software_mode_context(restore_hardware_mode=True):
+            speeds = self._get_speeds()
+            for i, speed in enumerate(speeds):
+                status += [(f"Fan speed {i + 1}", speed, "rpm")]
+
+            temps = self._get_temps()
+            for i, temp in enumerate(temps):
+                if temp is not None:
+                    status += [(f"Temperature {i + 1}", temp, "°C")]
+
+        return status
+
+    def set_color(self, channel, mode, colors, non_volatile=False, **kwargs):
+        if mode not in _MODES and not (non_volatile and mode in _DEVICE_MEMORY_EFFECTS):
+            raise ValueError(f'mode "{mode}" is not valid')
+
+        led_channels = self._parse_led_channels(channel)
+        colors = list(colors)
+
+        if non_volatile:
+            try:
+                self._send_command(_CMD_WAKE)
+                time.sleep(0.05)
+                self._send_device_memory_color(mode, colors)
+            finally:
+                self._send_command(_CMD_SLEEP, allow_timeout=True)
+            return
+
+        start_led = clamp(kwargs.get("start_led", 1), 1, _MAX_LEDS) - 1
+
+        with self._software_mode_context():
+            led_counts = self._get_led_counts()
+            requested_leds = kwargs.get("maximum_leds")
+            configured_counts = self._configured_led_counts(
+                led_channels, led_counts, requested_leds, start_led
+            )
+            self._setup_led_ports(configured_counts)
+            self._set_color_endpoint()
+            self._send_color_data(
+                self._make_color_buffer(led_channels, configured_counts, start_led, mode, colors)
+            )
+
+    def set_speed_profile(self, channel, profile, **kwargs):
+        raise NotSupportedByDriver
+
+    def set_fixed_speed(self, channel, duty, **kwargs):
+        fan = self._parse_fan_channel(channel)
+        percent = clamp(int(duty), 0, 100)
+
+        with self._software_mode_context():
+            self._send_write(
+                _MODE_SET_SPEED, _DATA_TYPE_SET_SPEED, bytes([0x01, fan, 0x00, percent, 0x00])
+            )
+
+    def _parse_fan_channel(self, channel):
+        if isinstance(channel, int):
+            if channel < 0 or channel >= self._fan_count:
+                raise ValueError(f"fan channel index must be 0-{self._fan_count - 1}")
+            return channel
+        if isinstance(channel, str):
+            if channel.lower() in ["fan1", "fan 1", "1"]:
+                return 0
+            if channel.lower() in ["fan2", "fan 2", "2"]:
+                return 1
+        raise ValueError(f"invalid fan channel: {channel!r}")
+
+    @classmethod
+    def probe(
+        cls, handle, vendor=None, product=None, release=None, serial=None, match=None, **kwargs
+    ):
+        if handle.hidinfo["interface_number"] != _INTERFACE_NUMBER:
+            return
+        yield from super().probe(
+            handle,
+            vendor=vendor,
+            product=product,
+            release=release,
+            serial=serial,
+            match=match,
+            **kwargs,
+        )
+
+    def _get_led_counts(self):
+        res = self._read_data(_MODE_LED_COUNT, _DATA_TYPE_LED_COUNT)
+        num_devices = min(res[0], _LED_PORT_COUNT)
+        led_counts = []
+        for i in range(num_devices):
+            offset = 1 + i * 4
+            connected = u16le_from(res, offset=offset) == 0x0002
+            num_leds = u16le_from(res, offset=offset + 2)
+            led_counts.append(num_leds if connected else 0)
+        while len(led_counts) < _LED_PORT_COUNT:
+            led_counts.append(0)
+        self._led_count = led_counts
+        return led_counts
+
+    def _parse_led_channels(self, channel):
+        if channel in ["argb", "argb1", "led1"]:
+            return [0]
+        if channel in ["argb2", "led2"]:
+            return [1]
+        if channel in ["led", "sync"]:
+            return [0, 1]
+        raise ValueError(
+            'unknown channel, should be one of: "argb", "argb1", "argb2", "led", '
+            '"led1", "led2", or "sync"'
+        )
+
+    def _configured_led_counts(self, led_channels, led_counts, requested_leds, start_led):
+        configured_counts = list(led_counts)
+        for led_channel in led_channels:
+            discovered_leds = led_counts[led_channel]
+            if requested_leds is None and discovered_leds == 0:
+                configured_counts[led_channel] = 0
+                continue
+            num_leds = requested_leds if requested_leds is not None else discovered_leds
+            configured_counts[led_channel] = clamp(num_leds, 1, _MAX_LEDS - start_led)
+        return configured_counts
+
+    def _make_color_buffer(self, led_channels, led_counts, start_led, mode, colors):
+        color = (0, 0, 0)
+        if mode != "off" and colors:
+            color = tuple(colors[0])
+
+        color_data = bytearray()
+        for led_channel, led_count in enumerate(led_counts):
+            for led_index in range(led_count):
+                if led_channel in led_channels and led_index >= start_led:
+                    color_data.extend(color)
+                else:
+                    color_data.extend([0x00, 0x00, 0x00])
+        return bytes(color_data)
+
+    def _send_device_memory_color(self, mode, colors):
+        if mode in _DEVICE_MEMORY_EFFECTS:
+            self._send_device_memory_write(
+                _MODE_DEVICE_MEMORY_COLOR,
+                _DATA_TYPE_DEVICE_MEMORY_EFFECT,
+                _DEVICE_MEMORY_EFFECTS[mode],
+            )
+            return
+
+        self._send_device_memory_write(
+            _MODE_DEVICE_MEMORY_COLOR,
+            _DATA_TYPE_DEVICE_MEMORY_COLOR,
+            self._make_device_memory_color_payload(mode, colors),
+        )
+
+    def _make_device_memory_color_payload(self, mode, colors):
+        red = green = blue = 0x00
+        brightness = 0x00
+        if mode != "off" and colors:
+            red, green, blue = tuple(colors[0])
+            brightness = 0xFF
+
+        return bytes(
+            [
+                0x09,
+                0x00,
+                0x00,
+                0x00,
+                0x01,
+                brightness,
+                blue,
+                green,
+                red,
+                0x02,
+                0x00,
+                0x01,
+            ]
+        )
+
+    def _send_device_memory_write(self, endpoint, data_type, data):
+        """Send a Device Memory endpoint write matching observed iCUE transactions."""
+        payload = bytearray()
+        payload.extend((len(data) + len(data_type)).to_bytes(2, "little"))
+        payload.extend([0x00, 0x00])
+        payload.extend(data_type)
+        payload.extend(data)
+
+        self._send_command(_CMD_OPEN_WRITE_ENDPOINT, endpoint, allow_timeout=True)
+        self._send_command(_CMD_READ_METADATA, allow_timeout=True)
+        self._send_command(_CMD_WRITE_ENDPOINT, bytes(payload), allow_timeout=True)
+        time.sleep(0.02)
+        self._send_command(_CMD_CLOSE_WRITE_ENDPOINT, allow_timeout=True)
+
+    def _setup_led_ports(self, led_counts):
+        port_payload = bytearray([0x0D, 0x00, _LED_PORT_COUNT])
+        for led_count in led_counts:
+            port_payload.extend([0x01, 0x01 if led_count else 0x00])
+        self._send_write(_MODE_SET_LED_PORTS, (), bytes(port_payload), extra=0)
+
+        led_payload = bytearray([0x0C, 0x00, _LED_PORT_COUNT])
+        for led_count in led_counts:
+            led_payload.extend([led_count, 0x00])
+        self._send_write(_MODE_SET_LED_DATA, (), bytes(led_payload), extra=0)
+        time.sleep(0.1)
+        self._send_command(_CMD_RESET_LED_POWER, allow_timeout=True)
+
+    def _set_color_endpoint(self):
+        self._send_command(_CMD_CLOSE_WRITE_ENDPOINT, _MODE_SET_COLOR, allow_timeout=True)
+        time.sleep(0.02)
+        self._send_command(_CMD_OPEN_COLOR_ENDPOINT, _MODE_SET_COLOR, allow_timeout=True)
+        time.sleep(0.02)
+
+    def _send_color_data(self, data):
+        payload = bytearray()
+        payload.extend((len(data) + 2).to_bytes(2, "little"))
+        payload.extend([0x00, 0x00])
+        payload.extend(_DATA_TYPE_SET_COLOR)
+        payload.extend(data)
+
+        for offset in range(0, len(payload), _MAX_COLOR_WRITE_CHUNK):
+            command = _CMD_WRITE_COLOR if offset == 0 else _CMD_WRITE_COLOR_MORE
+            self._send_command(
+                command, payload[offset : offset + _MAX_COLOR_WRITE_CHUNK], allow_timeout=True
+            )
+        self._send_command(_CMD_CLOSE_WRITE_ENDPOINT, _MODE_SET_COLOR, allow_timeout=True)
+
+    def _get_connected_fans(self):
+        res = self._read_data(_MODE_CONNECTED_SPEEDS, _DATA_TYPE_CONNECTED_SPEEDS)
+        num_devices = res[0]
+        connected = []
+        for i in range(min(num_devices, self._fan_count)):
+            connected.append(res[i + 1] == 0x03)
+        while len(connected) < self._fan_count:
+            connected.append(False)
+        return connected
+
+    def _get_speeds(self):
+        res = self._read_data(_MODE_GET_SPEEDS, _DATA_TYPE_SPEEDS)
+        speeds = []
+        num_speeds = res[0]
+        for i in range(min(num_speeds, self._fan_count)):
+            speed = u16le_from(res, offset=1 + i * 2)
+            speeds.append(speed)
+        while len(speeds) < self._fan_count:
+            speeds.append(0)
+        return speeds
+
+    def _get_temps(self):
+        res = self._read_data(_MODE_GET_TEMPS, _DATA_TYPE_TEMPS)
+        num_temps = res[0]
+        temps = []
+        for i in range(min(num_temps, self._temp_sensor_count)):
+            connected = res[1 + i * 3] == 0x00
+            if connected:
+                temp_raw = u16le_from(res, offset=1 + i * 3 + 1)
+                temps.append(temp_raw / 10)
+            else:
+                temps.append(None)
+        while len(temps) < self._temp_sensor_count:
+            temps.append(None)
+        return temps
+
+    def _read_data(self, mode, data_type):
+        last_dtype = None
+        for _ in range(3):
+            responses = [self._send_command(_CMD_CLOSE_ENDPOINT, allow_timeout=True)]
+            time.sleep(0.02)
+            responses.append(self._send_command(_CMD_OPEN_ENDPOINT, mode, allow_timeout=True))
+            time.sleep(0.02)
+
+            responses.append(self._send_command(_CMD_READ_INITIAL, allow_timeout=True))
+            responses.append(self._send_command(_CMD_READ_MORE, allow_timeout=True))
+            responses.append(self._send_command(_CMD_READ_FINAL, allow_timeout=True))
+            responses.append(self._send_command(_CMD_CLOSE_ENDPOINT, allow_timeout=True))
+
+            for response in responses:
+                if len(response) >= 5:
+                    last_dtype = tuple(response[3:5])
+                    if last_dtype == data_type:
+                        return response[5:]
+
+            time.sleep(0.05)
+
+        raise ExpectationNotMet(f"device returned incorrect data type: {last_dtype!r}")
+
+    def _send_command(self, command, data=(), allow_timeout=False):
+        buf = bytearray(_REPORT_LENGTH + 1)
+        buf[1] = 0x08
+
+        cmd_start = 2
+        data_start = cmd_start + len(command)
+        data_end = data_start + len(data)
+
+        buf[cmd_start:data_start] = command
+        buf[data_start:data_end] = data
+
+        self.device.clear_enqueued_reports()
+        self.device.write(buf)
+        time.sleep(0.02)
+
+        try:
+            res = self.device.read(_RESPONSE_LENGTH)
+        except Timeout:
+            if allow_timeout:
+                return b""
+            raise
+
+        while res[0] != 0x00:
+            try:
+                res = self.device.read(_RESPONSE_LENGTH)
+            except Timeout:
+                if allow_timeout:
+                    return b""
+                raise
+
+        return bytes(res)
+
+    def _send_write(self, endpoint, data_type, data, extra=2):
+        """Send a write transaction to an endpoint."""
+        payload = bytearray()
+        payload.extend((len(data) + extra).to_bytes(2, "little"))
+        payload.extend([0x00, 0x00])
+        payload.extend(data_type)
+        payload.extend(data)
+
+        self._send_command(_CMD_CLOSE_WRITE_ENDPOINT, endpoint, allow_timeout=True)
+        time.sleep(0.02)
+        self._send_command(_CMD_OPEN_WRITE_ENDPOINT, endpoint, allow_timeout=True)
+        time.sleep(0.02)
+        self._send_command(_CMD_WRITE_ENDPOINT, bytes(payload), allow_timeout=True)
+        self._send_command(_CMD_CLOSE_WRITE_ENDPOINT, endpoint, allow_timeout=True)
+
+    @contextmanager
+    def _software_mode_context(self, restore_hardware_mode=False):
+        """Enter software mode and optionally restore hardware mode afterwards.
+
+        The Commander DUO ignores fixed-speed writes if hardware mode is
+        restored immediately afterwards, so public operations keep software mode
+        active by default.
+        """
+        try:
+            self._send_command(_CMD_WAKE)
+            time.sleep(0.05)
+            yield
+        finally:
+            if restore_hardware_mode:
+                self._send_command(_CMD_SLEEP)

--- a/tests/test_commander_duo.py
+++ b/tests/test_commander_duo.py
@@ -1,0 +1,536 @@
+from collections import deque
+
+from _testutils import noop
+from liquidctl.driver.commander_duo import CommanderDuo
+from liquidctl.error import ExpectationNotMet, NotSupportedByDriver
+
+
+def int_to_le(num, length=2, signed=False):
+    return int(num).to_bytes(length=length, byteorder="little", signed=signed)
+
+
+class MockCommanderDuoDevice:
+    def __init__(self):
+        self.vendor_id = 0x1B1C
+        self.product_id = 0x0C56
+        self.address = "addr"
+        self.path = b"path"
+        self.release_number = None
+        self.serial_number = None
+        self.bus = None
+        self.port = None
+
+        self.open = noop
+        self.close = noop
+        self.clear_enqueued_reports = noop
+
+        self.sent = []
+        self._last_write = bytes()
+        self._read_frames = deque()
+        self._mode = None
+        self._awake = False
+
+        self.firmware_version = (0x00, 0x08, 0x69, 0x00)
+        self.fan_statuses = (0x03, 0x01)
+        self.speeds = (1124, 0)
+        self.temperatures = (30.6, None)
+        self.led_counts = (15, 0)
+        self.fixed_speed_writes = []
+        self.endpoint_writes = []
+        self.color_writes = []
+
+    def read(self, length):
+        if self._read_frames:
+            return list(self._read_frames.popleft())[:length]
+
+        command = self._last_write[2]
+        data = bytearray([0x00, command, 0x00])
+
+        if command == 0x02:
+            data.extend(self.firmware_version)
+        elif command == 0x08:
+            data.extend(self._data_for_mode())
+        elif command in [0x06, 0x07]:
+            data.extend([0x03, 0x00])
+
+        return list(data)[:length]
+
+    def write(self, data):
+        data = bytes(data)
+        self.sent.append(data)
+        self._last_write = data
+
+        if data[0] != 0x00 or data[1] != 0x08:
+            raise ValueError("Start of packets going out should be 00:08")
+
+        command = data[2]
+        if command == 0x01 and data[3:6] == bytes([0x03, 0x00, 0x02]):
+            self._awake = True
+        elif command == 0x01 and data[3:6] == bytes([0x03, 0x00, 0x01]):
+            self._awake = False
+        elif command == 0x0D:
+            self._mode = data[4]
+        elif command == 0x05:
+            self._mode = None
+        elif data[2:4] == bytes([0x06, 0x01]):
+            data_length = int.from_bytes(data[4:6], byteorder="little")
+            data_type = data[8:10]
+            payload = data[10 : 8 + data_length]
+            self.endpoint_writes.append((data_length, data_type, payload))
+            if data_type == bytes([0x07, 0x00]):
+                self.fixed_speed_writes.append((data_type, payload))
+        elif data[2:4] in [bytes([0x06, 0x00]), bytes([0x07, 0x00])]:
+            self.color_writes.append(data[4:])
+
+        return len(data)
+
+    def queue_read_data_response(self, data_type, payload, frame):
+        frames = {
+            "initial": 2,
+            "more": 3,
+            "final": 4,
+            "close": 5,
+        }
+        for index in range(6):
+            if index == frames[frame]:
+                self._read_frames.append(
+                    bytes([0x00, 0x08, 0x00]) + bytes(data_type) + bytes(payload)
+                )
+            else:
+                self._read_frames.append(bytes([0x00, 0x08, 0x00, 0xFF, 0xFF]))
+
+    def _data_for_mode(self):
+        if self._mode == 0x17:
+            data = bytearray([0x06, 0x00, len(self.speeds)])
+            for speed in self.speeds:
+                data.extend(int_to_le(speed))
+            return data
+        if self._mode == 0x1A:
+            return bytes([0x09, 0x00, len(self.fan_statuses), *self.fan_statuses])
+        if self._mode == 0x20:
+            data = bytearray([0x0F, 0x00, len(self.led_counts)])
+            for count in self.led_counts:
+                data.extend(int_to_le(2 if count else 3))
+                data.extend(int_to_le(count))
+            return data
+        if self._mode == 0x21:
+            data = bytearray([0x10, 0x00, len(self.temperatures)])
+            for temp in self.temperatures:
+                if temp is None:
+                    data.append(1)
+                    data.extend(int_to_le(0))
+                else:
+                    data.append(0)
+                    data.extend(int_to_le(temp * 10))
+            return data
+        return bytes([0xFF, 0xFF])
+
+
+def _make_commander_duo_device():
+    device = MockCommanderDuoDevice()
+    duo = CommanderDuo(device, "Corsair Commander DUO")
+    duo.connect()
+    return duo
+
+
+def _assert_raises(exception, func, *args, **kwargs):
+    try:
+        func(*args, **kwargs)
+    except exception:
+        return
+    raise AssertionError(f"{exception.__name__} was not raised")
+
+
+def test_initialize_commander_duo():
+    commander_duo_device = _make_commander_duo_device()
+
+    res = commander_duo_device.initialize()
+
+    assert res[0] == ("Firmware version", "0.8.105", "")
+    assert res[1] == ("Fan port 1 connected", True, "")
+    assert res[2] == ("Fan port 2 connected", False, "")
+    assert res[3] == ("Temperature sensor 1 connected", True, "")
+    assert res[4] == ("Temperature sensor 2 connected", False, "")
+    assert res[5] == ("ARGB port 1 LED count", 15, "")
+    assert res[6] == ("ARGB port 2 LED count", 0, "")
+    assert not commander_duo_device.device._awake
+
+
+def test_initialize_commander_duo_parses_firmware_0_10_112():
+    commander_duo_device = _make_commander_duo_device()
+    commander_duo_device.device.firmware_version = (0x00, 0x0A, 0x70, 0x00)
+
+    res = commander_duo_device.initialize()
+
+    assert res[0] == ("Firmware version", "0.10.112", "")
+
+
+def test_status_commander_duo():
+    commander_duo_device = _make_commander_duo_device()
+
+    res = commander_duo_device.get_status()
+
+    assert res == [
+        ("Fan speed 1", 1124, "rpm"),
+        ("Fan speed 2", 0, "rpm"),
+        ("Temperature 1", 30.6, "°C"),
+    ]
+    assert not commander_duo_device.device._awake
+
+
+def test_read_data_accepts_matching_payload_in_initial_frame():
+    _check_read_data_accepts_matching_payload_in_frame("initial")
+
+
+def test_read_data_accepts_matching_payload_in_more_frame():
+    _check_read_data_accepts_matching_payload_in_frame("more")
+
+
+def test_read_data_accepts_matching_payload_in_final_frame():
+    _check_read_data_accepts_matching_payload_in_frame("final")
+
+
+def test_read_data_accepts_matching_payload_in_close_frame():
+    _check_read_data_accepts_matching_payload_in_frame("close")
+
+
+def _check_read_data_accepts_matching_payload_in_frame(frame):
+    commander_duo_device = _make_commander_duo_device()
+
+    commander_duo_device.device.queue_read_data_response(
+        data_type=(0x09, 0x00),
+        payload=(0x02, 0x03, 0x01),
+        frame=frame,
+    )
+
+    assert commander_duo_device._get_connected_fans() == [True, False]
+
+
+def test_set_fixed_speed_commander_duo_uses_mode_0x18():
+    commander_duo_device = _make_commander_duo_device()
+
+    commander_duo_device.set_fixed_speed("fan1", 61)
+
+    close_writes = [
+        sent for sent in commander_duo_device.device.sent if sent[2:5] == bytes([0x05, 0x01, 0x01])
+    ]
+    open_writes = [
+        sent for sent in commander_duo_device.device.sent if sent[2:4] == bytes([0x0D, 0x01])
+    ]
+    write_writes = [
+        sent for sent in commander_duo_device.device.sent if sent[2:4] == bytes([0x06, 0x01])
+    ]
+
+    assert close_writes[-1][5] == 0x18
+    assert open_writes[-1][4] == 0x18
+    assert write_writes[-1][4:15] == bytes(
+        [0x07, 0x00, 0x00, 0x00, 0x07, 0x00, 0x01, 0x00, 0x00, 0x3D, 0x00]
+    )
+    assert commander_duo_device.device.fixed_speed_writes[-1] == (
+        bytes([0x07, 0x00]),
+        bytes([0x01, 0x00, 0x00, 0x3D, 0x00]),
+    )
+    assert commander_duo_device.device._awake
+
+
+def test_set_fixed_speed_commander_duo_keeps_software_mode_active():
+    commander_duo_device = _make_commander_duo_device()
+
+    commander_duo_device.set_fixed_speed("fan1", 58)
+
+    sleep_commands = [
+        sent
+        for sent in commander_duo_device.device.sent
+        if sent[2:6] == bytes([0x01, 0x03, 0x00, 0x01])
+    ]
+    assert not sleep_commands
+    assert commander_duo_device.device._awake
+
+
+def test_set_fixed_speed_commander_duo_clamps_duty():
+    commander_duo_device = _make_commander_duo_device()
+
+    commander_duo_device.set_fixed_speed("fan1", -10)
+    commander_duo_device.set_fixed_speed("fan1", 110)
+
+    assert commander_duo_device.device.fixed_speed_writes[0] == (
+        bytes([0x07, 0x00]),
+        bytes([0x01, 0x00, 0x00, 0x00, 0x00]),
+    )
+    assert commander_duo_device.device.fixed_speed_writes[1] == (
+        bytes([0x07, 0x00]),
+        bytes([0x01, 0x00, 0x00, 0x64, 0x00]),
+    )
+
+
+def test_set_fixed_speed_commander_duo_rejects_invalid_channels():
+    commander_duo_device = _make_commander_duo_device()
+
+    for channel in ["fan", "fans", "fan3", -1, 2]:
+        _assert_raises(ValueError, commander_duo_device.set_fixed_speed, channel, 50)
+
+
+def test_set_speed_profile_commander_duo_is_not_supported():
+    commander_duo_device = _make_commander_duo_device()
+
+    _assert_raises(
+        NotSupportedByDriver, commander_duo_device.set_speed_profile, "fan1", [(25, 30), (40, 80)]
+    )
+
+
+def test_set_color_commander_duo_sets_led_ports_and_writes_rgb_data():
+    commander_duo_device = _make_commander_duo_device()
+
+    commander_duo_device.set_color("argb1", "fixed", [(255, 0, 0)], maximum_leds=2)
+
+    endpoint_writes = commander_duo_device.device.endpoint_writes
+    color_writes = commander_duo_device.device.color_writes
+
+    assert endpoint_writes[0] == (7, bytes([0x0D, 0x00]), bytes([0x02, 0x01, 0x01, 0x01, 0x00]))
+    assert endpoint_writes[1] == (7, bytes([0x0C, 0x00]), bytes([0x02, 0x02, 0x00, 0x00, 0x00]))
+    assert color_writes[0][:8] == bytes([0x08, 0x00, 0x00, 0x00, 0x12, 0x00, 0xFF, 0x00])
+    assert color_writes[0][8:12] == bytes([0x00, 0xFF, 0x00, 0x00])
+    assert commander_duo_device.device.sent[-1][2:5] == bytes([0x05, 0x01, 0x01])
+    assert commander_duo_device.device.sent[-1][5] == 0x22
+    assert commander_duo_device.device._awake
+
+
+def test_set_color_commander_duo_honors_sync_channel_and_start_led():
+    commander_duo_device = _make_commander_duo_device()
+    commander_duo_device.device.led_counts = (3, 2)
+
+    commander_duo_device.set_color("sync", "fixed", [(0x01, 0x02, 0x03)], start_led=2)
+
+    assert commander_duo_device.device.endpoint_writes[0] == (
+        7,
+        bytes([0x0D, 0x00]),
+        bytes([0x02, 0x01, 0x01, 0x01, 0x01]),
+    )
+    assert commander_duo_device.device.endpoint_writes[1] == (
+        7,
+        bytes([0x0C, 0x00]),
+        bytes([0x02, 0x03, 0x00, 0x02, 0x00]),
+    )
+    assert commander_duo_device.device.color_writes[0][:6] == bytes(
+        [0x11, 0x00, 0x00, 0x00, 0x12, 0x00]
+    )
+    color_payload = commander_duo_device.device.color_writes[0]
+    assert color_payload[6:21] == bytes(
+        [
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x02,
+            0x03,
+            0x01,
+            0x02,
+            0x03,
+            0x00,
+            0x00,
+            0x00,
+            0x01,
+            0x02,
+            0x03,
+        ]
+    )
+    assert set(color_payload[21:]) == {0x00}
+
+
+def test_set_color_commander_duo_splits_large_volatile_rgb_writes():
+    commander_duo_device = _make_commander_duo_device()
+    commander_duo_device.device.led_counts = (20, 0)
+
+    commander_duo_device.set_color("argb1", "fixed", [(0x01, 0x02, 0x03)])
+
+    color_write_commands = [
+        sent[2:4]
+        for sent in commander_duo_device.device.sent
+        if sent[2:4] in [bytes([0x06, 0x00]), bytes([0x07, 0x00])]
+    ]
+    assert color_write_commands == [bytes([0x06, 0x00]), bytes([0x07, 0x00])]
+    expected_payload = bytes(
+        [0x3E, 0x00, 0x00, 0x00, 0x12, 0x00] + [0x01, 0x02, 0x03] * 20
+    )
+    assert commander_duo_device.device.color_writes[0][:61] == expected_payload[:61]
+    assert commander_duo_device.device.color_writes[1][:5] == expected_payload[61:]
+    assert set(commander_duo_device.device.color_writes[0][61:]) == {0x00}
+    assert set(commander_duo_device.device.color_writes[1][5:]) == {0x00}
+    assert commander_duo_device.device.sent[-1][2:5] == bytes([0x05, 0x01, 0x01])
+    assert commander_duo_device.device.sent[-1][5] == 0x22
+
+
+def test_set_color_commander_duo_rejects_invalid_mode():
+    commander_duo_device = _make_commander_duo_device()
+
+    _assert_raises(ValueError, commander_duo_device.set_color, "argb1", "rainbow", [])
+
+
+def test_set_color_commander_duo_rejects_invalid_channel():
+    commander_duo_device = _make_commander_duo_device()
+
+    _assert_raises(ValueError, commander_duo_device.set_color, "fan1", "fixed", [(255, 0, 0)])
+
+
+def test_set_color_commander_duo_rejects_invalid_non_volatile_channel_without_write():
+    commander_duo_device = _make_commander_duo_device()
+
+    _assert_raises(
+        ValueError,
+        commander_duo_device.set_color,
+        "fan1",
+        "fixed",
+        [(255, 0, 0)],
+        non_volatile=True,
+    )
+
+    assert not commander_duo_device.device.sent
+    assert not commander_duo_device.device.endpoint_writes
+    assert not commander_duo_device.device.color_writes
+
+
+def test_set_color_commander_duo_writes_device_memory_color_when_non_volatile(caplog):
+    commander_duo_device = _make_commander_duo_device()
+
+    commander_duo_device.set_color(
+        "argb1", "fixed", [(0x11, 0x22, 0x33)], maximum_leds=2, non_volatile=True
+    )
+
+    open_writes = [
+        sent for sent in commander_duo_device.device.sent if sent[2:4] == bytes([0x0D, 0x01])
+    ]
+    close_writes = [
+        sent
+        for sent in commander_duo_device.device.sent
+        if sent[2:5] == bytes([0x05, 0x01, 0x01])
+    ]
+    wake_writes = [
+        sent
+        for sent in commander_duo_device.device.sent
+        if sent[2:6] == bytes([0x01, 0x03, 0x00, 0x02])
+    ]
+
+    assert "Device Memory lighting is not supported" not in caplog.text
+    assert wake_writes
+    assert commander_duo_device.device.sent.index(
+        wake_writes[-1]
+    ) < commander_duo_device.device.sent.index(open_writes[-1])
+    assert open_writes[-1][4:6] == bytes([0x65, 0x6D])
+    assert close_writes[-1][5:7] == bytes([0x00, 0x00])
+    assert commander_duo_device.device.endpoint_writes[-1] == (
+        14,
+        bytes([0x7E, 0x20]),
+        bytes([0x09, 0x00, 0x00, 0x00, 0x01, 0xFF, 0x33, 0x22, 0x11, 0x02, 0x00, 0x01]),
+    )
+    assert any(sent[2:4] == bytes([0x09, 0x01]) for sent in commander_duo_device.device.sent)
+    assert commander_duo_device.device.sent[-1][2:6] == bytes([0x01, 0x03, 0x00, 0x01])
+    assert not commander_duo_device.device.color_writes
+    assert not commander_duo_device.device._awake
+
+
+def test_set_color_commander_duo_writes_device_memory_off_when_non_volatile():
+    commander_duo_device = _make_commander_duo_device()
+
+    commander_duo_device.set_color("sync", "off", [], non_volatile=True)
+
+    assert commander_duo_device.device.endpoint_writes[-1] == (
+        14,
+        bytes([0x7E, 0x20]),
+        bytes([0x09, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01]),
+    )
+    assert not commander_duo_device.device.color_writes
+    assert not commander_duo_device.device._awake
+
+
+def test_set_color_commander_duo_writes_device_memory_rainbow_when_non_volatile():
+    commander_duo_device = _make_commander_duo_device()
+
+    commander_duo_device.set_color("sync", "rainbow", [], non_volatile=True)
+
+    assert commander_duo_device.device.endpoint_writes[-1] == (
+        10,
+        bytes([0x02, 0xA4]),
+        bytes([0x08, 0x04, 0x00, 0x00, 0x00, 0x02, 0x00, 0x01]),
+    )
+    assert not commander_duo_device.device.color_writes
+    assert not commander_duo_device.device._awake
+
+
+def test_set_color_commander_duo_device_memory_lighting_only_opens_lighting_endpoint():
+    for mode, colors in (
+        ("fixed", [(0x11, 0x22, 0x33)]),
+        ("off", []),
+        ("rainbow", []),
+    ):
+        commander_duo_device = _make_commander_duo_device()
+
+        commander_duo_device.set_color("sync", mode, colors, non_volatile=True)
+
+        open_endpoints = [
+            sent[4:6]
+            for sent in commander_duo_device.device.sent
+            if sent[2:4] == bytes([0x0D, 0x01])
+        ]
+        device_memory_endpoints = [
+            endpoint for endpoint in open_endpoints if endpoint.endswith(bytes([0x6D]))
+        ]
+
+        assert device_memory_endpoints == [bytes([0x65, 0x6D])]
+        assert bytes([0x61, 0x6D]) not in open_endpoints
+        assert bytes([0x62, 0x6D]) not in open_endpoints
+        assert bytes([0x63, 0x6D]) not in open_endpoints
+
+
+def test_set_color_commander_duo_does_not_invent_led_count_without_override():
+    commander_duo_device = _make_commander_duo_device()
+    commander_duo_device.device.led_counts = (0, 0)
+
+    commander_duo_device.set_color("argb1", "fixed", [(255, 0, 0)])
+
+    endpoint_writes = commander_duo_device.device.endpoint_writes
+    color_writes = commander_duo_device.device.color_writes
+
+    assert endpoint_writes[0] == (7, bytes([0x0D, 0x00]), bytes([0x02, 0x01, 0x00, 0x01, 0x00]))
+    assert endpoint_writes[1] == (7, bytes([0x0C, 0x00]), bytes([0x02, 0x00, 0x00, 0x00, 0x00]))
+    assert color_writes[0][:6] == bytes([0x02, 0x00, 0x00, 0x00, 0x12, 0x00])
+    assert set(color_writes[0][6:]) == {0x00}
+    assert commander_duo_device.device._awake
+
+
+def test_set_color_commander_duo_maximum_leds_overrides_zero_detected_count():
+    commander_duo_device = _make_commander_duo_device()
+    commander_duo_device.device.led_counts = (0, 0)
+
+    commander_duo_device.set_color("argb1", "fixed", [(0x01, 0x02, 0x03)], maximum_leds=2)
+
+    assert commander_duo_device.device.endpoint_writes[0] == (
+        7,
+        bytes([0x0D, 0x00]),
+        bytes([0x02, 0x01, 0x01, 0x01, 0x00]),
+    )
+    assert commander_duo_device.device.endpoint_writes[1] == (
+        7,
+        bytes([0x0C, 0x00]),
+        bytes([0x02, 0x02, 0x00, 0x00, 0x00]),
+    )
+    assert commander_duo_device.device.color_writes[0][:12] == bytes(
+        [0x08, 0x00, 0x00, 0x00, 0x12, 0x00, 0x01, 0x02, 0x03, 0x01, 0x02, 0x03]
+    )
+    assert set(commander_duo_device.device.color_writes[0][12:]) == {0x00}
+
+
+def test_read_data_commander_duo_raises_on_wrong_dtype():
+    commander_duo_device = _make_commander_duo_device()
+    for _ in range(18):
+        commander_duo_device.device._read_frames.append(bytes([0x00, 0x08, 0x00, 0xFF, 0xFF, 0x00]))
+
+    _assert_raises(ExpectationNotMet, commander_duo_device._get_connected_fans)
+
+
+def test_software_mode_context_can_restore_hardware_mode_when_requested():
+    commander_duo_device = _make_commander_duo_device()
+
+    with commander_duo_device._software_mode_context(restore_hardware_mode=True):
+        assert commander_duo_device.device._awake
+
+    assert not commander_duo_device.device._awake


### PR DESCRIPTION
# Add Corsair Commander DUO support

Add a new Corsair Commander DUO driver with fan status/control, ARGB lighting,
and capture-backed Device Memory lighting support.

The driver supports the DUO's two PWM fan channels and two standard 5 V ARGB
ports.  Software lighting supports `off` and `fixed`, while Device Memory
lighting supports `off`, `fixed`, and `rainbow` through `--non-volatile`.
Device Memory lighting is intentionally limited to the observed global hardware
lighting endpoint (`65 6d`): fixed/off use the captured `7e 20` payload format,
and rainbow uses the captured `02 a4` payload.  The implementation deliberately
does not write the nearby `61/62/63 6d` endpoints because the captures and
Commander Core protocol parallels indicate those are cooling/profile data.

The user guide and protocol notes document the remaining limitations: DUO
hardware lighting is global rather than per-port, iCUE LINK devices are not
supported by this driver, and advanced Device Memory effects such as speed,
direction, palettes, readback APIs, and broader hardware profile management are
out of scope for this change.

Hardware verification was performed on a Commander DUO.  Persistent rainbow and
persistent fixed `3200ff` (`50R 0G 255B`) were written with `--non-volatile` and
visually confirmed to persist.

Related: [Commander DUO USB captures](https://github.com/liquidctl/collected-device-data/pull/21) used for protocol reverse engineering.

---

Checklist:

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [x] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [x] `liquidctl.8` Linux/Unix/Mac OS man page
    - [x] protocol documentation in `docs/developer/protocol`
- [x] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [x] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [x] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [x] Document the protocol in `docs/developer/protocol/`

Verification performed:

- `lsp_diagnostics` clean for `liquidctl/driver/__init__.py`,
  `liquidctl/driver/commander_duo.py`, and `tests/test_commander_duo.py`
- `.venv/bin/python -m py_compile liquidctl/driver/__init__.py`
  `liquidctl/driver/commander_duo.py tests/test_commander_duo.py`
- `.venv/bin/python -m pytest tests/test_commander_duo.py` (`22 passed`)
- driver import smoke test for `commander_duo` registration
- `git diff --check` for tracked PR files

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
