### PR TITLE
commander_core: three independent driver fixes

### DIFF
--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -186,9 +186,10 @@ class CommanderCore(UsbHidDriver):
                 # set number of curve points
                 new_data.append(int.to_bytes(len(curve_points), length=1, byteorder="big"))
 
-                # set curve points
+                # set curve points (decidegree temps; round() so float inputs
+                # like 31.3 produce 313, not 312 via truncation)
                 for (temp, duty) in curve_points:
-                    new_data.append(int.to_bytes(temp*10, length=2, byteorder="little", signed=False))
+                    new_data.append(int.to_bytes(round(temp * 10), length=2, byteorder="little", signed=False))
                     new_data.append(int.to_bytes(clamp(duty, 0, 100), length=2, byteorder="little", signed=False))
 
                 # Update device data

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -148,9 +148,9 @@ class CommanderCore(UsbHidDriver):
         channels = self._parse_channels(channel)
         curve_points = list(profile)
         if len(curve_points) < 2:
-            ValueError('a minimum of 2 speed curve points must be configured.')
+            raise ValueError('a minimum of 2 speed curve points must be configured.')
         if len(curve_points) > 7:
-            ValueError('a maximum of 7 speed curve points may be configured.')
+            raise ValueError('a maximum of 7 speed curve points may be configured.')
 
         with self._wake_device_context():
             # Set hardware speed mode

--- a/liquidctl/driver/commander_core.py
+++ b/liquidctl/driver/commander_core.py
@@ -19,6 +19,7 @@ _LOGGER = logging.getLogger(__name__)
 
 _REPORT_LENGTH = 96
 _RESPONSE_LENGTH = 96
+_MAX_RESPONSE_RETRIES = 16  # see _send_command — drains stale reports / echoes
 
 _INTERFACE_NUMBER = 0
 
@@ -288,12 +289,18 @@ class CommanderCore(UsbHidDriver):
         self.device.clear_enqueued_reports()
         self.device.write(buf)
 
-        res = self.device.read(_RESPONSE_LENGTH)
-        while res[0] != 0x00:
+        # Skip unsolicited reports (res[0] != 0x00) and stale command echoes
+        # (res[1] != command[0]).  Both can occur under firmware 2.x between
+        # the drain and the write.  A bounded retry budget covers either
+        # case so the function cannot spin indefinitely.
+        retries = _MAX_RESPONSE_RETRIES
+        while True:
             res = self.device.read(_RESPONSE_LENGTH)
-        buf = bytes(res)
-        assert buf[1] == command[0], 'response does not match command'
-        return buf
+            if res[0] == 0x00 and res[1] == command[0]:
+                return bytes(res)
+            retries -= 1
+            if retries <= 0:
+                raise ExpectationNotMet('response does not match command')
 
     @contextmanager
     def _wake_device_context(self):

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -402,3 +402,15 @@ def test_parse_channels_error_commander_core():
     core = CommanderCore(MockCommanderCoreDevice(), 'Corsair Commander Core', True)
     with pytest.raises(ValueError):
         core._parse_channels('fan')
+
+
+def test_set_speed_profile_raises_on_too_few_points(commander_core_device):
+    """Fix for unraised ValueError typo: minimum of 2 curve points is enforced."""
+    with pytest.raises(ValueError):
+        commander_core_device.set_speed_profile('fan1', [(30, 50)])
+
+
+def test_set_speed_profile_raises_on_too_many_points(commander_core_device):
+    """Fix for unraised ValueError typo: maximum of 7 curve points is enforced."""
+    with pytest.raises(ValueError):
+        commander_core_device.set_speed_profile('fan1', [(t, 50) for t in range(20, 28)])

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -414,3 +414,13 @@ def test_set_speed_profile_raises_on_too_many_points(commander_core_device):
     """Fix for unraised ValueError typo: maximum of 7 curve points is enforced."""
     with pytest.raises(ValueError):
         commander_core_device.set_speed_profile('fan1', [(t, 50) for t in range(20, 28)])
+
+
+def test_set_speed_profile_rounds_float_temperatures(commander_core_device):
+    """Curve temperatures are encoded as decidegrees; floats must be rounded
+    rather than truncated.  31.3 * 10 evaluates to 312.9999... under IEEE-754,
+    so int() would store 312 instead of the intended 313."""
+    commander_core_device.device.speeds_mode = (0, 0, 0, 0, 0, 0, 0)
+    commander_core_device.set_speed_profile('fan1', [(20.0, 0), (31.3, 50)])
+    stored = commander_core_device.device.curve_points_by_device[1]
+    assert stored[1][0] == 31.3, f'expected 31.3, got {stored[1][0]!r}'

--- a/tests/test_commander_core.py
+++ b/tests/test_commander_core.py
@@ -424,3 +424,23 @@ def test_set_speed_profile_rounds_float_temperatures(commander_core_device):
     commander_core_device.set_speed_profile('fan1', [(20.0, 0), (31.3, 50)])
     stored = commander_core_device.device.curve_points_by_device[1]
     assert stored[1][0] == 31.3, f'expected 31.3, got {stored[1][0]!r}'
+
+
+def test_send_command_raises_on_persistent_wrong_echo(commander_core_device):
+    """Replacement for the assert-based response check: under python -O the
+    assert disappears and the function silently returns wrong data.  The new
+    code raises ExpectationNotMet after a bounded number of retries."""
+    commander_core_device.device.read = lambda length: [0x00, 0xFF, 0x00] + [0] * (length - 3)
+    commander_core_device.device.write = lambda data: len(data)
+    with pytest.raises(ExpectationNotMet):
+        commander_core_device._send_command((0x02, 0x13))
+
+
+def test_send_command_raises_on_persistent_nonzero_report_id(commander_core_device):
+    """A device that emits only unsolicited reports (res[0] != 0x00) must not
+    cause the driver to spin forever.  The single retry budget covers both
+    res[0] != 0x00 and stale echo cases."""
+    commander_core_device.device.read = lambda length: [0xFF, 0x02, 0x00] + [0] * (length - 3)
+    commander_core_device.device.write = lambda data: len(data)
+    with pytest.raises(ExpectationNotMet):
+        commander_core_device._send_command((0x02, 0x13))


### PR DESCRIPTION
# commander_core: three independent driver fixes

This PR contains three small, independent fixes to `liquidctl/driver/commander_core.py`. Each commit is self-contained and reviewable on its own; together they harden the driver against bad inputs, IEEE-754 surprises, and a tolerance gap in the HID response loop.

**This PR does NOT claim to fix #753** (intermittent `set` failures on firmware 2.x). Hardware investigation on a Commander ST 0x0c32 / fw 2.0.17 strongly suggests #753 is a firmware-side lockup, not a driver bug; details in a separate comment on that issue.

## Commits

### 1. `commander_core: raise ValueError on invalid curve point count`

The two bound checks in `set_speed_profile` constructed a `ValueError` but never raised it, so out-of-range curve sizes were silently no-op'd and the function proceeded to encode garbage payloads. Adds the missing `raise` to both sites.

```python
if len(curve_points) < 2:
-    ValueError('a minimum of 2 speed curve points must be configured.')
+    raise ValueError('a minimum of 2 speed curve points must be configured.')
if len(curve_points) > 7:
-    ValueError('a maximum of 7 speed curve points may be configured.')
+    raise ValueError('a maximum of 7 speed curve points may be configured.')
```

Tests cover both bounds via `pytest.raises(ValueError)`.

### 2. `commander_core: round float curve temperatures to decidegrees`

Curve temperatures are encoded on the wire as little-endian uint16 decidegrees (`temp * 10`). The existing `int.to_bytes(temp*10, ...)` call relies on `temp` being an integer; under IEEE-754 a literal float like `31.3` evaluates to `312.999999...` and `int.to_bytes()` truncates to **312** instead of the intended **313** — silently encoding the wrong set point.

```python
- new_data.append(int.to_bytes(temp*10, length=2, byteorder="little", signed=False))
+ new_data.append(int.to_bytes(round(temp * 10), length=2, byteorder="little", signed=False))
```

Test confirms `set_speed_profile('fan1', [(20.0, 0), (31.3, 50)])` stores 31.3 (313 decidegrees) instead of 31.2 (312).

### 3. `commander_core: bounded retry in _send_command, raise instead of assert`

The response-validation in `_send_command` had two related problems:

1. **`assert buf[1] == command[0]`** is the only check that a returned report actually corresponds to the command just sent. Asserts are stripped by `python -O`, so under optimisation the driver silently accepts mismatched reports and decodes garbage.

2. **The `while res[0] != 0x00` loop** drains unsolicited reports until a valid one arrives or `device.read()` times out. If the first matching `res[0]==0x00` report has the wrong `res[1]` (a stale echo from an in-flight command), the assert above fires; with asserts disabled, the wrong buffer is returned.

Replaces both with a single bounded retry loop (`_MAX_RESPONSE_RETRIES = 16` attempts) that requires BOTH `res[0]==0x00` AND `res[1]==command[0]`, and raises `ExpectationNotMet` on persistent mismatch.

```python
- res = self.device.read(_RESPONSE_LENGTH)
- while res[0] != 0x00:
-     res = self.device.read(_RESPONSE_LENGTH)
- buf = bytes(res)
- assert buf[1] == command[0], 'response does not match command'
- return buf
+ retries = _MAX_RESPONSE_RETRIES
+ while True:
+     res = self.device.read(_RESPONSE_LENGTH)
+     if res[0] == 0x00 and res[1] == command[0]:
+         return bytes(res)
+     retries -= 1
+     if retries <= 0:
+         raise ExpectationNotMet('response does not match command')
```

Same semantics on the happy path; tolerant of stale echoes and unsolicited reports; survives `python -O`. Two new tests cover persistent-wrong-echo and persistent-nonzero-report-id paths.

## Test plan

- [x] `pytest tests/test_commander_core.py` passes (17/17, including 5 new tests)
- [x] Full `pytest` suite shows no regressions (pre-existing PermissionError failures on `/var/run/liquidctl` are unrelated to this PR)
- [x] `liquidctl set fan4 speed N` verified on hardware (Commander ST 0x0c32 fw 2.0.17)
- [x] `liquidctl set fan4 speed (T1 P1)(T2 P2)...` verified with both int and float temperatures
