### PR TITLE
Add driver for Enermax Liqtech XTR pump-head LCD (USB 2e3c:0a12)

### DIFF
--- a/liquidctl/driver/__init__.py
+++ b/liquidctl/driver/__init__.py
@@ -43,6 +43,7 @@ from liquidctl.driver import nzxt_epsu
 from liquidctl.driver import rgb_fusion2
 from liquidctl.driver import smart_device
 from liquidctl.driver import ga2_lcd
+from liquidctl.driver import enermax_liqtech_xtr
 
 if sys.platform == 'linux':
     from liquidctl.driver import ddr4

--- a/liquidctl/driver/enermax_liqtech_xtr.py
+++ b/liquidctl/driver/enermax_liqtech_xtr.py
@@ -1,0 +1,151 @@
+# Copyright 2024  liquidctl contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""liquidctl driver for Enermax Liqtech XTR series liquid coolers.
+
+Protocol reverse-engineered from the USB traffic on Linux; no vendor
+documentation was available.  The device is a USB HID peripheral that
+controls the LCD display on the pump head of the Liqtech XTR AIO cooler.
+It does not expose any readable sensor data over USB.
+
+Copyright 2024  liquidctl contributors
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+import logging
+
+from liquidctl.driver.usb import UsbHidDriver
+from liquidctl.error import NotSupportedByDriver
+
+LOGGER = logging.getLogger(__name__)
+
+# Every outbound report starts with this ID followed by 64 bytes of data.
+_REPORT_ID = 0x20
+_REPORT_LEN = 65  # report-ID byte + 64 data bytes
+
+# (command_byte, hi-byte offset within the 65-byte report buffer)
+# Values are 16-bit big-endian, displayed verbatim (no unit conversion).
+_CMD_CPU  = (0x01, 5)   # primary CPU field
+_CMD_CPU2 = (0x02, 6)   # secondary CPU field — mirrors primary; hardware shows ≤2 digits
+_CMD_GPU  = (0x04, 8)   # GPU field, 4-digit capable
+_CMD_PUMP = (0x10, 11)  # pump-RPM field
+
+_CHANNELS = {
+    'cpu':  _CMD_CPU,
+    'gpu':  _CMD_GPU,
+    'pump': _CMD_PUMP,
+}
+
+_MODES = ('temperature', 'rpm')
+
+
+class EnermaxLiqtechXtr(UsbHidDriver):
+    """liquidctl driver for Enermax Liqtech XTR AIO liquid coolers.
+
+    The Liqtech XTR exposes the pump-head LCD over USB HID.  It is a
+    write-only display: no temperatures or pump speeds can be read back
+    from the device — those values must come from host sensors.
+
+    Three display fields are available via ``set_screen``:
+
+    ``cpu``
+        Primary CPU temperature field (°C).  Also written to the secondary
+        CPU field (cmd 0x02); note that field's hardware only renders the
+        two lowest digits.
+
+    ``gpu``
+        4-digit GPU field.  Use ``id * 1000 + temp_c`` to show which GPU
+        is currently displayed (e.g. ``2065`` = GPU #2 at 65 °C) and cycle
+        through multiple GPUs by calling ``set_screen`` in a loop.
+
+    ``pump``
+        Pump RPM.  Read from the host Super-I/O chip (e.g. via hwmon) and
+        pushed to the display; the USB device itself has no tachometer.
+
+    **Screen refresh:** Each field blanks after roughly 2 seconds without
+    a write.  Call ``set_screen`` from a loop or systemd service to keep
+    the display live.
+
+    Protocol (reverse-engineered; Enermax VID 0x2e3c PID 0x0a12):
+
+    - HID report ID ``0x20``, 64 data bytes (65 total including report ID).
+    - buf[1] = command byte; value big-endian at buf[off:off+2].
+    - Field offsets (in the 65-byte buffer): cpu cmd=0x01 @5, cpu2 cmd=0x02
+      @6, gpu cmd=0x04 @8, pump cmd=0x10 @11.
+    - Status command (0x10/0x01) returns only static device info; no live
+      sensor data is readable from the device.
+    """
+
+    _MATCHES = [
+        (0x2e3c, 0x0a12, 'Enermax Liqtech XTR', {}),
+    ]
+
+    def initialize(self, **kwargs):
+        """Initialize the device.
+
+        Writes zeros to all display fields to confirm USB connectivity, then
+        returns a single-entry status list identifying the device.
+        """
+        for cmd, off in (_CMD_CPU, _CMD_CPU2, _CMD_GPU, _CMD_PUMP):
+            self._write_field(cmd, off, 0)
+        return [('Device', 'Enermax Liqtech XTR', '')]
+
+    def get_status(self, **kwargs):
+        """Return device status.
+
+        The Enermax Liqtech XTR is a write-only display over USB; no sensor
+        values can be read back from the device.  Returns an empty list.
+        """
+        return []
+
+    def set_screen(self, channel, mode, value, **kwargs):
+        """Set a numeric field on the pump-head LCD.
+
+        channel  one of: cpu, gpu, pump
+        mode     one of: temperature, rpm  (informational; value displayed as-is)
+        value    integer in [0, 9999]
+
+        For ``channel='cpu'`` the value is additionally written to the
+        secondary CPU field so both fields stay consistent.
+
+        The screen requires periodic refresh (blanks after ~2 s); call this
+        method in a loop for a live display.
+        """
+        channel = channel.lower()
+        mode = mode.lower()
+        if channel not in _CHANNELS:
+            raise ValueError(
+                f'unknown channel {channel!r}, must be one of: {", ".join(_CHANNELS)}'
+            )
+        if mode not in _MODES:
+            raise ValueError(
+                f'unknown mode {mode!r}, must be one of: {", ".join(_MODES)}'
+            )
+        val = int(value)
+        if not 0 <= val <= 9999:
+            raise ValueError(f'value {val} out of range [0, 9999]')
+
+        cmd, off = _CHANNELS[channel]
+        self._write_field(cmd, off, val)
+        if channel == 'cpu':
+            self._write_field(*_CMD_CPU2, val)
+        LOGGER.debug('set_screen channel=%s mode=%s value=%d', channel, mode, val)
+
+    def set_color(self, channel, mode, colors, **kwargs):
+        """Not supported — device has no USB-controlled LEDs."""
+        raise NotSupportedByDriver
+
+    def set_fixed_speed(self, channel, duty, **kwargs):
+        """Not supported — pump speed is controlled via motherboard PWM header."""
+        raise NotSupportedByDriver
+
+    def set_speed_profile(self, channel, profile, **kwargs):
+        """Not supported — pump speed is controlled via motherboard PWM header."""
+        raise NotSupportedByDriver
+
+    def _write_field(self, cmd, off, val):
+        val = max(0, min(int(val), 9999))
+        buf = [_REPORT_ID, cmd] + [0x00] * (_REPORT_LEN - 2)
+        buf[off]     = (val >> 8) & 0xff
+        buf[off + 1] = val & 0xff
+        self.device.write(buf)

--- a/tests/test_enermax_liqtech_xtr.py
+++ b/tests/test_enermax_liqtech_xtr.py
@@ -1,0 +1,257 @@
+# Copyright 2024  liquidctl contributors
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import pytest
+
+from liquidctl.driver.enermax_liqtech_xtr import EnermaxLiqtechXtr
+from liquidctl.error import NotSupportedByDriver
+from tests._testutils import MockHidapiDevice
+
+# Report-buffer constants (matching the driver source)
+REPORT_ID = 0x20
+
+
+def _decode_field(report, offset):
+    """Return the 16-bit big-endian value at buf[offset:offset+2], where
+    buf[0] is the report ID and report.data starts at buf[1].
+    """
+    data_off = offset - 1
+    return (report.data[data_off] << 8) | report.data[data_off + 1]
+
+
+@pytest.fixture
+def device():
+    mock = MockHidapiDevice(vendor_id=0x2e3c, product_id=0x0a12, address='addr')
+    drv = EnermaxLiqtechXtr(mock, 'Enermax Liqtech XTR')
+    drv.connect()
+    return drv
+
+
+# ---------------------------------------------------------------------------
+# initialize
+# ---------------------------------------------------------------------------
+
+class TestInitialize:
+    def test_returns_device_description(self, device):
+        result = device.initialize()
+        assert result == [('Device', 'Enermax Liqtech XTR', '')]
+
+    def test_writes_zero_to_all_fields(self, device):
+        device.device.sent.clear()
+        device.initialize()
+        # 4 writes: cpu (0x01), cpu2 (0x02), gpu (0x04), pump (0x10)
+        assert len(device.device.sent) == 4
+        cmds = {r.data[0] for r in device.device.sent}
+        assert cmds == {0x01, 0x02, 0x04, 0x10}
+
+    def test_all_writes_use_report_id_0x20(self, device):
+        device.device.sent.clear()
+        device.initialize()
+        for r in device.device.sent:
+            assert r.number == REPORT_ID
+
+    def test_all_field_values_are_zero(self, device):
+        device.device.sent.clear()
+        device.initialize()
+        for r in device.device.sent:
+            # Every byte after the command byte must be 0x00
+            assert all(b == 0 for b in r.data[1:]), f'non-zero bytes in report cmd=0x{r.data[0]:02x}'
+
+
+# ---------------------------------------------------------------------------
+# get_status
+# ---------------------------------------------------------------------------
+
+class TestGetStatus:
+    def test_returns_empty_list(self, device):
+        assert device.get_status() == []
+
+    def test_does_not_write_to_device(self, device):
+        device.device.sent.clear()
+        device.get_status()
+        assert device.device.sent == []
+
+
+# ---------------------------------------------------------------------------
+# set_screen — CPU channel
+# ---------------------------------------------------------------------------
+
+class TestSetScreenCpu:
+    def test_cpu_writes_two_reports(self, device):
+        device.device.sent.clear()
+        device.set_screen('cpu', 'temperature', 45)
+        assert len(device.device.sent) == 2
+
+    def test_cpu_primary_field_cmd(self, device):
+        device.device.sent.clear()
+        device.set_screen('cpu', 'temperature', 45)
+        primary = next(r for r in device.device.sent if r.data[0] == 0x01)
+        assert _decode_field(primary, 5) == 45
+
+    def test_cpu_secondary_field_cmd(self, device):
+        device.device.sent.clear()
+        device.set_screen('cpu', 'temperature', 45)
+        secondary = next(r for r in device.device.sent if r.data[0] == 0x02)
+        assert _decode_field(secondary, 6) == 45
+
+    def test_cpu_both_reports_use_report_id_0x20(self, device):
+        device.device.sent.clear()
+        device.set_screen('cpu', 'temperature', 45)
+        for r in device.device.sent:
+            assert r.number == REPORT_ID
+
+    def test_cpu_value_zero(self, device):
+        device.device.sent.clear()
+        device.set_screen('cpu', 'temperature', 0)
+        primary = next(r for r in device.device.sent if r.data[0] == 0x01)
+        assert _decode_field(primary, 5) == 0
+
+    def test_cpu_value_max(self, device):
+        device.device.sent.clear()
+        device.set_screen('cpu', 'temperature', 9999)
+        primary = next(r for r in device.device.sent if r.data[0] == 0x01)
+        assert _decode_field(primary, 5) == 9999
+
+    def test_cpu_channel_case_insensitive(self, device):
+        device.device.sent.clear()
+        device.set_screen('CPU', 'temperature', 55)
+        assert len(device.device.sent) == 2
+
+
+# ---------------------------------------------------------------------------
+# set_screen — GPU channel
+# ---------------------------------------------------------------------------
+
+class TestSetScreenGpu:
+    def test_gpu_writes_one_report(self, device):
+        device.device.sent.clear()
+        device.set_screen('gpu', 'temperature', 2065)
+        assert len(device.device.sent) == 1
+
+    def test_gpu_cmd_byte(self, device):
+        device.device.sent.clear()
+        device.set_screen('gpu', 'temperature', 2065)
+        r = device.device.sent[0]
+        assert r.data[0] == 0x04
+
+    def test_gpu_value_offset(self, device):
+        device.device.sent.clear()
+        device.set_screen('gpu', 'temperature', 2065)
+        assert _decode_field(device.device.sent[0], 8) == 2065
+
+    def test_gpu_id_encoding_b70_1(self, device):
+        """GPU #1 at 57 °C → 1057."""
+        device.device.sent.clear()
+        device.set_screen('gpu', 'temperature', 1057)
+        assert _decode_field(device.device.sent[0], 8) == 1057
+
+    def test_gpu_id_encoding_nvidia(self, device):
+        """GPU #9 (3080) at 72 °C → 9072."""
+        device.device.sent.clear()
+        device.set_screen('gpu', 'temperature', 9072)
+        assert _decode_field(device.device.sent[0], 8) == 9072
+
+    def test_gpu_report_id(self, device):
+        device.device.sent.clear()
+        device.set_screen('gpu', 'temperature', 50)
+        assert device.device.sent[0].number == REPORT_ID
+
+
+# ---------------------------------------------------------------------------
+# set_screen — PUMP channel
+# ---------------------------------------------------------------------------
+
+class TestSetScreenPump:
+    def test_pump_writes_one_report(self, device):
+        device.device.sent.clear()
+        device.set_screen('pump', 'rpm', 2900)
+        assert len(device.device.sent) == 1
+
+    def test_pump_cmd_byte(self, device):
+        device.device.sent.clear()
+        device.set_screen('pump', 'rpm', 2900)
+        assert device.device.sent[0].data[0] == 0x10
+
+    def test_pump_value_offset(self, device):
+        device.device.sent.clear()
+        device.set_screen('pump', 'rpm', 2900)
+        assert _decode_field(device.device.sent[0], 11) == 2900
+
+    def test_pump_report_id(self, device):
+        device.device.sent.clear()
+        device.set_screen('pump', 'rpm', 2900)
+        assert device.device.sent[0].number == REPORT_ID
+
+
+# ---------------------------------------------------------------------------
+# set_screen — report length
+# ---------------------------------------------------------------------------
+
+class TestReportLength:
+    def test_report_is_65_bytes_total(self, device):
+        """Report ID + 64 data bytes = 65 total."""
+        device.device.sent.clear()
+        device.set_screen('cpu', 'temperature', 40)
+        for r in device.device.sent:
+            # MockHidapiDevice stores report.data = buf[1:], so data length = 64
+            assert len(r.data) == 64
+
+    def test_non_value_bytes_are_zero(self, device):
+        """All bytes except the command byte and the two value bytes must be 0x00."""
+        device.device.sent.clear()
+        device.set_screen('pump', 'rpm', 2900)
+        r = device.device.sent[0]
+        # cmd=0x10, value at data[10:12] (offset 11-12 in full buf)
+        for i, b in enumerate(r.data):
+            if i == 0:       # command byte
+                assert b == 0x10
+            elif i in (10, 11):  # value bytes
+                pass  # checked separately
+            else:
+                assert b == 0, f'data[{i}] = 0x{b:02x}, expected 0x00'
+
+
+# ---------------------------------------------------------------------------
+# set_screen — validation
+# ---------------------------------------------------------------------------
+
+class TestSetScreenValidation:
+    def test_unknown_channel_raises(self, device):
+        with pytest.raises(ValueError, match='unknown channel'):
+            device.set_screen('fan', 'rpm', 1000)
+
+    def test_unknown_mode_raises(self, device):
+        with pytest.raises(ValueError, match='unknown mode'):
+            device.set_screen('cpu', 'duty', 50)
+
+    def test_value_below_zero_raises(self, device):
+        with pytest.raises(ValueError, match='out of range'):
+            device.set_screen('cpu', 'temperature', -1)
+
+    def test_value_above_9999_raises(self, device):
+        with pytest.raises(ValueError, match='out of range'):
+            device.set_screen('gpu', 'temperature', 10000)
+
+    def test_value_exactly_zero_is_valid(self, device):
+        device.set_screen('pump', 'rpm', 0)  # must not raise
+
+    def test_value_exactly_9999_is_valid(self, device):
+        device.set_screen('gpu', 'temperature', 9999)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Unsupported methods
+# ---------------------------------------------------------------------------
+
+class TestUnsupportedMethods:
+    def test_set_color_raises(self, device):
+        with pytest.raises(NotSupportedByDriver):
+            device.set_color('led', 'static', [(255, 0, 0)])
+
+    def test_set_fixed_speed_raises(self, device):
+        with pytest.raises(NotSupportedByDriver):
+            device.set_fixed_speed('pump', 50)
+
+    def test_set_speed_profile_raises(self, device):
+        with pytest.raises(NotSupportedByDriver):
+            device.set_speed_profile('pump', [(20, 50), (40, 80)])


### PR DESCRIPTION
## Summary

The Enermax Liqtech XTR AIO cooler has a numeric LCD on the pump head that accepts live data over USB HID. No vendor documentation or prior Linux/liquidctl support existed; the protocol was fully reverse-engineered by iterative black-box probing of the HID interface on a Proxmox Linux host (the Windows companion app could not be used as a reference because GPU temperatures were passed through to a VM, leaving the screen blank).

**Protocol (reverse-engineered):**
- HID report ID `0x20`, 64 data bytes
- Values are 16-bit big-endian, displayed verbatim (no unit conversion by device)
- Three writable display fields:

  | Field | Command | Byte offset | Display capacity |
  |-------|---------|-------------|------------------|
  | CPU temp | `0x01` | 5–6 | 4 digits |
  | GPU temp | `0x04` | 8–9 | 4 digits |
  | Pump RPM | `0x10` | 11–12 | 4 digits |

- A secondary CPU field (`0x02` @6–7) exists but its hardware renders only ~2 digits; the driver mirrors the primary CPU value there silently.
- Screen blanks if any field is not refreshed within ~2 seconds.
- No sensor data is readable from the device over USB (`get_status` returns `[]`).

## New file: `liquidctl/driver/enermax_liqtech_xtr.py`

Exposes three channels via `set_screen`:

```bash
liquidctl set cpu screen temperature 45
liquidctl set gpu screen temperature 2065   # GPU #2 at 65 °C  (id × 1000 + temp_c)
liquidctl set pump screen rpm 2900
```

The `id × 1000 + temp_c` convention for the GPU field encodes which GPU is currently shown in the leading digit, enabling multiple-GPU cycling from a daemon without needing a separate field.

`set_color`, `set_fixed_speed`, and `set_speed_profile` raise `NotSupportedByDriver` — the device has no USB-controlled LEDs and pump speed is PWM-controlled via the motherboard header.

## New file: `tests/test_enermax_liqtech_xtr.py`

30 unit tests covering all channels, byte offsets, report length, boundary values, validation errors, and unsupported-method errors.

## Tested on

- Proxmox VE 9 / Linux 6.x, Enermax Liqtech XTR 360 (USB `2e3c:0a12`)
- All three display fields confirmed working at 1 s refresh cadence
