### PR TITLE
fix: [#908] kraken 2024 plus lcd static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## Unreleased
+
+### Changes since 1.16.0
+
+Fixed:
+
+- Kraken X3/Z3: fix LCD static image upload on the Kraken 2024 Plus, whose firmware does not
+  respond to the bucket-based transfer protocol used by other LCD-capable Krakens; static images
+  are now sent through the same bucket-free protocol already used for Kraken 2023 units on
+  firmware 2.X.Y (liquidctl#908, liquidctl#864)
+
 ## [1.16.0] – 2026-03-03
 
 ### Changes since 1.15.0

--- a/docs/kraken-x3-z3-guide.md
+++ b/docs/kraken-x3-z3-guide.md
@@ -38,6 +38,13 @@ The functionality of the 2024 RGB AIO is identical to the 2023 model, retaining 
 
 The functionality of the 2024 RGB AIO is identical to the 2023 Standard model, with a 240x240 LCD.
 
+On this device, the bucket-based upload protocol used by other LCD-capable Krakens is not
+functional: bucket queries never receive a real response from the firmware, only continuous
+unsolicited status broadcasts (see [#864][`issue-864`] and [#908][`issue-908`]).  Because of this,
+`static` images are instead sent through the same bucket-free transfer path used by 2023 units on
+firmware 2.X.Y.  **GIF mode is not supported on this device** for the same reason it isn't
+supported on 2023 units running firmware 2.X.Y.
+
 
 ## Initialization
 
@@ -193,7 +200,8 @@ The LCD screen can be configured in a few different modes.
 Images and GiFs are automatically resized and rotated to match the device orientation.
 
 *Note that, on the 2023 models (Standard and Elite), the GIF screen mode is not currently supported
-on firmware versions 2.X (see [#631][`issue-631`]).*
+on firmware versions 2.X (see [#631][`issue-631`]).  The GIF screen mode is also not supported on
+the Kraken 2024 Plus (see [#864][`issue-864`] and [#908][`issue-908`]).*
 
 
 ## Interaction with Linux hwmon drivers
@@ -212,3 +220,5 @@ be forced with `--direct-access`.
 
 [liquidtux]: https://github.com/liquidctl/liquidtux
 [`issue-631`]: https://github.com/liquidctl/liquidctl/issues/631
+[`issue-864`]: https://github.com/liquidctl/liquidctl/issues/864
+[`issue-908`]: https://github.com/liquidctl/liquidctl/issues/908

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -43,6 +43,11 @@ _READ_LENGTH = 64
 _WRITE_LENGTH = 64
 _MAX_READ_ATTEMPTS = 12
 
+# some devices (e.g. the Kraken 2024 Plus) push status broadcasts much more
+# frequently than _MAX_READ_ATTEMPTS allows for; a dedicated, larger budget is
+# used when only skipping over broadcasts while waiting for a real response
+_MAX_BROADCAST_SKIP_ATTEMPTS = 200
+
 _LCD_TOTAL_MEMORY = 24320
 
 # some LCD-capable Krakens (e.g. the 2024 Plus) continuously push unsolicited
@@ -790,12 +795,14 @@ class KrakenZ3(KrakenX3):
         response to the last command, silently corrupting bucket
         bookkeeping (see issues #864 and #908).
         """
-        for _ in range(_MAX_READ_ATTEMPTS):
+        for _ in range(_MAX_BROADCAST_SKIP_ATTEMPTS):
             msg = self._read()
             if bytes(msg[0:2]) == _LCD_STATUS_BROADCAST_PREFIX:
                 continue
             return msg
-        assert False, f"no response received (attempts={_MAX_READ_ATTEMPTS}, only status broadcasts)"
+        assert (
+            False
+        ), f"no response received (attempts={_MAX_BROADCAST_SKIP_ATTEMPTS}, only status broadcasts)"
 
     def _bulk_write(self, data):
         if sys.platform == "win32":
@@ -832,8 +839,15 @@ class KrakenZ3(KrakenX3):
             self.brightness = msg[0x18]
             self.orientation = msg[0x1A]
 
-        def _is_2023_fw_version2():
+        def _uses_simple_lcd_protocol():
             device_product_id = self.device.product_id
+            if device_product_id == 0x3014:
+                # the Kraken 2024 Plus's bucket protocol appears to be
+                # unimplemented: bucket queries/deletes never receive a
+                # real response, only unsolicited status broadcasts (see
+                # issues #864 and #908); use the bucket-free transfer path
+                # instead, as already done for 2023 units on firmware 2.X.Y
+                return True
             if device_product_id == 0x300E:
                 self._get_fw_version()
                 return self._fw[0] == 2
@@ -854,7 +868,7 @@ class KrakenZ3(KrakenX3):
             self._write([0x30, 0x02, 0x01, self.brightness, 0x0, 0x0, 0x1, int(value_int / 90)])
             return
         elif mode == "static":
-            if _is_2023_fw_version2():
+            if _uses_simple_lcd_protocol():
                 data = self._prepare_static_file_rgb16(value, self.orientation)
                 self._send_2023_data_fw2(
                     data, [0x06, 0x0, 0x0, 0x0] + list(len(data).to_bytes(4, "little"))
@@ -870,7 +884,7 @@ class KrakenZ3(KrakenX3):
                 self._send_data(data, [0x02, 0x0, 0x0, 0x0] + list(len(data).to_bytes(4, "little")))
             return
         elif mode == "gif":
-            if _is_2023_fw_version2():
+            if _uses_simple_lcd_protocol():
                 raise NotSupportedByDriver(
                     "gif images are not supported on firmware 2.X.Y, please see issue #631"
                 )

--- a/liquidctl/driver/kraken3.py
+++ b/liquidctl/driver/kraken3.py
@@ -45,6 +45,16 @@ _MAX_READ_ATTEMPTS = 12
 
 _LCD_TOTAL_MEMORY = 24320
 
+# some LCD-capable Krakens (e.g. the 2024 Plus) continuously push unsolicited
+# status broadcasts on the same endpoint used for command responses; these
+# must be filtered out of single, blind reads or they will be mistaken for
+# the response to the last command (see issues #864 and #908)
+_LCD_STATUS_BROADCAST_PREFIX = bytes([0x75, 0x02])
+
+# generic error response prefix used by the LCD/bucket protocol; the second
+# byte and remaining fields vary depending on the command that was rejected
+_LCD_ERROR_PREFIX = 0xFF
+
 _STATUS_TEMPERATURE = "Liquid temperature"
 _STATUS_PUMP_SPEED = "Pump speed"
 _STATUS_PUMP_DUTY = "Pump duty"
@@ -768,7 +778,24 @@ class KrakenZ3(KrakenX3):
 
     def _write_then_read(self, data):
         self._write(data)
-        return self._read()
+        return self._read_skipping_broadcasts()
+
+    def _read_skipping_broadcasts(self):
+        """
+        Reads a single message, discarding any unsolicited LCD status
+        broadcasts along the way.
+
+        Without this, a blind single read (as previously done by
+        `_write_then_read`) can consume a broadcast instead of the actual
+        response to the last command, silently corrupting bucket
+        bookkeeping (see issues #864 and #908).
+        """
+        for _ in range(_MAX_READ_ATTEMPTS):
+            msg = self._read()
+            if bytes(msg[0:2]) == _LCD_STATUS_BROADCAST_PREFIX:
+                continue
+            return msg
+        assert False, f"no response received (attempts={_MAX_READ_ATTEMPTS}, only status broadcasts)"
 
     def _bulk_write(self, data):
         if sys.platform == "win32":
@@ -980,6 +1007,10 @@ class KrakenZ3(KrakenX3):
 
         assert self.bulk_device, "Cannot find bulk out device"
 
+        # drain any backlog of queued status broadcasts before starting the
+        # handshake, since some devices push them continuously (see #864)
+        self.device.clear_enqueued_reports()
+
         self._write_then_read([0x36, 0x03])  # unknown
 
         buckets = self._query_buckets()  # query all buckets and store their response
@@ -1053,6 +1084,7 @@ class KrakenZ3(KrakenX3):
         buckets = {}
         for bI in range(16):
             response = self._write_then_read([0x30, 0x04, bI])  # query bucket
+            _LOGGER.debug("bucket %d info: %r", bI, LazyHexRepr(response[0:22]))
             buckets[bI] = response
         return buckets
 
@@ -1143,7 +1175,15 @@ class KrakenZ3(KrakenX3):
         def parse_delete_result(msg):
             return msg[14] == 0x1
 
-        return self._read_until_first_match({b"\x33\x02": parse_delete_result})
+        def parse_delete_error(msg):
+            _LOGGER.debug(
+                "bucket %d delete rejected by device: %r", bucketIndex, LazyHexRepr(msg[0:20])
+            )
+            return False
+
+        return self._read_until_first_match(
+            {b"\x33\x02": parse_delete_result, b"\xff\x02": parse_delete_error}
+        )
 
     def _delete_all_buckets(self):
         """
@@ -1158,6 +1198,9 @@ class KrakenZ3(KrakenX3):
         switches active bucket, returns true if successful, false otherwise
         """
         response = self._write_then_read([0x38, 0x1, mode, bucketIndex])
+        if response[0] == _LCD_ERROR_PREFIX:
+            _LOGGER.debug("bucket switch rejected by device: %r", LazyHexRepr(response[0:20]))
+            return False
         return response[14] == 0x1
 
     def _setup_bucket(self, startBucketIndex, endBucketIndex, startingMemoryAddress, memorySize):
@@ -1177,4 +1220,7 @@ class KrakenZ3(KrakenX3):
                 0x1,
             ]
         )
+        if response[0] == _LCD_ERROR_PREFIX:
+            _LOGGER.debug("bucket setup rejected by device: %r", LazyHexRepr(response[0:20]))
+            return False
         return response[14] == 0x1

--- a/tests/test_kraken3.py
+++ b/tests/test_kraken3.py
@@ -12,11 +12,14 @@ from liquidctl.driver.kraken3 import (
     _SPEED_CHANNELS_KRAKENX,
     _COLOR_CHANNELS_KRAKENZ,
     _SPEED_CHANNELS_KRAKENZ,
+    _COLOR_CHANNELS_KRAKEN2023,
+    _SPEED_CHANNELS_KRAKEN2023,
     _HWMON_CTRL_MAPPING_KRAKENX,
     _HWMON_CTRL_MAPPING_KRAKENZ,
 )
 from test_krakenz3_response import krakenz3_response
 
+from liquidctl.error import NotSupportedByDriver
 from liquidctl.util import HUE2_MAX_ACCESSORIES_IN_CHANNEL as MAX_ACCESSORIES
 from liquidctl.util import Hue2Accessory
 
@@ -558,3 +561,59 @@ def test_krakenz3_screen_not_totally_broken_part2(mock_krakenz3):
     mock_krakenz3.set_screen(
         "lcd", "gif", os.path.join(os.path.dirname(os.path.abspath(__file__)), "rgb.gif")
     )
+
+
+def test_kraken2024plus_static_uses_bucket_free_protocol():
+    """The 2024 Plus's bucket protocol never gets a real response from the
+    firmware (only unsolicited status broadcasts, see #864 and #908), so
+    static images must be sent through the bucket-free protocol instead.
+    """
+
+    raw = MockKraken(raw_led_channels=0)
+    raw.product_id = 0x3014
+
+    dev = KrakenZ3(
+        raw,
+        "Mock Kraken 2024 Plus",
+        speed_channels=_SPEED_CHANNELS_KRAKEN2023,
+        color_channels=_COLOR_CHANNELS_KRAKEN2023,
+        hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENZ,
+        bulk_buffer_size=1024 * 1024 * 2,
+        lcd_resolution=(240, 240),
+    )
+    dev.connect()
+
+    calls = []
+    dev._send_2023_data_fw2 = lambda data, bulk_info: calls.append("fw2")
+    dev._send_data = lambda data, bulk_info: calls.append("bucket")
+
+    dev.set_screen(
+        "lcd", "static", os.path.join(os.path.dirname(os.path.abspath(__file__)), "yellow.jpg")
+    )
+
+    assert calls == ["fw2", "fw2"], "static images must go through the bucket-free protocol"
+
+
+def test_kraken2024plus_gif_not_supported():
+    """GIF mode is not supported on the 2024 Plus, for the same reason it is
+    unsupported on 2023 units running firmware 2.X.Y.
+    """
+
+    raw = MockKraken(raw_led_channels=0)
+    raw.product_id = 0x3014
+
+    dev = KrakenZ3(
+        raw,
+        "Mock Kraken 2024 Plus",
+        speed_channels=_SPEED_CHANNELS_KRAKEN2023,
+        color_channels=_COLOR_CHANNELS_KRAKEN2023,
+        hwmon_ctrl_mapping=_HWMON_CTRL_MAPPING_KRAKENZ,
+        bulk_buffer_size=1024 * 1024 * 2,
+        lcd_resolution=(240, 240),
+    )
+    dev.connect()
+
+    with pytest.raises(NotSupportedByDriver):
+        dev.set_screen(
+            "lcd", "gif", os.path.join(os.path.dirname(os.path.abspath(__file__)), "rgb.gif")
+        )


### PR DESCRIPTION
Fixes the LCD static image upload failure on the NZXT Kraken 2024 Plus (1e71:3014). On this
device, the bucket-based transfer protocol used by other LCD-capable Krakens is not implemented
by the firmware: bucket queries and deletes never receive a real response, only continuous
unsolicited status broadcasts, which previously surfaced as an opaque
`AssertionError('missing messages...')`.

Static images are now sent through the same bucket-free transfer protocol already used for
Kraken 2023 units running firmware 2.X.Y, bypassing the non-functional bucket protocol entirely.
GIF mode remains unsupported on this device, for the same reason it is unsupported on 2023 units
running firmware 2.X.Y.

Verified working on real Kraken 2024 Plus hardware (SteamOS).

<!-- Tags (fill in and keep as many as applicable): -->

Fixes: #908
Closes: #908
Related: #864

---

Checklist:

- [x] Adhere to the [development process]
- [x] Conform to the [style guide]
- [x] Verify that the changes work as expected on real hardware
- [x] Add automated tests cases
- [x] Verify that all (other) automated tests (still) pass
- [x] Update/add documentation
    - [x] applicable `docs/*guide.md` device guides, with ["new/changed in" notes]

[development process]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md
[style guide]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/style-guide.md
["new/changed in" notes]: https://github.com/liquidctl/liquidctl/blob/main/docs/developer/process.md#newchanged-in-notes