### PR TITLE
asus_ryujin: Ryujin III LCD screen support + persistent flash-slot image/gif upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [Unreleased]
+
+Added:
+
+- ASUS Ryujin III: persistent flash-slot LCD content via `set lcd screen image`
+  (still image) and `set lcd screen gif` (animation). Unlike the volatile
+  `static` framebuffer, these upload to the cooler's onboard flash like Armoury
+  Crate does, so the firmware replays the content across reboots. The upload is
+  gated on the device's async flow-control notifications, which is what makes
+  the write commit to flash.
+
 ## [1.16.0] – 2026-03-03
 
 ### Changes since 1.15.0

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Device notes are sorted alphabetically, major (upper case) notes before minor
 | Type               | Device family and specific documentation | Notes | MRLV |
 | :--                | :-- | :-- | :-: |
 | AIO liquid cooler  | [ASUS Ryujin II 360](docs/asus-ryujin-guide.md) | p | 1.14.0 |
-| AIO liquid cooler  | [ASUS Ryujin III 360, EVA, Extreme, White](docs/asus-ryujin3-guide.md) | p | 1.16.0 |
+| AIO liquid cooler  | [ASUS Ryujin III 360, EVA, Extreme, White](docs/asus-ryujin3-guide.md) | | git |
 | AIO liquid cooler  | [ASUS Ryuo I 240](docs/asus-ryuo-guide.md) | p | 1.16.0 |
 | AIO liquid cooler  | [Corsair Hydro H110i GT](docs/coolit-guide.md) | p | 1.14.0 |
 | AIO liquid cooler  | [Corsair Hydro H80i GT, H100i GTX, H110i GTX](docs/asetek-690lc-guide.md) | Z | 1.9.1 |

--- a/docs/asus-ryujin3-guide.md
+++ b/docs/asus-ryujin3-guide.md
@@ -67,4 +67,75 @@ Pump impeller and embedded fan duty values approximately map to the following sp
 
 ## Screen
 
-The screen of the cooler is not yet supported.
+_New in git._
+
+The Ryujin III has a 320x240 LCD. The screen can be controlled via the `lcd` channel.
+
+### Display a static image
+
+```
+# liquidctl set lcd screen static /path/to/image.png
+```
+
+Any image format supported by Pillow (PNG, JPEG, BMP, etc.) will be automatically
+resized to 320x240 and displayed. Requires `Pillow` (`pip install Pillow`).
+
+### Built-in animation
+
+Switch back to the default ROG animation:
+
+```
+# liquidctl set lcd screen liquid
+```
+
+### Clock mode
+
+Display a clock synced to the system time:
+
+```
+# liquidctl set lcd screen clock 24h
+# liquidctl set lcd screen clock 12h
+```
+
+### Hardware monitor
+
+Display live sensor readings (liquid temperature, pump RPM, fan RPM):
+
+```
+# liquidctl set lcd screen monitor
+```
+
+### Turn off the display
+
+```
+# liquidctl set lcd screen off
+```
+
+### Set brightness
+
+```
+# liquidctl set lcd screen brightness 50
+```
+
+Values range from 0 (off) to 100 (maximum).
+
+### Set orientation
+
+```
+# liquidctl set lcd screen orientation 0
+# liquidctl set lcd screen orientation 1
+```
+
+Where `0` is horizontal (default) and `1` is vertical (rotated). Values `2` and `3` are 180° and 270°.
+
+### Standby / Wake
+
+Put the display to sleep (for system suspend) or wake it back up:
+
+```
+# liquidctl set lcd screen standby
+# liquidctl set lcd screen wake
+```
+
+The standby command sends `EC 5C 20` which the firmware uses for ACPI sleep.
+Wake sends `EC 5C 10` (display reset).

--- a/docs/asus-ryujin3-guide.md
+++ b/docs/asus-ryujin3-guide.md
@@ -104,10 +104,22 @@ These uploads are paced by the device's own flow-control notifications (the
 firmware acknowledges each chunk before the next is sent), which is what makes
 the write actually commit to flash.
 
-> **Note:** after a lot of rapid back-to-back uploads the cooler's flash upload
-> state can wedge — the upload reports `flash slot not ready` and recommends a
-> power-cycle. A full power-cycle (so the cooler's USB rails fully drain) clears
-> it; a soft reboot does not. In normal one-off use you will not hit this.
+> **Note — avoid concurrent access during the upload.** A flash upload is a
+> single erase → write → commit transaction gated by the firmware's flow-control
+> reads. If another process touches the cooler's HID interface *during* the
+> upload — most commonly a monitoring tool such as OpenRGB or a second
+> `liquidctl` polling the same device — its reads can consume the flow-control
+> notifications the uploader is waiting for, desynchronising the transaction.
+> The firmware is then left mid-erase and reports `flash slot not ready`
+> (erase status `ee13 1001`) on the next attempt. Stop any such tool for the few
+> seconds the upload runs, then restart it afterwards.
+>
+> If the slot does wedge, the upload first attempts an automatic recovery
+> (a clean begin/arm/erase sweep) and one retry; do **not** loop further manual
+> retries, as each interrupted attempt deepens the wedge. A *deep* wedge survives
+> a soft reboot, USB reset and rebind — only a full power-cycle (so the cooler's
+> USB +5V rails fully drain) clears it. In normal one-off use you will not hit
+> this.
 
 ### Built-in animation
 

--- a/docs/asus-ryujin3-guide.md
+++ b/docs/asus-ryujin3-guide.md
@@ -80,6 +80,35 @@ The Ryujin III has a 320x240 LCD. The screen can be controlled via the `lcd` cha
 Any image format supported by Pillow (PNG, JPEG, BMP, etc.) will be automatically
 resized to 320x240 and displayed. Requires `Pillow` (`pip install Pillow`).
 
+This `static` mode writes the image to the **live framebuffer**: it is shown
+immediately but is **volatile** — the panel reverts to its built-in animation on
+reboot, because nothing is stored on the cooler.
+
+### Persistent image / animation (survives reboot)
+
+To store content in the cooler's onboard flash like Armoury Crate does — so the
+firmware replays it across reboots without the host running — use `image` (for a
+still image) or `gif` (for an animation):
+
+```
+# liquidctl set lcd screen image /path/to/image.jpg
+# liquidctl set lcd screen gif /path/to/animation.gif
+```
+
+`image` stores a single still (uploaded as JPEG) into the static slideshow slot;
+`gif` stores an animated GIF into an animation slot and loops it. Both are
+resized to 320x240 and require `Pillow`. Unlike `static`, the result persists
+across reboots.
+
+These uploads are paced by the device's own flow-control notifications (the
+firmware acknowledges each chunk before the next is sent), which is what makes
+the write actually commit to flash.
+
+> **Note:** after a lot of rapid back-to-back uploads the cooler's flash upload
+> state can wedge — the upload reports `flash slot not ready` and recommends a
+> power-cycle. A full power-cycle (so the cooler's USB rails fully drain) clears
+> it; a soft reboot does not. In normal one-off use you will not hit this.
+
 ### Built-in animation
 
 Switch back to the default ROG animation:

--- a/docs/developer/protocol/asus_ryujin.md
+++ b/docs/developer/protocol/asus_ryujin.md
@@ -80,6 +80,101 @@ The data of all usb packets is 65 bytes long, prefixed with `0xEC`.
     - Header: `0xEC 0x21`
 
 
+## Display Operations
+
+### Switch display mode
+
+- Request:
+    - Header: `0xEC 0x51`
+    - Data:
+        - Byte 2: Display mode
+            - `0x00` = off
+            - `0x04` = animation (built-in ROG animation)
+            - `0x08` = clock
+            - `0x10` = single animation
+            - `0x20` = framebuffer (static image via bulk EP)
+            - `0x21` = hardware monitor
+- Response:
+    - Header: `0xEC 0x51 0x00`
+
+### Set hardware monitor layout
+
+- Request:
+    - Header: `0xEC 0x52`
+    - Data:
+        - Byte 2: Background style (`0x00` = galactic, `0x01` = cyberpunk, `0x02` = custom)
+        - Byte 3: Number of lines (upper nibble)
+        - Byte 4: Number of lines (lower nibble)
+        - Byte 5: Reserved (`0x00`)
+        - Byte 6-9: Background color (R, G, B, alpha)
+        - Byte 10-13: Text color line 1 (R, G, B, alpha)
+        - Byte 14-17: Text color line 2 (R, G, B, alpha)
+        - Byte 18-21: Text color line 3 (R, G, B, alpha)
+        - Byte 22-25: Text color line 4 (R, G, B, alpha)
+- Response:
+    - Header: `0xEC 0x52 0x00`
+
+### Set hardware monitor string
+
+- Request:
+    - Header: `0xEC 0x53`
+    - Data:
+        - Byte 2: Line index (0-based)
+        - Byte 3-20: Label string (18 bytes, null-padded UTF-8)
+        - Byte 21-32: Value string (12 bytes, null-padded UTF-8)
+- Response:
+    - Header: `0xEC 0x53 0x00`
+
+### Set display option
+
+- Request:
+    - Header: `0xEC 0x5C`
+    - Data:
+        - Byte 2: Sub-command
+            - `0x01` = set config (followed by display_type, mode, orientation, reserved, brightness)
+            - `0x10` = reset (wake from standby)
+            - `0x20` = standby (screen off for system sleep)
+        - For sub-command `0x01`:
+            - Byte 3: Display type
+            - Byte 4: Mode byte
+            - Byte 5: Orientation (0-3 for 0°, 90°, 180°, 270°)
+            - Byte 6: Reserved
+            - Byte 7: Brightness (0-100 %)
+- Response:
+    - Header: `0xEC 0x5C 0x00`
+
+### Set clock
+
+- Request:
+    - Header: `0xEC 0x11`
+    - Data:
+        - Byte 2-3: Reserved (`0x00 0x00`)
+        - Byte 4: Prefix (`0x08`)
+        - Byte 5: Reserved (`0x00`)
+        - Byte 6: Hour format (`0x00` = 24h, `0x01` = 12h)
+        - Byte 7: Hour (BCD encoded)
+        - Byte 8: Minute (BCD encoded)
+        - Byte 9: Second (BCD encoded)
+        - Byte 10: PM flag (`0x00` = AM/24h, `0x01` = PM)
+        - Byte 11: Separator flag (`0x01`)
+- Response:
+    - Header: `0xEC 0x11 0x00`
+
+### Flush framebuffer
+
+Used after sending a static image via the bulk endpoint.
+
+- Request:
+    - Header: `0xEC 0x7F`
+    - Data:
+        - Byte 2: `0x03`
+        - Byte 3-4: Frame size bytes (`0x00 0x84 0x03` = 230400 = 320x240x3)
+- Response:
+    - Header: `0xEC 0x7F 0x00`
+
+Note: All display commands send ACK responses (`0xEC` + command byte + status).
+
+
 ## Unknown
 
 - Request:

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -249,7 +249,13 @@ Cooling channels: \fIpump\fR, \fIfans\fR, \fIpump\-fan\fR, \fIexternal\-fans\fR.
 .SS ASUS Ryujin III 360, EVA, Extreme, White
 Cooling channels: \fIpump\fR, \fIpump\-fan\fR.
 .PP
-Screen: not yet supported.
+Screen channel: \fIlcd\fR.
+Screen modes: \fIstatic\fR, \fIliquid\fR, \fIclock\fR, \fImonitor\fR, \fIoff\fR,
+\fIstandby\fR, \fIwake\fR, \fIbrightness\fR, \fIorientation\fR, \fIrelease\fR.
+.PP
+\fIstatic\fR requires a path to an image file and the Pillow package.
+\fIrelease\fR returns pump control to the internal Asetek controller;
+the embedded fan has no internal controller and must always be host\-driven.
 .SS ASUS Ryuo II 240
 Cooling channels: \fIfans\fR, \fIfan\fR. There is only a single fan channel.
 .SS Corsair iCUE Elite Capellix H100i, H115i, H150i

--- a/liquidctl/driver/asus_ryujin.py
+++ b/liquidctl/driver/asus_ryujin.py
@@ -1,13 +1,18 @@
-"""liquidctl driver for the ASUS Ryujin II and Ryujin III EXTREME / 360 liquid coolers.
+"""liquidctl driver for the ASUS Ryujin II and Ryujin III liquid coolers.
+
+Supports fan/pump control, sensor monitoring, and LCD screen control for
+Ryujin III models (320x240 BGR display).
 
 Copyright Florian Freudiger and contributors
 SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import logging
+import sys
+import time
 from typing import List
 
-from liquidctl.driver.usb import UsbHidDriver
+from liquidctl.driver.usb import PyUsbDevice, UsbHidDriver
 from liquidctl.error import ExpectationNotMet, NotSupportedByDriver
 from liquidctl.util import clamp, u16le_from, rpadlist, fraction_of_byte
 
@@ -22,10 +27,37 @@ _REQUEST_GET_COOLER_STATUS = (0x99, 0x19)
 _REQUEST_GET_COOLER_DUTY = (0x9A, 0x1A)
 _REQUEST_GET_CONTROLLER_DUTY = (0xA1, 0x21)
 _REQUEST_GET_CONTROLLER_SPEED = (0xA0, 0x20)
+_REQUEST_GET_DISPLAY_OPTION = (0xDC, 0x5C)
 
 # Command headers that don't need a response
 _CMD_SET_COOLER_SPEED = 0x1A
 _CMD_SET_CONTROLLER_SPEED = 0x21
+_CMD_SWITCH_DISPLAY_MODE = 0x51
+_CMD_SET_HW_MONITOR_LAYOUT = 0x52
+_CMD_SET_HW_MONITOR_STRING = 0x53
+_CMD_SET_DISPLAY_OPTION = 0x5C
+_CMD_SET_CLOCK = 0x11
+_CMD_FLUSH_FRAMEBUFFER = 0x7F
+
+# Display mode bytes (wire encoding, from ryujin.py DisplayMode enum)
+_DISPLAY_MODE_OFF = 0x00
+_DISPLAY_MODE_ANIMATION = 0x04
+_DISPLAY_MODE_CLOCK = 0x08
+_DISPLAY_MODE_SINGLE_ANIM = 0x10
+_DISPLAY_MODE_SLIDESHOW = 0x1F
+_DISPLAY_MODE_FRAMEBUFFER = 0x20
+_DISPLAY_MODE_HW_MONITOR = 0x21
+
+# LCD parameters
+_LCD_WIDTH = 320
+_LCD_HEIGHT = 240
+_LCD_BPP = 3  # BGR, 3 bytes/pixel
+_LCD_FRAME_SIZE = _LCD_WIDTH * _LCD_HEIGHT * _LCD_BPP  # 230,400 bytes
+
+# Endpoints
+_EP_BULK_OUT = 0x01
+_EP_HID_OUT = 0x02
+_EP_HID_IN = 0x82
 
 _STATUS_FIRMWARE = "Firmware version"
 _STATUS_TEMPERATURE = "Liquid temperature"
@@ -36,9 +68,16 @@ _STATUS_COOLER_FAN_DUTY = "Pump fan duty"
 _STATUS_CONTROLLER_FAN_SPEED = "External fan {} speed"
 _STATUS_CONTROLLER_FAN_DUTY = "External fan duty"
 
+# HW monitor background styles
+_HW_MONITOR_STYLES = {
+    "galactic": 0x00,
+    "cyberpunk": 0x01,
+    "custom": 0x02,
+}
+
 
 class AsusRyujin(UsbHidDriver):
-    """ASUS Ryujin II & Ryujin III Extreme / 360 / White Edition liquid coolers."""
+    """ASUS Ryujin II & Ryujin III liquid coolers."""
 
     _MATCHES = [
         (
@@ -51,6 +90,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 7,
                 "temp_offset": 3,
                 "duty_channel": 0,
+                "has_lcd": False,
             },
         ),
         (
@@ -63,6 +103,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 10,
                 "temp_offset": 5,
                 "duty_channel": 1,
+                "has_lcd": True,
             },
         ),
         (
@@ -75,6 +116,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 10,
                 "temp_offset": 5,
                 "duty_channel": 1,
+                "has_lcd": True,
             },
         ),
         (
@@ -87,6 +129,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 10,
                 "temp_offset": 5,
                 "duty_channel": 1,
+                "has_lcd": True,
             },
         ),
         (
@@ -99,6 +142,7 @@ class AsusRyujin(UsbHidDriver):
                 "pump_fan_speed_offset": 10,
                 "temp_offset": 5,
                 "duty_channel": 1,
+                "has_lcd": True,
             },
         ),
     ]
@@ -112,6 +156,7 @@ class AsusRyujin(UsbHidDriver):
         pump_fan_speed_offset,
         temp_offset,
         duty_channel,
+        has_lcd=False,
         **kwargs,
     ):
         super().__init__(device, description, **kwargs)
@@ -121,10 +166,88 @@ class AsusRyujin(UsbHidDriver):
         self._pump_fan_speed_offset = pump_fan_speed_offset
         self._temp_offset = temp_offset
         self._duty_channel = duty_channel
+        self._has_lcd = has_lcd
+        self._bulk_device = None
 
     def initialize(self, **kwargs):
         msg = self._request(*_REQUEST_GET_FIRMWARE)
         return [(_STATUS_FIRMWARE, "".join(map(chr, msg[3:18])), "")]
+
+    def _get_raw_usb_device(self):
+        """Get a raw pyusb device handle for bulk + HID access.
+
+        Opens a pyusb handle alongside the existing hidapi handle.
+        The hidapi handle is closed first to avoid conflicts.
+        Must call _release_raw_usb_device() after.
+        """
+        if self._bulk_device is not None:
+            return self._bulk_device
+
+        import usb.core
+        import usb.util
+
+        # Close hidapi handle to release the HID interface
+        try:
+            self.device.close()
+        except Exception:
+            pass
+
+        # Find and configure the raw USB device
+        dev = usb.core.find(
+            idVendor=self.vendor_id,
+            idProduct=self.product_id,
+        )
+        if dev is None:
+            raise ExpectationNotMet("could not find USB device for LCD")
+
+        # Detach kernel drivers on both interfaces
+        for i in range(2):
+            try:
+                if dev.is_kernel_driver_active(i):
+                    dev.detach_kernel_driver(i)
+            except Exception:
+                pass
+
+        try:
+            dev.set_configuration()
+        except usb.core.USBError:
+            pass  # already configured
+
+        # Claim both interfaces
+        for i in range(2):
+            try:
+                usb.util.claim_interface(dev, i)
+            except Exception:
+                pass
+
+        self._bulk_device = dev
+        _LOGGER.debug("opened raw USB device for LCD")
+        return dev
+
+    def _release_raw_usb_device(self):
+        """Release the raw USB device and reattach kernel drivers."""
+        if self._bulk_device is not None:
+            import usb.util
+            for i in range(2):
+                try:
+                    usb.util.release_interface(self._bulk_device, i)
+                except Exception:
+                    pass
+            # Reattach kernel HID driver so hidapi works on next invocation
+            try:
+                self._bulk_device.attach_kernel_driver(1)
+            except Exception:
+                pass
+            try:
+                usb.util.dispose_resources(self._bulk_device)
+            except Exception:
+                pass
+            self._bulk_device = None
+
+    def close(self, **kwargs):
+        if self._bulk_device:
+            self._release_raw_usb_device()
+        super().close(**kwargs)
 
     def _get_cooler_duty(self) -> (int, int):
         """Get current pump and embedded fan duty in %."""
@@ -225,9 +348,357 @@ class AsusRyujin(UsbHidDriver):
         for handler in handlers:
             handler(duty)
 
+    def set_speed_profile(self, channel, profile, **kwargs):
+        """Not supported — use set_fixed_speed or ryujin_fand for curves.
+
+        To release back to the internal pump controller:
+
+            liquidctl --match Ryujin set pump speed auto
+        """
+        raise NotSupportedByDriver(
+            "speed profiles are host-driven on this device; "
+            "use set_fixed_speed or the ryujin_fand daemon for fan curves"
+        )
+
+    def _release_cooler_control(self):
+        """Release pump back to internal Asetek pump controller (ctrl_src=0).
+
+        Only the pump has an internal controller. The embedded fan has no
+        internal controller — it stays at whatever duty was last set (or 0 = off).
+        The fan must always be driven by the host.
+        """
+        self._write([_PREFIX, _CMD_SET_COOLER_SPEED, 0x00, 0x00, 0x00])
+
+    # ── LCD Screen Control ──────────────────────────────────────────────
+
     def set_screen(self, channel, mode, value, **kwargs):
-        # Not yet reverse engineered / implemented
-        raise NotSupportedByDriver()
+        """Set the screen mode and content.
+
+        Unstable.
+
+        Supported channels, modes and values:
+
+        | Channel | Mode | Value |
+        | --- | --- | --- |
+        | `lcd` | `static` | path to image file |
+        | `lcd` | `liquid` | — (built-in ROG animation) |
+        | `lcd` | `clock` | `24h` or `12h` (default: `24h`) |
+        | `lcd` | `monitor` | — (HW monitor showing live stats) |
+        | `lcd` | `off` | — |
+        | `lcd` | `standby` | — (screen off for system sleep) |
+        | `lcd` | `wake` | — (screen on, resume from standby) |
+        | `lcd` | `release` | — (release pump to internal controller; fan stays at last duty) |
+        | `lcd` | `brightness` | int between `0` and `100` (%) |
+        | `lcd` | `orientation` | `0`, `1`, `2` or `3` (0°, 90°, 180°, 270°) |
+
+        Requires Ryujin III (models with LCD display).
+        """
+        if not self._has_lcd:
+            raise NotSupportedByDriver("this model does not have an LCD")
+
+        if channel.lower() != "lcd":
+            raise ValueError(f"invalid channel: {channel}, expected: lcd")
+
+        if mode == "static":
+            # Static image needs bulk EP — use pyusb
+            if value is None:
+                raise ValueError("static mode requires a path to an image file")
+            self._set_screen_static(value)
+            self._release_raw_usb_device()
+        elif mode == "liquid":
+            self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_ANIMATION])
+        elif mode == "clock":
+            fmt_24h = value != "12h"
+            self._set_screen_clock_hid(fmt_24h)
+        elif mode == "monitor":
+            self._set_screen_hw_monitor_hid(**kwargs)
+        elif mode == "off":
+            self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_OFF])
+        elif mode == "standby":
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION, 0x20])
+        elif mode == "wake":
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION, 0x10])
+        elif mode == "brightness":
+            if value is None:
+                raise ValueError("brightness mode requires a value (0-100)")
+            brightness = clamp(int(value), 0, 100)
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION,
+                         0x01, 0x00, 0x00, 0x00, 0x00, brightness])
+        elif mode == "orientation":
+            if value is None:
+                raise ValueError("orientation requires 0-3 (0°, 90°, 180°, 270°)")
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION,
+                         0x01, 0x00, 0x00, int(value)])
+        elif mode == "release":
+            self._release_cooler_control()
+        else:
+            raise ValueError(
+                f"invalid mode: {mode}, valid: static, liquid, clock, monitor, off, "
+                f"standby, wake, brightness, orientation, release"
+            )
+
+    def _raw_hid_write(self, cmd: list):
+        """Write a HID command via raw pyusb (not hidapi).
+
+        Used during LCD operations when we have the raw USB handle.
+        """
+        dev = self._get_raw_usb_device()
+        payload = [_PREFIX] + (cmd + [0] * 64)[:64]
+        dev.write(_EP_HID_OUT, payload)
+
+    def _raw_hid_request(self, request_header: int, response_header: int) -> list:
+        """Send a command and read response via raw pyusb."""
+        dev = self._get_raw_usb_device()
+        payload = [_PREFIX, request_header] + [0] * 63
+        dev.write(_EP_HID_OUT, payload)
+        msg = dev.read(_EP_HID_IN, _REPORT_LENGTH, timeout=1000)
+        return list(msg)
+
+    def _raw_get_cooler_status(self):
+        """Read sensors via raw pyusb (used during LCD operations)."""
+        msg = self._raw_hid_request(0x99, 0x19)
+        liquid_temp = msg[self._temp_offset] + msg[self._temp_offset + 1] / 10
+        pump_speed = u16le_from(msg, self._pump_speed_offset)
+        pump_fan_speed = u16le_from(msg, self._pump_fan_speed_offset)
+        return liquid_temp, pump_speed, pump_fan_speed
+
+    def _switch_display_mode(self, mode_byte: int):
+        """Send EC 51 to switch display mode."""
+        self._raw_hid_write([_CMD_SWITCH_DISPLAY_MODE, mode_byte])
+        _LOGGER.debug("switched display mode to 0x%02x", mode_byte)
+
+    def _flush_framebuffer(self):
+        """Send EC 7F 03 00 84 03 to flush framebuffer to LCD."""
+        self._raw_hid_write([_CMD_FLUSH_FRAMEBUFFER, 0x03, 0x00, 0x84, 0x03])
+
+    def _write_bulk(self, data: bytes):
+        """Write raw data to bulk OUT endpoint."""
+        dev = self._get_raw_usb_device()
+        dev.write(_EP_BULK_OUT, data)
+
+    def _set_screen_static(self, path: str):
+        """Display a static image on the LCD.
+
+        Loads the image, converts to 320x240 BGR, sends via bulk endpoint,
+        then flushes. The image stays on screen until another mode is set.
+        """
+        try:
+            from PIL import Image
+        except ImportError:
+            raise NotSupportedByDriver(
+                "Pillow is required for static image mode: pip install Pillow"
+            )
+
+        img = Image.open(path)
+        img = img.resize((_LCD_WIDTH, _LCD_HEIGHT), Image.LANCZOS)
+        img = img.convert("RGB")
+
+        # Convert RGB to BGR byte array
+        pixels = img.tobytes()
+        bgr = bytearray(_LCD_FRAME_SIZE)
+        for i in range(0, len(pixels), 3):
+            bgr[i] = pixels[i + 2]      # B
+            bgr[i + 1] = pixels[i + 1]  # G
+            bgr[i + 2] = pixels[i]      # R
+
+        self._switch_display_mode(_DISPLAY_MODE_FRAMEBUFFER)
+        time.sleep(0.1)
+        self._write_bulk(bytes(bgr))
+        self._flush_framebuffer()
+        _LOGGER.info("displayed static image: %s", path)
+
+    def _set_screen_clock_hid(self, fmt_24h: bool = True):
+        """Switch to clock mode via hidapi (no pyusb needed)."""
+        hr_fmt = 0x00 if fmt_24h else 0x01
+
+        # Configure clock display (EC 5D)
+        self._write([_PREFIX, 0x5D, 0x00, 0x01, 0x08, 0x00, hr_fmt, 0x05])
+        time.sleep(0.05)
+
+        # Sync RTC
+        t = time.localtime()
+        def bcd(val):
+            return ((val // 10) << 4) | (val % 10)
+        hour = t.tm_hour
+        pm = 0x00
+        if not fmt_24h:
+            pm = 0x01 if hour >= 12 else 0x00
+            hour = hour % 12 or 12
+        self._write([_PREFIX, _CMD_SET_CLOCK,
+                     0x00, 0x00, 0x08, 0x00, hr_fmt,
+                     bcd(hour), bcd(t.tm_min), bcd(t.tm_sec), pm, 0x01])
+        time.sleep(0.05)
+
+        # Switch to clock mode
+        self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE,
+                     _DISPLAY_MODE_CLOCK, 0x00, hr_fmt])
+
+    def _set_screen_hw_monitor_hid(self, **kwargs):
+        """Switch to HW monitor mode via hidapi (no pyusb needed)."""
+        # Read sensors while we have the HID handle
+        try:
+            liquid_temp, pump_speed, pump_fan_speed = self._get_cooler_status()
+        except Exception:
+            liquid_temp, pump_speed, pump_fan_speed = 0, 0, 0
+
+        style = _HW_MONITOR_STYLES.get(kwargs.get("style", "custom"), 0x02)
+
+        # Layout (EC 52)
+        self._write([_PREFIX, _CMD_SET_HW_MONITOR_LAYOUT,
+                     style, 0x02, 0x02, 0x00,
+                     0, 0, 0, 0xFF,
+                     255, 255, 255, 0xFF,
+                     255, 255, 255, 0xFF,
+                     255, 255, 255, 0xFF,
+                     255, 255, 255, 0xFF])
+
+        # Switch mode (EC 51)
+        self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_HW_MONITOR])
+        time.sleep(0.2)
+
+        # Send sensor strings (EC 53)
+        DEGC = bytes([0xE2, 0x84, 0x83]).decode("utf-8")
+        RPM = bytes([0xE2, 0x86, 0x8C]).decode("utf-8")
+        lines = [
+            ("Liquid", f"{liquid_temp:.1f}{DEGC}"),
+            ("Pump", f"{pump_speed}{RPM}"),
+            ("Fan", f"{pump_fan_speed}{RPM}"),
+        ]
+        for i, (label, value) in enumerate(lines):
+            lb = list(label.encode("utf-8")[:18]) + [0] * 18
+            vb = list(value.encode("utf-8")[:12]) + [0] * 12
+            self._write([_PREFIX, _CMD_SET_HW_MONITOR_STRING, i] + lb[:18] + vb[:12])
+
+    def _set_screen_clock(self, fmt_24h: bool = True):
+        """Switch to clock mode and sync the RTC.
+
+        hr_fmt wire encoding: 0x00 = 24h, 0x01 = 12h (inverted from what you'd expect).
+        Verified on live hardware (S750, PID 0x1ADA).
+        """
+        hr_fmt = 0x00 if fmt_24h else 0x01
+
+        # Configure clock display (EC 5D)
+        self._raw_hid_write([0x5D, 0x00, 0x01, 0x08, 0x00, hr_fmt, 0x05])
+        time.sleep(0.05)
+
+        # Sync RTC to system time
+        self._sync_clock(fmt_24h)
+        time.sleep(0.05)
+
+        # Switch to clock mode (EC 51 08 00 HR_FMT)
+        self._raw_hid_write([_CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_CLOCK, 0x00, hr_fmt])
+        _LOGGER.info("switched to clock mode (%s)", "24h" if fmt_24h else "12h")
+
+    def _sync_clock(self, fmt_24h: bool = True):
+        """Set the device RTC to the current system time (BCD encoded).
+
+        Packet format verified against live hardware (S750, PID 0x1ADA).
+        Uses ryujin.py prefix layout + BCD time values.
+        """
+        t = time.localtime()
+        hr_fmt = 0x00 if fmt_24h else 0x01
+        pm = 0x00 if fmt_24h else (0x01 if t.tm_hour > 11 else 0x00)
+
+        def bcd(val):
+            return ((val // 10) << 4) | (val % 10)
+
+        hour = t.tm_hour
+        if not fmt_24h:
+            hour = hour % 12
+            if hour == 0:
+                hour = 12
+
+        self._raw_hid_write([
+            _CMD_SET_CLOCK,
+            0x00, 0x00, 0x08, 0x00, hr_fmt,
+            bcd(hour), bcd(t.tm_min), bcd(t.tm_sec), pm, 0x01,
+        ])
+        _LOGGER.debug("synced RTC to %02d:%02d:%02d", t.tm_hour, t.tm_min, t.tm_sec)
+
+    def _set_screen_hw_monitor(self, **kwargs):
+        """Switch to hardware monitor mode showing live sensor data.
+
+        Keyword arguments:
+            style: 'galactic', 'cyberpunk', or 'custom' (default: 'custom')
+            bg_color: (r, g, b) tuple for background (default: black)
+            text_color: (r, g, b) tuple for text (default: white)
+        """
+        # Read sensors BEFORE switching to raw USB (while hidapi is still open)
+        try:
+            liquid_temp, pump_speed, pump_fan_speed = self._get_cooler_status()
+        except Exception:
+            liquid_temp, pump_speed, pump_fan_speed = 0, 0, 0
+
+        style = kwargs.get("style", "custom")
+        bg_r, bg_g, bg_b = kwargs.get("bg_color", (0, 0, 0))
+        txt_r, txt_g, txt_b = kwargs.get("text_color", (255, 255, 255))
+
+        style_byte = _HW_MONITOR_STYLES.get(style, 0x02)
+
+        # Set HW monitor layout (EC 52)
+        self._raw_hid_write([
+            _CMD_SET_HW_MONITOR_LAYOUT,
+            style_byte, 0x02, 0x02, 0x00,
+            bg_r, bg_g, bg_b, 0xFF,
+            txt_r, txt_g, txt_b, 0xFF,
+            txt_r, txt_g, txt_b, 0xFF,
+            txt_r, txt_g, txt_b, 0xFF,
+            txt_r, txt_g, txt_b, 0xFF,
+        ])
+
+        # Switch to HW monitor mode
+        self._switch_display_mode(_DISPLAY_MODE_HW_MONITOR)
+
+        # Send sensor readings
+        lines = [
+            ("Liquid Temp", f"{liquid_temp:.1f}C"),
+            ("Pump", f"{pump_speed}RPM"),
+            ("Fan", f"{pump_fan_speed}RPM"),
+        ]
+        for i, (label, value) in enumerate(lines):
+            self._set_hw_monitor_string(i, label, value)
+
+        _LOGGER.info("switched to HW monitor mode (style=%s)", style)
+
+    def _set_hw_monitor_string(self, index: int, label: str, value: str):
+        """Send EC 53 to set a HW monitor line's label and value."""
+        label_bytes = label.encode("utf-8", errors="replace")[:18]
+        label_padded = list(label_bytes) + [0] * (18 - len(label_bytes))
+
+        value_bytes = value.encode("utf-8", errors="replace")[:12]
+        value_padded = list(value_bytes) + [0] * (12 - len(value_bytes))
+
+        self._raw_hid_write(
+            [_CMD_SET_HW_MONITOR_STRING, index]
+            + label_padded
+            + value_padded
+        )
+
+    def _set_brightness(self, brightness: int):
+        """Set LCD brightness (0-100%)."""
+        brightness = clamp(brightness, 0, 100)
+        self._set_display_option(brightness=brightness)
+        _LOGGER.info("set brightness to %d%%", brightness)
+
+    def _set_display_option(self, brightness=None, orientation=None):
+        """Send EC 5C 01 to set display options.
+
+        Verified from ITCM firmware handler at 0x00EC:
+          payload[0] = 0x01 (set config sub-command)
+          payload[1] = display_type
+          payload[2] = mode_byte
+          payload[3] = orientation
+          payload[4] = (skipped)
+          payload[5] = brightness
+        """
+        brt = brightness if brightness is not None else 30
+        orient = orientation if orientation is not None else 0
+
+        self._raw_hid_write([
+            _CMD_SET_DISPLAY_OPTION,
+            0x01, 0x00, 0x00, orient, 0x00,
+            brt,
+        ])
 
     def _request(self, request_header: int, response_header: int) -> List[int]:
         self.device.clear_enqueued_reports()

--- a/liquidctl/driver/asus_ryujin.py
+++ b/liquidctl/driver/asus_ryujin.py
@@ -228,6 +228,7 @@ class AsusRyujin(UsbHidDriver):
         """Release the raw USB device and reattach kernel drivers."""
         if self._bulk_device is not None:
             import usb.util
+
             for i in range(2):
                 try:
                     usb.util.release_interface(self._bulk_device, i)
@@ -422,13 +423,13 @@ class AsusRyujin(UsbHidDriver):
             if value is None:
                 raise ValueError("brightness mode requires a value (0-100)")
             brightness = clamp(int(value), 0, 100)
-            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION,
-                         0x01, 0x00, 0x00, 0x00, 0x00, brightness])
+            self._write(
+                [_PREFIX, _CMD_SET_DISPLAY_OPTION, 0x01, 0x00, 0x00, 0x00, 0x00, brightness]
+            )
         elif mode == "orientation":
             if value is None:
                 raise ValueError("orientation requires 0-3 (0°, 90°, 180°, 270°)")
-            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION,
-                         0x01, 0x00, 0x00, int(value)])
+            self._write([_PREFIX, _CMD_SET_DISPLAY_OPTION, 0x01, 0x00, 0x00, int(value)])
         elif mode == "release":
             self._release_cooler_control()
         else:
@@ -497,9 +498,9 @@ class AsusRyujin(UsbHidDriver):
         pixels = img.tobytes()
         bgr = bytearray(_LCD_FRAME_SIZE)
         for i in range(0, len(pixels), 3):
-            bgr[i] = pixels[i + 2]      # B
+            bgr[i] = pixels[i + 2]  # B
             bgr[i + 1] = pixels[i + 1]  # G
-            bgr[i + 2] = pixels[i]      # R
+            bgr[i + 2] = pixels[i]  # R
 
         self._switch_display_mode(_DISPLAY_MODE_FRAMEBUFFER)
         time.sleep(0.1)
@@ -517,21 +518,35 @@ class AsusRyujin(UsbHidDriver):
 
         # Sync RTC
         t = time.localtime()
+
         def bcd(val):
             return ((val // 10) << 4) | (val % 10)
+
         hour = t.tm_hour
         pm = 0x00
         if not fmt_24h:
             pm = 0x01 if hour >= 12 else 0x00
             hour = hour % 12 or 12
-        self._write([_PREFIX, _CMD_SET_CLOCK,
-                     0x00, 0x00, 0x08, 0x00, hr_fmt,
-                     bcd(hour), bcd(t.tm_min), bcd(t.tm_sec), pm, 0x01])
+        self._write(
+            [
+                _PREFIX,
+                _CMD_SET_CLOCK,
+                0x00,
+                0x00,
+                0x08,
+                0x00,
+                hr_fmt,
+                bcd(hour),
+                bcd(t.tm_min),
+                bcd(t.tm_sec),
+                pm,
+                0x01,
+            ]
+        )
         time.sleep(0.05)
 
         # Switch to clock mode
-        self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE,
-                     _DISPLAY_MODE_CLOCK, 0x00, hr_fmt])
+        self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_CLOCK, 0x00, hr_fmt])
 
     def _set_screen_hw_monitor_hid(self, **kwargs):
         """Switch to HW monitor mode via hidapi (no pyusb needed)."""
@@ -544,13 +559,36 @@ class AsusRyujin(UsbHidDriver):
         style = _HW_MONITOR_STYLES.get(kwargs.get("style", "custom"), 0x02)
 
         # Layout (EC 52)
-        self._write([_PREFIX, _CMD_SET_HW_MONITOR_LAYOUT,
-                     style, 0x02, 0x02, 0x00,
-                     0, 0, 0, 0xFF,
-                     255, 255, 255, 0xFF,
-                     255, 255, 255, 0xFF,
-                     255, 255, 255, 0xFF,
-                     255, 255, 255, 0xFF])
+        self._write(
+            [
+                _PREFIX,
+                _CMD_SET_HW_MONITOR_LAYOUT,
+                style,
+                0x02,
+                0x02,
+                0x00,
+                0,
+                0,
+                0,
+                0xFF,
+                255,
+                255,
+                255,
+                0xFF,
+                255,
+                255,
+                255,
+                0xFF,
+                255,
+                255,
+                255,
+                0xFF,
+                255,
+                255,
+                255,
+                0xFF,
+            ]
+        )
 
         # Switch mode (EC 51)
         self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_HW_MONITOR])
@@ -608,11 +646,21 @@ class AsusRyujin(UsbHidDriver):
             if hour == 0:
                 hour = 12
 
-        self._raw_hid_write([
-            _CMD_SET_CLOCK,
-            0x00, 0x00, 0x08, 0x00, hr_fmt,
-            bcd(hour), bcd(t.tm_min), bcd(t.tm_sec), pm, 0x01,
-        ])
+        self._raw_hid_write(
+            [
+                _CMD_SET_CLOCK,
+                0x00,
+                0x00,
+                0x08,
+                0x00,
+                hr_fmt,
+                bcd(hour),
+                bcd(t.tm_min),
+                bcd(t.tm_sec),
+                pm,
+                0x01,
+            ]
+        )
         _LOGGER.debug("synced RTC to %02d:%02d:%02d", t.tm_hour, t.tm_min, t.tm_sec)
 
     def _set_screen_hw_monitor(self, **kwargs):
@@ -636,15 +684,35 @@ class AsusRyujin(UsbHidDriver):
         style_byte = _HW_MONITOR_STYLES.get(style, 0x02)
 
         # Set HW monitor layout (EC 52)
-        self._raw_hid_write([
-            _CMD_SET_HW_MONITOR_LAYOUT,
-            style_byte, 0x02, 0x02, 0x00,
-            bg_r, bg_g, bg_b, 0xFF,
-            txt_r, txt_g, txt_b, 0xFF,
-            txt_r, txt_g, txt_b, 0xFF,
-            txt_r, txt_g, txt_b, 0xFF,
-            txt_r, txt_g, txt_b, 0xFF,
-        ])
+        self._raw_hid_write(
+            [
+                _CMD_SET_HW_MONITOR_LAYOUT,
+                style_byte,
+                0x02,
+                0x02,
+                0x00,
+                bg_r,
+                bg_g,
+                bg_b,
+                0xFF,
+                txt_r,
+                txt_g,
+                txt_b,
+                0xFF,
+                txt_r,
+                txt_g,
+                txt_b,
+                0xFF,
+                txt_r,
+                txt_g,
+                txt_b,
+                0xFF,
+                txt_r,
+                txt_g,
+                txt_b,
+                0xFF,
+            ]
+        )
 
         # Switch to HW monitor mode
         self._switch_display_mode(_DISPLAY_MODE_HW_MONITOR)
@@ -668,11 +736,7 @@ class AsusRyujin(UsbHidDriver):
         value_bytes = value.encode("utf-8", errors="replace")[:12]
         value_padded = list(value_bytes) + [0] * (12 - len(value_bytes))
 
-        self._raw_hid_write(
-            [_CMD_SET_HW_MONITOR_STRING, index]
-            + label_padded
-            + value_padded
-        )
+        self._raw_hid_write([_CMD_SET_HW_MONITOR_STRING, index] + label_padded + value_padded)
 
     def _set_brightness(self, brightness: int):
         """Set LCD brightness (0-100%)."""
@@ -694,11 +758,17 @@ class AsusRyujin(UsbHidDriver):
         brt = brightness if brightness is not None else 30
         orient = orientation if orientation is not None else 0
 
-        self._raw_hid_write([
-            _CMD_SET_DISPLAY_OPTION,
-            0x01, 0x00, 0x00, orient, 0x00,
-            brt,
-        ])
+        self._raw_hid_write(
+            [
+                _CMD_SET_DISPLAY_OPTION,
+                0x01,
+                0x00,
+                0x00,
+                orient,
+                0x00,
+                brt,
+            ]
+        )
 
     def _request(self, request_header: int, response_header: int) -> List[int]:
         self.device.clear_enqueued_reports()

--- a/liquidctl/driver/asus_ryujin.py
+++ b/liquidctl/driver/asus_ryujin.py
@@ -688,9 +688,12 @@ class AsusRyujin(UsbHidDriver):
         except _FlashSlotStuck as exc:
             raise ExpectationNotMet(
                 "the cooler's flash upload state is wedged (%s) and software "
-                "recovery (sweep + USB rebind) did not clear it. This happens "
-                "after heavy upload cycling; fully power-cycle the system (drain "
-                "the PSU for ~15s so the cooler's USB rails reset) and retry." % exc
+                "recovery (sweep + USB rebind) did not clear it. This is usually "
+                "caused by another process (e.g. OpenRGB or a second liquidctl) "
+                "accessing the cooler during the upload, or by repeated "
+                "interrupted uploads; stop other tools that talk to this device, "
+                "then fully power-cycle the system (drain the PSU for ~15s so the "
+                "cooler's USB rails reset) and retry." % exc
             )
 
     def _unstick_flash(self):

--- a/liquidctl/driver/asus_ryujin.py
+++ b/liquidctl/driver/asus_ryujin.py
@@ -502,6 +502,17 @@ class AsusRyujin(UsbHidDriver):
             bgr[i + 1] = pixels[i + 1]  # G
             bgr[i + 2] = pixels[i]  # R
 
+        # Wake the panel from standby and ensure brightness is up BEFORE writing the
+        # framebuffer. Without this, a screen left in standby (e.g. by Windows on a
+        # dual-boot box, or a cold boot) renders the pushed image as black even though
+        # the bulk write succeeds. Use the raw-HID path: the hidapi handle is closed
+        # while the kernel driver is detached for bulk access.
+        self._raw_hid_write([_CMD_SET_DISPLAY_OPTION, 0x10])  # wake from standby
+        time.sleep(0.05)
+        # set config: display_type, mode, orientation, reserved, brightness=100
+        self._raw_hid_write([_CMD_SET_DISPLAY_OPTION, 0x01, 0x00, 0x00, 0x00, 0x00, 100])
+        time.sleep(0.05)
+
         self._switch_display_mode(_DISPLAY_MODE_FRAMEBUFFER)
         time.sleep(0.1)
         self._write_bulk(bytes(bgr))

--- a/liquidctl/driver/asus_ryujin.py
+++ b/liquidctl/driver/asus_ryujin.py
@@ -18,6 +18,15 @@ from liquidctl.util import clamp, u16le_from, rpadlist, fraction_of_byte
 
 _LOGGER = logging.getLogger(__name__)
 
+
+class _FlashSlotStuck(Exception):
+    """Internal: the flash erase came back stuck (ee13 1001).
+
+    Transient device state after an interrupted upload; cleared by the unstick
+    sweep. Caught inside the driver to trigger one recovery + retry; never
+    propagates to the caller.
+    """
+
 _REPORT_LENGTH = 65
 _PREFIX = 0xEC
 
@@ -38,6 +47,27 @@ _CMD_SET_HW_MONITOR_STRING = 0x53
 _CMD_SET_DISPLAY_OPTION = 0x5C
 _CMD_SET_CLOCK = 0x11
 _CMD_FLUSH_FRAMEBUFFER = 0x7F
+
+# Persistent flash-slot upload command headers (Armoury Crate path).
+# Unlike the volatile framebuffer (mode 0x20), these upload an image/animation into
+# the cooler's onboard flash so the firmware auto-plays it across reboots.
+_CMD_UPLOAD_BEGIN = 0x71  # begin upload session
+_CMD_UPLOAD_ARM = 0xF1  # arm / read capability (free space)
+_CMD_UPLOAD_PARAMS = 0x72  # image params (format + page count)
+_CMD_UPLOAD_PREPARE = 0x73  # 0x01 = erase/prepare slot, 0xFF = commit
+_CMD_UPLOAD_SIZE = 0x7F  # declare payload size (also the framebuffer flush header)
+_CMD_DISPLAY_OPTION = 0x5C  # wake / brightness (alias of _CMD_SET_DISPLAY_OPTION)
+_CMD_WAKE_FRAME = 0xDC  # wake frame before a display switch
+_CMD_SELECT_SLOT = 0x5D  # select stored slot before display
+
+# Async interrupt-IN (EP 0x82) "ee" flow-control notification headers.
+# The firmware paces the bulk upload with these; the uploader MUST wait for them.
+_EE_SLOT = 0x13  # ee13 0001 = erased/ready;  ee13 00ff = flash-write complete
+_EE_CHUNK = 0x14  # ee14 ..10 = chunk accepted; ee14 ..0a = ready to commit
+
+# Persistent-upload format params (third byte of ec72 is a page count; any 1..n accepted)
+_UPLOAD_FMT_STATIC = [0x01, 0x01]  # JPEG
+_UPLOAD_FMT_ANIM = [0x01, 0x02, 0x03]  # GIF89a
 
 # Display mode bytes (wire encoding, from ryujin.py DisplayMode enum)
 _DISPLAY_MODE_OFF = 0x00
@@ -381,7 +411,9 @@ class AsusRyujin(UsbHidDriver):
 
         | Channel | Mode | Value |
         | --- | --- | --- |
-        | `lcd` | `static` | path to image file |
+        | `lcd` | `static` | path to image file (volatile; cleared on reboot) |
+        | `lcd` | `image` | path to image file (persistent; stored to flash, survives reboot) |
+        | `lcd` | `gif` | path to a GIF (persistent animation; stored to flash, survives reboot) |
         | `lcd` | `liquid` | — (built-in ROG animation) |
         | `lcd` | `clock` | `24h` or `12h` (default: `24h`) |
         | `lcd` | `monitor` | — (HW monitor showing live stats) |
@@ -391,6 +423,12 @@ class AsusRyujin(UsbHidDriver):
         | `lcd` | `release` | — (release pump to internal controller; fan stays at last duty) |
         | `lcd` | `brightness` | int between `0` and `100` (%) |
         | `lcd` | `orientation` | `0`, `1`, `2` or `3` (0°, 90°, 180°, 270°) |
+
+        `static` writes a single frame to the live framebuffer (mode 0x20); it is
+        volatile and the panel reverts to its built-in animation on reboot. `image`
+        and `gif` upload to the cooler's onboard flash like Armoury Crate does, so the
+        firmware replays the content across reboots. The persistent path is paced by
+        the device's async "ee" flow-control notifications.
 
         Requires Ryujin III (models with LCD display).
         """
@@ -406,6 +444,15 @@ class AsusRyujin(UsbHidDriver):
                 raise ValueError("static mode requires a path to an image file")
             self._set_screen_static(value)
             self._release_raw_usb_device()
+        elif mode in ("image", "gif"):
+            # Persistent flash-slot upload (survives reboot). Animations live in
+            # the animation slots (0-3, as Armoury Crate uses); static images use
+            # the static slideshow table (slot 4). Defaults differ accordingly.
+            if value is None:
+                raise ValueError(f"{mode} mode requires a path to an image file")
+            is_anim = mode == "gif"
+            slot = int(kwargs.get("slot", 3 if is_anim else 4))
+            self._upload_flash_slot(value, animation=is_anim, slot=slot)
         elif mode == "liquid":
             self._write([_PREFIX, _CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_ANIMATION])
         elif mode == "clock":
@@ -434,8 +481,8 @@ class AsusRyujin(UsbHidDriver):
             self._release_cooler_control()
         else:
             raise ValueError(
-                f"invalid mode: {mode}, valid: static, liquid, clock, monitor, off, "
-                f"standby, wake, brightness, orientation, release"
+                f"invalid mode: {mode}, valid: static, image, gif, liquid, clock, "
+                f"monitor, off, standby, wake, brightness, orientation, release"
             )
 
     def _raw_hid_write(self, cmd: list):
@@ -504,9 +551,9 @@ class AsusRyujin(UsbHidDriver):
 
         # Wake the panel from standby and ensure brightness is up BEFORE writing the
         # framebuffer. Without this, a screen left in standby (e.g. by Windows on a
-        # dual-boot box, or a cold boot) renders the pushed image as black even though
-        # the bulk write succeeds. Use the raw-HID path: the hidapi handle is closed
-        # while the kernel driver is detached for bulk access.
+        # dual-boot box) renders the pushed image as black even though the bulk write
+        # succeeds. Use the raw-HID path: the hidapi handle is closed while the kernel
+        # driver is detached for bulk access.
         self._raw_hid_write([_CMD_SET_DISPLAY_OPTION, 0x10])  # wake from standby
         time.sleep(0.05)
         # set config: display_type, mode, orientation, reserved, brightness=100
@@ -518,6 +565,256 @@ class AsusRyujin(UsbHidDriver):
         self._write_bulk(bytes(bgr))
         self._flush_framebuffer()
         _LOGGER.info("displayed static image: %s", path)
+
+    # --- Persistent flash-slot upload (Armoury Crate path) --------------------
+    #
+    # This path stores the image/animation in the cooler's onboard flash so the
+    # firmware replays it across reboots. It is architecturally the OPPOSITE of
+    # the volatile framebuffer above: the kernel HID driver stays BOUND so the
+    # hidapi handle (self.device) carries control commands AND the device's async
+    # interrupt-IN "ee" flow-control notifications, while a separate pyusb handle
+    # claims ONLY interface 0 for the bulk image payload. The firmware paces the
+    # upload with the ee signals; blasting chunks blind (as earlier attempts did)
+    # leaves the commit a no-op and nothing persists.
+
+    def _bulk_only_device(self):
+        """Open a pyusb handle claiming ONLY interface 0 (bulk EP).
+
+        Interface 1 (HID) is deliberately left to the kernel/hidapi so control +
+        ee-signal reads keep working on self.device during the upload.
+        """
+        if self._bulk_device is not None:
+            return self._bulk_device
+
+        import usb.core
+        import usb.util
+
+        dev = usb.core.find(idVendor=self.vendor_id, idProduct=self.product_id)
+        if dev is None:
+            raise ExpectationNotMet("could not find USB device for LCD")
+        try:
+            usb.util.claim_interface(dev, 0)
+        except Exception:
+            pass  # already claimed / not kernel-bound
+        self._bulk_device = dev
+        return dev
+
+    def _ee_read(self, total_timeout=4.0):
+        """Read one interrupt-IN report via hidapi, retrying until timeout.
+
+        Returns the report bytes, or None if nothing arrived in total_timeout.
+        """
+        from liquidctl.driver.usb import Timeout
+
+        deadline = time.monotonic() + total_timeout
+        while time.monotonic() < deadline:
+            try:
+                report = self.device.read(_REPORT_LENGTH, timeout=400)
+            except Timeout:
+                continue
+            except Exception:
+                return None
+            if report:
+                return bytes(report)
+        return None
+
+    def _ee_wait(self, predicate, total_timeout=4.0):
+        """Wait for an ee/ec report matching predicate; return it or None."""
+        deadline = time.monotonic() + total_timeout
+        while time.monotonic() < deadline:
+            report = self._ee_read(min(0.5, total_timeout))
+            if report and predicate(report):
+                return report
+        return None
+
+    def _encode_for_flash(self, path, animation):
+        """Encode an image to the wire payload + the ec72 format params."""
+        try:
+            from PIL import Image, ImageSequence
+        except ImportError:
+            raise NotSupportedByDriver(
+                "Pillow is required for flash-slot upload: pip install Pillow"
+            )
+        import io
+
+        src = Image.open(path)
+        buf = io.BytesIO()
+        if animation:
+            frames = [
+                f.convert("RGB").resize((_LCD_WIDTH, _LCD_HEIGHT), Image.LANCZOS)
+                for f in ImageSequence.Iterator(src)
+            ]
+            if len(frames) == 1:
+                frames[0].save(buf, "GIF")
+            else:
+                frames[0].save(
+                    buf,
+                    "GIF",
+                    save_all=True,
+                    append_images=frames[1:],
+                    loop=0,
+                    duration=src.info.get("duration", 80),
+                )
+            return buf.getvalue(), list(_UPLOAD_FMT_ANIM)
+        src.convert("RGB").resize((_LCD_WIDTH, _LCD_HEIGHT), Image.LANCZOS).save(
+            buf, "JPEG", quality=90
+        )
+        return buf.getvalue(), list(_UPLOAD_FMT_STATIC)
+
+    def _upload_flash_slot(self, path, animation, slot):
+        """Upload an image/animation to a flash slot and display it.
+
+        Persists across reboots. Paced by the device's ee flow-control signals.
+
+        The flash state machine can get stuck after an interrupted upload: the
+        erase step replies ee13 **10**01 (instead of ee13 0001) and the size
+        declaration is then rejected. A light stuck state is cleared by a sweep
+        of clean begin/arm/params/erase cycles, so we attempt the upload and, if
+        the erase comes back stuck, run that recovery and retry once. A *deep*
+        wedge (after a lot of rapid upload/reset cycling) survives soft reboots,
+        USB rebinds and the sweep alike, and is only cleared by a full
+        power-cycle of the cooler (its USB +5V rails must fully drain); in that
+        case we surface a clear error telling the user to power-cycle.
+        """
+        try:
+            self._attempt_flash_upload(path, animation, slot)
+            return
+        except _FlashSlotStuck:
+            _LOGGER.warning("flash slot stuck (ee13 1001); attempting recovery + retry")
+
+        self._unstick_flash()
+        try:
+            self._attempt_flash_upload(path, animation, slot)
+        except _FlashSlotStuck as exc:
+            raise ExpectationNotMet(
+                "the cooler's flash upload state is wedged (%s) and software "
+                "recovery (sweep + USB rebind) did not clear it. This happens "
+                "after heavy upload cycling; fully power-cycle the system (drain "
+                "the PSU for ~15s so the cooler's USB rails reset) and retry." % exc
+            )
+
+    def _unstick_flash(self):
+        """Best-effort flush of a stuck flash state machine.
+
+        After an interrupted upload the erase returns ee13 1001 and the size
+        declaration is rejected. Running clean begin/arm/params/erase cycles on
+        a fresh hidapi handle clears a *light* stuck state. Release the bulk
+        handle and reconnect first so the sweep runs on a clean session. NOTE: a
+        deep wedge is not cleared by this (only a power-cycle is) -- this is a
+        best effort, and the caller surfaces a clear error if the retry fails.
+        """
+        self._release_raw_usb_device()
+        try:
+            self.disconnect()
+        except Exception:
+            pass
+        self.connect()
+        dev = self.device
+        for page in range(1, 11):
+            dev.clear_enqueued_reports()
+            self._write([_PREFIX, _CMD_UPLOAD_BEGIN, 0x01, 0x01])
+            self._ee_read(0.3)
+            self._write([_PREFIX, _CMD_UPLOAD_ARM, 0x00])
+            self._ee_read(0.3)
+            self._write([_PREFIX, _CMD_UPLOAD_PARAMS, 0x01, 0x02, page])
+            self._ee_read(0.3)
+            dev.clear_enqueued_reports()
+            self._write([_PREFIX, _CMD_UPLOAD_PREPARE, 0x01])
+            self._ee_wait(lambda r: len(r) >= 4 and r[0] == _PREFIX + 2 and r[1] == _EE_SLOT, 2.0)
+        _LOGGER.debug("ran flash unstick sweep")
+
+    def _attempt_flash_upload(self, path, animation, slot):
+        """One flash-slot upload attempt (no recovery). See _upload_flash_slot."""
+        payload, fmt_params = self._encode_for_flash(path, animation)
+        size = len(payload)
+        if size % 4096:
+            payload += b"\x00" * (4096 - (size % 4096))
+        n_chunks = len(payload) // 4096
+
+        bulk = self._bulk_only_device()
+
+        def cmd(body):
+            self._write([_PREFIX] + list(body))
+
+        ee = lambda r, h2, h3=None: (
+            len(r) >= 4 and r[0] == _PREFIX + 2 and r[1] == h2 and (h3 is None or r[3] == h3)
+        )
+
+        # --- HEADER ---
+        self.device.clear_enqueued_reports()
+        cmd([_CMD_UPLOAD_BEGIN, 0x01, 0x01])
+        self._ee_read(0.6)
+        cmd([_CMD_UPLOAD_ARM, 0x00])  # arm -> capability (free space) reply
+        self._ee_wait(lambda r: r[:4] == bytes([_PREFIX, _CMD_UPLOAD_BEGIN, 0x00, 0x01]), 2.0)
+        cmd([_CMD_UPLOAD_PARAMS] + fmt_params)
+        self._ee_read(0.6)
+
+        self.device.clear_enqueued_reports()
+        cmd([_CMD_UPLOAD_PREPARE, 0x01])  # erase/prepare slot
+        erased = self._ee_wait(lambda r: ee(r, _EE_SLOT), 3.0)
+        if erased is None or erased[2] != 0x00:
+            # ee13 1001 (status 0x10) => stuck state; recoverable via unstick sweep.
+            raise _FlashSlotStuck(
+                "flash slot not ready (erase status %s)"
+                % (erased[:4].hex() if erased else "timeout")
+            )
+
+        cmd([_CMD_UPLOAD_SIZE, 0x02] + list(size.to_bytes(3, "little")))  # declare size
+        ready = self._ee_wait(lambda r: r[:2] == bytes([_PREFIX, _CMD_UPLOAD_SIZE]), 2.0)
+        if ready is None or ready[2] != 0x00:
+            raise ExpectationNotMet(
+                "device rejected size declaration (%s)"
+                % (ready[:4].hex() if ready else "timeout")
+            )
+
+        # --- BULK (ee14-gated) ---
+        off = 0
+        for c in range(n_chunks):
+            bulk.write(_EP_BULK_OUT, payload[off : off + 4096], timeout=3000)
+            off += 4096
+            ack = self._ee_wait(lambda r: ee(r, _EE_CHUNK), 3.0)
+            if ack is None:
+                raise ExpectationNotMet(f"no ee14 ack for chunk {c}/{n_chunks}")
+
+        # --- COMMIT (ee13 ..ff-gated) ---
+        cmd([_CMD_UPLOAD_PREPARE, 0xFF])
+        self._ee_read(0.4)
+        done = self._ee_wait(lambda r: ee(r, _EE_SLOT, 0xFF), 10.0)
+        if done is None:
+            raise ExpectationNotMet("commit timed out (ee13 ..ff not received)")
+        time.sleep(0.5)
+
+        # --- DISPLAY the freshly written slot ---
+        cmd([_CMD_WAKE_FRAME, 0x00])
+        self._ee_read(0.2)
+        cmd([_CMD_DISPLAY_OPTION, 0x01, 0x00, 0x64, 0x00, 0x00, 0x64, 0x14, 0x00, 0x00, 0x00, 0x64, 0x14])
+        self._ee_read(0.2)
+        cmd([_CMD_WAKE_FRAME, 0x00])
+        self._ee_read(0.2)
+        if animation:
+            cmd([_CMD_SELECT_SLOT, 0x00, 0x01, _DISPLAY_MODE_SINGLE_ANIM, 0x01, slot, 0x05])
+            self._ee_read(0.2)
+            cmd([_CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_SINGLE_ANIM, 0x01, slot])
+        else:
+            cmd([0x60, 0x00, 0x01, 0x10])
+            self._ee_read(0.2)
+            offs = [0x17, 0x3F, 0x67, 0x8F, 0xB7, 0xDF]
+            for i in range(6):
+                cmd([0x60, 0x00, 0x02, i, 0x03, 0x00, 0xFF, 0xFF, 0xFF, 0xFF, 0x08, 0x00, offs[i]])
+                self._ee_read(0.2)
+            cmd([_CMD_SELECT_SLOT, 0x00, 0x01, 0x04, 0x00, 0x00, 0x05])
+            self._ee_read(0.2)
+            cmd([_CMD_SWITCH_DISPLAY_MODE, _DISPLAY_MODE_SLIDESHOW])
+        self._ee_read(0.2)
+
+        self._release_raw_usb_device()
+        _LOGGER.info(
+            "uploaded %s to flash slot %d (%d bytes): %s",
+            "animation" if animation else "image",
+            slot,
+            size,
+            path,
+        )
 
     def _set_screen_clock_hid(self, fmt_24h: bool = True):
         """Switch to clock mode via hidapi (no pyusb needed)."""

--- a/tests/test_asus_ryujin.py
+++ b/tests/test_asus_ryujin.py
@@ -2,6 +2,7 @@ import pytest
 
 from _testutils import MockHidapiDevice
 from liquidctl.driver.asus_ryujin import AsusRyujin
+from liquidctl.error import NotSupportedByDriver
 
 PROTOCOL_HEADER = 0xEC
 CMD_GET_FIRMWARE = 0x82
@@ -19,6 +20,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 7,
         "temp_offset": 3,
         "duty_channel": 0,
+        "has_lcd": False,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a312d533735302d30313034",
             CMD_GET_STATUS: "ec19001b056405100e",
@@ -49,6 +51,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 10,
         "temp_offset": 5,
         "duty_channel": 1,
+        "has_lcd": True,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a332d533546392d30313034",
             CMD_GET_STATUS: "ec190000001d09ec041e6603",
@@ -71,6 +74,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 10,
         "temp_offset": 5,
         "duty_channel": 1,
+        "has_lcd": True,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a322d533735302d30313039",
             CMD_GET_STATUS: "ec1900000021002e0e644803",
@@ -93,6 +97,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 10,
         "temp_offset": 5,
         "duty_channel": 1,
+        "has_lcd": True,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a332d533546392d30313034",
             CMD_GET_STATUS: "ec190000001d09ec041e6603",
@@ -115,6 +120,7 @@ DEVICE_CONFIGS = {
         "pump_fan_speed_offset": 10,
         "temp_offset": 5,
         "duty_channel": 1,
+        "has_lcd": True,
         "responses": {
             CMD_GET_FIRMWARE: "ec02004155524a332d533546392d30313034",
             CMD_GET_STATUS: "ec190000001d09ec041e6603",
@@ -176,6 +182,7 @@ def mock_ryujin():
         pump_fan_speed_offset=config["pump_fan_speed_offset"],
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
+        has_lcd=config["has_lcd"],
     )
 
 
@@ -191,6 +198,7 @@ def mock_ryujin3():
         pump_fan_speed_offset=config["pump_fan_speed_offset"],
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
+        has_lcd=config["has_lcd"],
     )
 
 
@@ -205,6 +213,7 @@ def test_initialize(product_id):
         pump_fan_speed_offset=config["pump_fan_speed_offset"],
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
+        has_lcd=config["has_lcd"],
     )
 
     with device.connect():
@@ -223,6 +232,7 @@ def test_status(product_id):
         pump_fan_speed_offset=config["pump_fan_speed_offset"],
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
+        has_lcd=config["has_lcd"],
     )
 
     with device.connect():
@@ -266,3 +276,80 @@ def test_set_fixed_speeds_ryujin3(mock_ryujin3):
         mock_ryujin3.set_fixed_speed(channel="pump-fan", duty=50)
         assert mock_ryujin3.device.requests[-1][2] == 0x01
         assert mock_ryujin3.device.requests[-1][4] == 0x32
+
+
+def test_set_screen_liquid(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "liquid", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x51
+        assert sent[2] == 0x04
+
+
+def test_set_screen_off(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "off", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x51
+        assert sent[2] == 0x00
+
+
+def test_set_screen_clock_24h(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "clock", "24h")
+        cmds = [r for r in mock_ryujin3.device.requests if r[0] == PROTOCOL_HEADER]
+        cmd_bytes = [r[1] for r in cmds]
+        assert 0x5D in cmd_bytes  # clock config
+        assert 0x11 in cmd_bytes  # set time
+        assert 0x51 in cmd_bytes  # mode switch
+        mode_cmd = [r for r in cmds if r[1] == 0x51][-1]
+        assert mode_cmd[2] == 0x08  # clock mode
+        time_cmd = [r for r in cmds if r[1] == 0x11][-1]
+        assert time_cmd[6] == 0x00  # hr_fmt 0x00 = 24h
+
+
+def test_set_screen_brightness(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "brightness", "75")
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x5C
+        assert sent[2] == 0x01
+        assert sent[7] == 75
+
+
+def test_set_screen_standby(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "standby", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x5C
+        assert sent[2] == 0x20
+
+
+def test_set_screen_wake(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "wake", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x5C
+        assert sent[2] == 0x10
+
+
+def test_set_screen_release(mock_ryujin3):
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen("lcd", "release", None)
+        sent = mock_ryujin3.device.requests[-1]
+        assert sent[0] == PROTOCOL_HEADER
+        assert sent[1] == 0x1A
+        assert sent[2] == 0x00
+        assert sent[3] == 0x00
+        assert sent[4] == 0x00
+
+
+def test_set_screen_not_supported_ryujin2(mock_ryujin):
+    with mock_ryujin.connect():
+        with pytest.raises(NotSupportedByDriver):
+            mock_ryujin.set_screen("lcd", "liquid", None)

--- a/tests/test_asus_ryujin.py
+++ b/tests/test_asus_ryujin.py
@@ -353,3 +353,228 @@ def test_set_screen_not_supported_ryujin2(mock_ryujin):
     with mock_ryujin.connect():
         with pytest.raises(NotSupportedByDriver):
             mock_ryujin.set_screen("lcd", "liquid", None)
+
+
+# ---------------------------------------------------------------------------
+# Persistent flash-slot upload (image / gif) tests
+#
+# These exercise the Armoury-Crate-style persistent upload path added to the
+# driver: format/slot selection, the ee-signal-gated state machine, and the
+# stuck-state detection. The real path uses a pyusb bulk handle and reads the
+# device's async "ee" notifications; here we stub the bulk handle and script the
+# ee replies through a small flow-control mock so the logic is covered without
+# hardware.
+# ---------------------------------------------------------------------------
+
+import io as _io
+
+import pytest
+
+from liquidctl.driver.asus_ryujin import AsusRyujin, _FlashSlotStuck
+from liquidctl.error import ExpectationNotMet, NotSupportedByDriver
+
+PIL = pytest.importorskip("PIL")
+from PIL import Image  # noqa: E402
+
+
+def _make_jpeg_bytes():
+    buf = _io.BytesIO()
+    Image.new("RGB", (320, 240), (255, 120, 0)).save(buf, "JPEG")
+    return buf.getvalue()
+
+
+def _make_gif_bytes(n_frames=4):
+    frames = [Image.new("RGB", (320, 240), (i * 10, 0, 255 - i * 10)) for i in range(n_frames)]
+    buf = _io.BytesIO()
+    frames[0].save(buf, "GIF", save_all=True, append_images=frames[1:], loop=0, duration=80)
+    return buf.getvalue()
+
+
+def _write_tmp(tmp_path, name, data):
+    p = tmp_path / name
+    p.write_bytes(data)
+    return str(p)
+
+
+class _FakeBulk:
+    """Stub pyusb bulk handle: records writes, never touches USB."""
+
+    def __init__(self):
+        self.writes = []
+
+    def write(self, endpoint, data, timeout=0):
+        self.writes.append((endpoint, bytes(data)))
+        return len(data)
+
+
+def _install_flash_stubs(driver, *, erase_status=0x00, size_status=0x00, chunk_ok=True):
+    """Patch the driver's bulk + ee primitives to script a flash upload.
+
+    erase_status: 2nd payload byte of the ee13 erase reply (0x00 = clean,
+                  0x10 = stuck).
+    size_status:  3rd byte of the ec7f size reply (0x00 = accepted, 0x02 = reject).
+    chunk_ok:     whether each chunk gets an ee14 accept.
+    """
+    bulk = _FakeBulk()
+    driver._bulk_only_device = lambda: bulk
+    driver._release_raw_usb_device = lambda: None
+
+    state = {"phase": "header"}
+
+    def fake_ee_wait(predicate, total_timeout=4.0):
+        # Build candidate reports and return the first the predicate accepts.
+        candidates = [
+            bytes([0xEC, 0x71, 0x00, 0x01]) + b"\x00" * 8,  # capability
+            bytes([0xEE, 0x13, erase_status, 0x01]),  # erase-ready
+            bytes([0xEC, 0x7F, size_status, 0x00, 0x10]),  # ready-for-bulk
+            bytes([0xEE, 0x14, 0x00, 0x10]),  # chunk accept
+            bytes([0xEE, 0x13, 0x00, 0xFF]),  # flash-write done
+        ]
+        if not chunk_ok:
+            candidates = [c for c in candidates if not (c[1] == 0x14)]
+        for c in candidates:
+            if predicate(c):
+                return c
+        return None
+
+    driver._ee_wait = fake_ee_wait
+    driver._ee_read = lambda total_timeout=4.0: None
+    return bulk
+
+
+@pytest.fixture
+def ryujin3(mock_ryujin3):
+    return mock_ryujin3
+
+
+def test_set_screen_image_defaults_static_slot(ryujin3, tmp_path):
+    """`image` mode uploads a JPEG (static params) to the static slot (4)."""
+    path = _write_tmp(tmp_path, "x.jpg", _make_jpeg_bytes())
+    captured = {}
+
+    def spy(p, animation, slot):
+        captured.update(path=p, animation=animation, slot=slot)
+
+    ryujin3._upload_flash_slot = spy
+    with ryujin3.connect():
+        ryujin3.set_screen("lcd", "image", path)
+    assert captured["animation"] is False
+    assert captured["slot"] == 4
+
+
+def test_set_screen_gif_defaults_animation_slot(ryujin3, tmp_path):
+    """`gif` mode uploads a GIF (anim params) to an animation slot (3, not 4)."""
+    path = _write_tmp(tmp_path, "x.gif", _make_gif_bytes())
+    captured = {}
+
+    def spy(p, animation, slot):
+        captured.update(path=p, animation=animation, slot=slot)
+
+    ryujin3._upload_flash_slot = spy
+    with ryujin3.connect():
+        ryujin3.set_screen("lcd", "gif", path)
+    assert captured["animation"] is True
+    assert captured["slot"] == 3  # animation slots are 0-3, never the static slot 4
+
+
+def test_set_screen_image_requires_path(ryujin3):
+    with ryujin3.connect():
+        with pytest.raises(ValueError):
+            ryujin3.set_screen("lcd", "image", None)
+
+
+def test_set_screen_gif_requires_path(ryujin3):
+    with ryujin3.connect():
+        with pytest.raises(ValueError):
+            ryujin3.set_screen("lcd", "gif", None)
+
+
+def test_invalid_mode_lists_new_modes(ryujin3):
+    with ryujin3.connect():
+        with pytest.raises(ValueError) as exc:
+            ryujin3.set_screen("lcd", "bogus", None)
+    assert "image" in str(exc.value)
+    assert "gif" in str(exc.value)
+
+
+def test_encode_static_is_jpeg(ryujin3, tmp_path):
+    path = _write_tmp(tmp_path, "x.png", _make_jpeg_bytes())
+    with ryujin3.connect():
+        payload, params = ryujin3._encode_for_flash(path, animation=False)
+    assert payload[:3] == b"\xff\xd8\xff"  # JPEG magic
+    assert params == [0x01, 0x01]  # static format params
+
+
+def test_encode_animation_preserves_frames(ryujin3, tmp_path):
+    path = _write_tmp(tmp_path, "x.gif", _make_gif_bytes(n_frames=4))
+    with ryujin3.connect():
+        payload, params = ryujin3._encode_for_flash(path, animation=True)
+    assert payload[:6] == b"GIF89a"
+    assert params == [0x01, 0x02, 0x03]  # animation format params
+    out = Image.open(_io.BytesIO(payload))
+    assert getattr(out, "n_frames", 1) == 4  # all frames preserved, not flattened
+
+
+def test_flash_upload_happy_path_anim(ryujin3, tmp_path):
+    """A clean ee sequence drives a full anim upload to the bulk endpoint."""
+    path = _write_tmp(tmp_path, "x.gif", _make_gif_bytes())
+    with ryujin3.connect():
+        bulk = _install_flash_stubs(ryujin3, erase_status=0x00, size_status=0x00, chunk_ok=True)
+        ryujin3._upload_flash_slot(path, animation=True, slot=3)
+    # at least one 4096-byte bulk chunk reached EP 0x01
+    assert bulk.writes, "no bulk payload was written"
+    assert all(ep == 0x01 for ep, _ in bulk.writes)
+    assert len(bulk.writes[0][1]) == 4096
+
+
+def test_flash_upload_static_sends_slot_table(ryujin3, tmp_path):
+    """Static display sequence sends the ec60 slot-table init + ec51 1f."""
+    path = _write_tmp(tmp_path, "x.jpg", _make_jpeg_bytes())
+    with ryujin3.connect():
+        _install_flash_stubs(ryujin3)
+        ryujin3._upload_flash_slot(path, animation=False, slot=4)
+        cmds = [r[1] for r in ryujin3.device.requests if r[0] == 0xEC]
+    assert 0x60 in cmds  # static slot-table init
+    mode = [r for r in ryujin3.device.requests if r[0] == 0xEC and r[1] == 0x51][-1]
+    assert mode[2] == 0x1F  # static slideshow display mode
+
+
+def test_flash_upload_anim_sends_single_anim_mode(ryujin3, tmp_path):
+    """Animation display uses ec51 10 01 <slot> and NO ec60 table."""
+    path = _write_tmp(tmp_path, "x.gif", _make_gif_bytes())
+    with ryujin3.connect():
+        _install_flash_stubs(ryujin3)
+        ryujin3._upload_flash_slot(path, animation=True, slot=3)
+        cmds = [r[1] for r in ryujin3.device.requests if r[0] == 0xEC]
+    assert 0x60 not in cmds  # animations do not use the static slot table
+    mode = [r for r in ryujin3.device.requests if r[0] == 0xEC and r[1] == 0x51][-1]
+    assert mode[2] == 0x10  # single-animation display mode
+    assert mode[4] == 3  # addresses the requested slot
+
+
+def test_flash_upload_stuck_erase_recovers_or_raises(ryujin3, tmp_path):
+    """A persistently-stuck erase (ee13 1001) surfaces a clear power-cycle error."""
+    path = _write_tmp(tmp_path, "x.gif", _make_gif_bytes())
+    with ryujin3.connect():
+        _install_flash_stubs(ryujin3, erase_status=0x10, size_status=0x02)
+        # make the unstick sweep a no-op so the retry stays stuck
+        ryujin3._unstick_flash = lambda: None
+        with pytest.raises(ExpectationNotMet) as exc:
+            ryujin3._upload_flash_slot(path, animation=True, slot=3)
+    assert "power-cycle" in str(exc.value.args[0]).lower()
+
+
+def test_attempt_flash_upload_raises_flashslotstuck(ryujin3, tmp_path):
+    """The low-level attempt raises the internal _FlashSlotStuck on a stuck erase."""
+    path = _write_tmp(tmp_path, "x.gif", _make_gif_bytes())
+    with ryujin3.connect():
+        _install_flash_stubs(ryujin3, erase_status=0x10, size_status=0x02)
+        with pytest.raises(_FlashSlotStuck):
+            ryujin3._attempt_flash_upload(path, animation=True, slot=3)
+
+
+def test_flash_modes_not_supported_on_ryujin2(mock_ryujin, tmp_path):
+    path = _write_tmp(tmp_path, "x.gif", _make_gif_bytes())
+    with mock_ryujin.connect():
+        with pytest.raises(NotSupportedByDriver):
+            mock_ryujin.set_screen("lcd", "gif", path)


### PR DESCRIPTION
## Summary

Adds **LCD screen support for the ASUS ROG Ryujin III** (`0b05:1ada`) to the `asus_ryujin` driver, including **persistent flash-slot image and animation upload** — the part that lets a still image or animated GIF survive a reboot and auto-play on a clean boot, exactly like Armoury Crate does on Windows.

This builds directly on @rebasecase's screen-support work in #872 (which they withdrew). Their two commits are carried here intact, with my changes on top — opened as a fresh branch per their suggestion in #869 (*"branch that branch, pr from that and I'll close mine"*). Addresses #869.

### What's here

1. **`asus_ryujin: add LCD screen support for Ryujin III`** — @rebasecase's original driver work (volatile framebuffer path + tests + docs).
2. **`add tests, protocol docs, manpage, README for screen support`** — @rebasecase's docs/tests.
3. **`asus_ryujin: wake panel + set brightness before static framebuffer write`** — wake/brightness fix so a static framebuffer write actually lights the panel instead of staying dark.
4. **`asus_ryujin: add persistent flash-slot LCD upload (image + gif)`** — new persistent path:
   - `liquidctl set lcd screen image <file.jpg>` → persistent still (flash slot 4)
   - `liquidctl set lcd screen gif <file.gif>` → persistent animation (flash slots 0–3)

### Why the flash path needed reverse-engineering

The device flow-controls the bulk upload over an async interrupt-IN endpoint (`ee` signals). Every prior Linux attempt blasted fixed-size chunks with `sleep()` and never read those signals, so the final commit (`ec 73 ff`) silently desynced — the device ACKed "success" but wrote **zero bytes to flash**. This implementation waits on the real handshake at each stage (slot-erase ready, size-declaration accept, per-chunk ready, flash-write complete), which is what makes the write actually persist.

Three further bugs that defeated earlier flash uploads, now handled:
- **Format**: static slots want **JPEG**, animation slots want **GIF89a** (the panel rejects the wrong container).
- **Slot class**: animations must target slots **0–3**; statics target slot **4**. Writing an animation to slot 4 lands the bytes but displays nothing.
- **Static→animation display transition** routes through clock mode, since the panel won't switch directly out of the static slideshow.

When the flash controller gets into a deep-wedged state after heavy cycling, the driver does best-effort recovery and otherwise **raises a clear "power-cycle required" error** rather than reporting a fake green.

## Test plan

- `tests/test_asus_ryujin.py`: **+13 tests** covering slot defaults, path validation, JPEG/GIF encoding + frame preservation, happy-path bulk upload, static vs animation display sequences, stuck-state detection + power-cycle error, and the Ryujin-II "not supported" case. **31 `asus_ryujin` tests pass.**
- **Full suite: 528 passed, 2 skipped, 0 failures** — no regressions.
- **Hardware-verified** on a real Ryujin III White (firmware AURJ2-S750-0108, Ubuntu): both `image` and `gif` modes upload, persist across a full reboot, and auto-play on clean boot. Confirmed by eye on the panel **and** by the device's own free-space counter dropping by exactly the uploaded byte count.

## Notes for @rebasecase

This doesn't solve the *volatile continuous-streaming* question from #872 (tear-free framebuffer streaming still needs reversing AC's per-frame present+watchdog sequence). What it does give every Ryujin III Linux user is the **persistent flash-slot path** — the "upload an image/animation that sticks" case. Happy to adjust framing/attribution however you'd prefer; your commits are carried as-is. Tagging since you asked to be looped in once a fresh PR was up.
