### PR TITLE
msi: fix Coreliquid probe dropping the control interface

### DIFF
--- a/liquidctl/driver/msi.py
+++ b/liquidctl/driver/msi.py
@@ -26,6 +26,7 @@ from liquidctl.util import RelaxedNamesEnum, check_unsafe, clamp, u16le_from
 _LOGGER = logging.getLogger(__name__)
 
 EXTRA_USAGE_PAGE = 0x0001
+_CONTROL_USAGE = 0x0000
 _MAX_DATA_LENGTH = 185
 _PER_LED_LENGTH = 720
 _REPORT_LENGTH = 64
@@ -367,7 +368,8 @@ class MpgCooler(UsbHidDriver):
         # have the desired usage page, or that on that system a
         # single handle is returned for that device interface (see: #259)
 
-        if handle.hidinfo["usage_page"] == EXTRA_USAGE_PAGE:
+        if (handle.hidinfo["usage_page"] == EXTRA_USAGE_PAGE
+                and handle.hidinfo["usage"] != _CONTROL_USAGE):
             return
         yield from super().probe(handle, **kwargs)
 

--- a/liquidctl/driver/msi.py
+++ b/liquidctl/driver/msi.py
@@ -368,8 +368,10 @@ class MpgCooler(UsbHidDriver):
         # have the desired usage page, or that on that system a
         # single handle is returned for that device interface (see: #259)
 
-        if (handle.hidinfo["usage_page"] == EXTRA_USAGE_PAGE
-                and handle.hidinfo["usage"] != _CONTROL_USAGE):
+        if (
+            handle.hidinfo["usage_page"] == EXTRA_USAGE_PAGE
+            and handle.hidinfo["usage"] != _CONTROL_USAGE
+        ):
             return
         yield from super().probe(handle, **kwargs)
 


### PR DESCRIPTION
The MSI MPG Coreliquid driver fails to detect the cooler on hidapi
backends that populate HID usage information (for example recent hidraw
on Linux): `liquidctl list` does not show the device, and direct
commands return "no device matches available drivers and selection
criteria".

`MpgCooler.probe()` skipped every handle on usage page 0x0001 (Generic
Desktop) to ignore redundant top level usages. On these backends,
however, the cooler exposes a single handle, and it is the control
interface itself, reported as usage page 0x0001 / usage 0x0000, so it
was dropped and the device disappeared.

Genuine extra top level usages carry a nonzero usage id (for example
0x0080 system control, 0x0006 keyboard), while the primary control
collection reports usage 0x0000. This qualifies the exclusion with
`usage != 0`, mirroring the precise (page, usage) approach already used
in `rgb_fusion2.py`: the redundant handles are still ignored, but the
control interface is kept.

Verified on real hardware (MPG Coreliquid K360, Linux/hidraw): before
the change `liquidctl list` omits the cooler; after it, the cooler is
detected and status, lighting, and fan commands work. The full test
suite passes (534 passed, 2 preexisting skips).

I could only test on Linux. The change widens which handles are accepted
on usage page 0x0001, so confirmation from a Windows user with an MSI
Coreliquid would be welcome. The HID usage tables and the existing
rgb_fusion2 handling both suggest the redundant Windows handles carry a
nonzero usage.

Related: #259
