### PR TITLE
Added support for "wave" effect for NZXT 2023 RGB Controller

### DIFF
--- a/docs/nzxt-smart-device-v1-guide.md
+++ b/docs/nzxt-smart-device-v1-guide.md
@@ -122,6 +122,7 @@ This can be specified by using the `--direction` flag.
 | `super-breathing` | Up to 40, one for each LED | Only one step |
 | `pulse` | Up to 8, one for each pulse |
 | `candle` | One |
+| `wave` | Up to 40, one for each LED |
 | `wings` | One |
 
 #### Deprecated modes

--- a/liquidctl/driver/smart_device.py
+++ b/liquidctl/driver/smart_device.py
@@ -732,7 +732,8 @@ class Nzxt2023RgbController(_BaseSmartDevice):
         'rainbow-pulse':    (0x0d, 0x01, 0x00, 0, 0),
         'rainbow-flow':     (0x0b, 0x01, 0x00, 0, 0),
         'super-rainbow':    (0x0c, 0x01, 0x00, 0, 0),
-        'candle':           (0x08, 0x00, 0x00, 0, 1)
+        'candle':           (0x08, 0x00, 0x00, 0, 1),
+        'wave':             (0x02, 0x6a, 0x00, 1, 40)
     }
 
     _SPEED_VALUES = {
@@ -747,6 +748,7 @@ class Nzxt2023RgbController(_BaseSmartDevice):
         'spectrum-wave':      [[0x5e, 0x01], [0x2c, 0x01], [0xfa,0x00], [0x96,0x00], [0x50, 0x00]],
         'cover-marquee':      [[0x5e, 0x01], [0x2c, 0x01], [0xfa,0x00], [0x96,0x00], [0x50, 0x00]],
         'alternating':        [[0x40, 0x06], [0x14, 0x05], [0xe8, 0x03], [0x20, 0x03], [0x58, 0x02]],
+        'wave':               [[0x96, 0x00], [0x80, 0x00], [0x6a, 0x00], [0x40, 0x00], [0x20, 0x00]],
         'fixed':              [[0x32, 0x00]]*5,
         'super-fixed':        [[0x32, 0x00]]*5,
         'candle':             [[0x32, 0x00]]*5,
@@ -824,13 +826,13 @@ class Nzxt2023RgbController(_BaseSmartDevice):
                 return
         assert False, f'missing messages (attempts={self._MAX_READ_ATTEMPTS}, missing={len(parsers)})'
 
-    def _write_individual_color(self, cid, colors):
+    def _write_individual_color(self, cid, colors, effect_byte=0x01, speed_byte=0x00):
         color_count = len(colors)
         led_padding = [0x00, 0x00, 0x00]*(40 - color_count)  # turn off remaining LEDs
         leds = list(itertools.chain(*colors)) + led_padding
         self._write([0x22, 0x10, cid, 0x00] + leds[0:60])  # send first 20 colors to device (3 bytes per color)
         self._write([0x22, 0x11, cid, 0x00] + leds[60:])  # send remaining colors to device
-        self._write([0x22, 0xa0, cid, 0x00, 0x01, 0x00, 0x00, 0x08, 0x00,
+        self._write([0x22, 0xa0, cid, 0x00, effect_byte, speed_byte, 0x00, 0x08, 0x00,
                      0x00, 0x80, 0x00, 0x32, 0x00, 0x00, 0x01])
 
     def _write_colors(self, cid, mode, colors, sval, direction='forward',):
@@ -839,7 +841,13 @@ class Nzxt2023RgbController(_BaseSmartDevice):
         color_count = len(colors)
 
         if maxcolors == 40:
-            self._write_individual_color(cid, colors)
+            bytes = [0x01, 0x00] # defaults
+
+            if mode == 'wave':
+                bytes[0] = 0x02 # set effect
+                bytes[1] = self._SPEED_VALUES[mode][sval][0] # set speed
+
+            self._write_individual_color(cid, colors, effect_byte=bytes[0], speed_byte=bytes[1])
         else:
             # Header and device id
             header = [0x2a, 0x04, cid, cid]


### PR DESCRIPTION
I was bummed out that my favorite wave effect was not supported in liquidctl, so i quickly looked at the USB traffic of NZXT CAM and figured out how it works and added it. The changes are minimal and focused on just having the effect work. I also tested it and it the wave effect, along with other effects work as usual.

<img width="999" height="642" alt="resim" src="https://github.com/user-attachments/assets/56dfac6c-3e59-4649-b234-eda531dda647" />

the wave effect is marquee-like effect that spins all LEDs in the forward direction. i use it like above image to give the impression of a spinning propeller.

I also added speed control which NZXT CAM lacks for this mode. where "normal" speed is [ 0x6a, 0x00 ] and all other speeds are scaled accordingly.

Can be used like

`liquidctl --match NZXT set [channel] color wave [colors] --speed [speed]`

I also tried adding the "wings" effect, but that was a little complicated as i wasn't able to get it to animate, this PR and commit does not include it.

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: None
Closes: None
Related: None

---

Checklist:

<!-- To check an item, fill the brackets with the letter x; the result should look like `[x]`.  Feel free to leave unchecked items that are not applicable or that you could not perform. -->

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [ ] Add automated tests cases
- [ ] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [ ] README, with ["new/changed in" notes]
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]
    - [ ] `liquidctl.8` Linux/Unix/Mac OS man page
    - [ ] protocol documentation in `docs/developer/protocol`
- [ ] Submit relevant data, scripts or dissectors to https://github.com/liquidctl/collected-device-data

New CLI flag?

- [ ] Adjust the completion scripts in `extra/completions/`

New device?

- [ ] Regenerate `extra/linux/71-liquidctl.rules` (instructions in the file header)
- [ ] Add entry to the README's supported device list with applicable notes and `git` MRLV

New driver?

- [ ] Document the protocol in `docs/developer/protocol/`

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes
