### PR TITLE
asus_ryujin: add Ryujin III Extreme LCD support

### DIFF
--- a/docs/asus-ryujin3-guide.md
+++ b/docs/asus-ryujin3-guide.md
@@ -67,4 +67,69 @@ Pump impeller and embedded fan duty values approximately map to the following sp
 
 ## Screen
 
-The screen of the cooler is not yet supported.
+_New in git._<br>
+
+The Ryujin III Extreme has a 640×480 LCD.  A static image can be displayed
+with:
+
+```
+# liquidctl set lcd screen static /path/to/image.png
+```
+
+Images are resized to the native resolution and converted to RGB automatically.
+The image stays on screen while the cooler remains powered.
+
+Animated GIFs are streamed from the host computer:
+
+```
+# liquidctl set lcd screen gif /path/to/animation.gif
+```
+
+The command keeps running while the animation plays; press Ctrl+C to stop it.
+
+To rotate through the cooler statistics with the default dashboard, run:
+
+```
+# liquidctl set lcd screen stats B300FF 5
+```
+
+The first argument is an optional six-digit RGB font colour shorthand (default:
+`B300FF`); the second is an optional page interval in seconds (default: `5`).
+The display runs until Ctrl+C.  Display brightness and orientation controls
+are not supported.
+
+For a configurable dashboard, pass a JSON file instead:
+
+```
+# liquidctl set lcd screen stats extra/contrib/asus_ryujin/example_layouts/ryujin_extreme_stats.json
+```
+
+The [example configuration](../extra/contrib/asus_ryujin/example_layouts/ryujin_extreme_stats.json)
+shows the supported keys.  `layout` maps one to four cards to rotating `stats`
+lists.  Card geometry is calculated automatically.  Built-in statistics are
+`liquid_temperature`, `pump_duty`, `pump_speed`, `pump_fan_duty`, and
+`pump_fan_speed`.
+
+`background_opacity` accepts a value from `0.0` to `1.0` and can be set on the
+LCD background and each card.  `offset_x` and `offset_y` adjust a card's
+position in pixels.
+
+For system telemetry, use a `custom` stat with a `command` array and optional
+`unit`.  Its standard output is displayed.  The command is executed directly,
+without a shell; configuration files must still be trusted because they choose
+the executable.
+
+```json
+{
+  "stat": "custom",
+  "indicator": "GPU TEMP",
+  "command": ["nvidia-smi", "--query-gpu=temperature.gpu", "--format=csv,noheader,nounits"],
+  "unit": "°C"
+}
+```
+
+Colours are six-digit hexadecimal strings, such as `"100713"` or `"B300FF"`.
+The leading `#` is optional.
+
+Set `background` to an image or animated GIF.  Relative paths are resolved
+from the JSON file's directory.

--- a/docs/developer/protocol/asus_ryujin.md
+++ b/docs/developer/protocol/asus_ryujin.md
@@ -3,6 +3,28 @@
 The data of all usb packets is 65 bytes long, prefixed with `0xEC`.
 
 
+## Ryujin III Extreme LCD
+
+The Ryujin III Extreme (USB ID `0b05:1bcb`) exposes its LCD on a separate bulk
+USB interface.  The cooler control interface is HID, while the LCD pixel data
+is written to bulk OUT endpoint `0x02`.
+
+The display is 640×480 pixels in packed RGB888 format (921,600 bytes per
+frame).  Before a frame upload, perform the following HID operations:
+
+1. Query LCD state: `EC D0`; the reply is headed by `EC 50`.
+   - byte 4 is the panel ID;
+   - byte 5 is the current display mode;
+   - bytes 6–7 are mode arguments.
+2. Write raw framebuffer mode `EC 51 20 <reply byte 6> <reply byte 7>`.
+   Reapply this command even when the reported mode is already `0x20`, to
+   reset display state left by an earlier raw-frame session.
+3. Announce the byte length with `EC 7F 03 <u32le length>`.
+4. Write the RGB888 frame to bulk endpoint `0x02`.
+
+Frame data is sent in ordinary top-to-bottom, left-to-right RGB888 order.
+
+
 ## Generic Operations
 
 ### Get firmware info

--- a/extra/contrib/asus_ryujin/example_layouts/ryujin_extreme_st4.json
+++ b/extra/contrib/asus_ryujin/example_layouts/ryujin_extreme_st4.json
@@ -1,0 +1,40 @@
+{
+  "background": "../lcd_animations/horiz/iii_ex_st4.gif",
+  "background_color": "170F1D",
+  "background_opacity": 0.2,
+  "font_color": "D8B4FE",
+  "interval": 5,
+  "title": "RYUJIN III EXTREME",
+  "layout": {
+    "coolant": {
+      "background_color": "2E193A",
+      "background_opacity": 0.2,
+      "font_color": "D8B4FE",
+      "offset_x": 0,
+      "offset_y": 0,
+      "stats": [{"stat": "liquid_temperature", "indicator": "COOLANT"}]
+    },
+    "pump": {
+      "background_color": "2E193A",
+      "background_opacity": 0.2,
+      "font_color": "D8B4FE",
+      "offset_x": 0,
+      "offset_y": 0,
+      "stats": [
+        {"stat": "pump_speed", "indicator": "PUMP"},
+        {"stat": "pump_duty", "indicator": "PUMP"}
+      ]
+    },
+    "pump_fan": {
+      "background_color": "2E193A",
+      "background_opacity": 0.2,
+      "font_color": "D8B4FE",
+      "offset_x": 0,
+      "offset_y": 0,
+      "stats": [
+        {"stat": "pump_fan_speed", "indicator": "PUMP FAN"},
+        {"stat": "pump_fan_duty", "indicator": "PUMP FAN"}
+      ]
+    }
+  }
+}

--- a/extra/contrib/asus_ryujin/example_layouts/ryujin_extreme_stats.json
+++ b/extra/contrib/asus_ryujin/example_layouts/ryujin_extreme_stats.json
@@ -1,0 +1,39 @@
+{
+  "background_color": "100713",
+  "background_opacity": 1.0,
+  "font_color": "B300FF",
+  "interval": 5,
+  "title": "RYUJIN III EXTREME",
+  "layout": {
+    "coolant": {
+      "background_color": "210B2D",
+      "background_opacity": 1.0,
+      "font_color": "B300FF",
+      "offset_x": 0,
+      "offset_y": 0,
+      "stats": [{"stat": "liquid_temperature", "indicator": "COOLANT"}]
+    },
+    "pump": {
+      "background_color": "210B2D",
+      "background_opacity": 1.0,
+      "font_color": "B300FF",
+      "offset_x": 0,
+      "offset_y": 0,
+      "stats": [
+        {"stat": "pump_speed", "indicator": "PUMP"},
+        {"stat": "pump_duty", "indicator": "PUMP"}
+      ]
+    },
+    "pump_fan": {
+      "background_color": "210B2D",
+      "background_opacity": 1.0,
+      "font_color": "B300FF",
+      "offset_x": 0,
+      "offset_y": 0,
+      "stats": [
+        {"stat": "pump_fan_speed", "indicator": "PUMP FAN"},
+        {"stat": "pump_fan_duty", "indicator": "PUMP FAN"}
+      ]
+    }
+  }
+}

--- a/extra/contrib/asus_ryujin/lcd_animations/.gitignore
+++ b/extra/contrib/asus_ryujin/lcd_animations/.gitignore
@@ -1,0 +1,4 @@
+# Armoury Crate animation assets are proprietary and intentionally local-only.
+*
+!.gitignore
+!README.md

--- a/extra/contrib/asus_ryujin/lcd_animations/README.md
+++ b/extra/contrib/asus_ryujin/lcd_animations/README.md
@@ -1,0 +1,25 @@
+# Local Armoury Crate animation assets
+
+The Ryujin III Extreme animation preset refers to GIFs in this directory.  The
+GIFs are not included in this repository.
+
+If Armoury Crate is installed locally, search its installation directory for
+`iii_ex_st*.gif`.  A typical Windows installation starts at:
+
+```
+C:\Program Files (x86)\ASUS\ArmouryDevice
+```
+
+The files are normally below an
+`lcd\common\35\hw_monitor\share_theme\bg_anim` directory.  The intermediate
+version directory can change between releases.
+
+Copy the files here while preserving their `horiz/` and `vert/` directories.
+For example, the `ryujin_extreme_st4.json` preset expects:
+
+```
+extra/contrib/asus_ryujin/lcd_animations/horiz/iii_ex_st4.gif
+```
+
+The `.gitignore` file keeps copied assets out of Git.  Do not commit or
+redistribute them without permission from the rights holder.

--- a/liquidctl.8
+++ b/liquidctl.8
@@ -249,7 +249,8 @@ Cooling channels: \fIpump\fR, \fIfans\fR, \fIpump\-fan\fR, \fIexternal\-fans\fR.
 .SS ASUS Ryujin III 360, EVA, Extreme, White
 Cooling channels: \fIpump\fR, \fIpump\-fan\fR.
 .PP
-Screen: not yet supported.
+Screen: on the Ryujin III Extreme, static images, host-streamed GIFs and a
+statistics dashboard are supported with the \fIlcd\fR channel.
 .SS ASUS Ryuo II 240
 Cooling channels: \fIfans\fR, \fIfan\fR. There is only a single fan channel.
 .SS Corsair iCUE Elite Capellix H100i, H115i, H150i

--- a/liquidctl/cli.py
+++ b/liquidctl/cli.py
@@ -7,7 +7,7 @@ Usage:
   liquidctl [options] set <channel> speed (<temperature> <percentage>) ...
   liquidctl [options] set <channel> speed <percentage>
   liquidctl [options] set <channel> color <mode> [<color>] ...
-  liquidctl [options] set <channel> screen <mode> [<value>]
+  liquidctl [options] set <channel> screen <mode> [<value>] [<interval>]
   liquidctl --help
   liquidctl --version
 
@@ -283,8 +283,12 @@ def _device_set_color(dev, args, **opts):
     color = map(color_from_str, args['<color>'])
     dev.set_color(args['<channel>'].lower(), args['<mode>'].lower(), color, **opts)
 
+
 def _device_set_screen(dev, args, **opts):
+    if args["<interval>"] is not None:
+        opts["interval"] = args["<interval>"]
     dev.set_screen(args["<channel>"], args["<mode>"], args["<value>"], **opts)
+
 
 def _device_set_speed(dev, args, **opts):
     if len(args['<temperature>']) > 0:

--- a/liquidctl/driver/asus_ryujin.py
+++ b/liquidctl/driver/asus_ryujin.py
@@ -5,9 +5,25 @@ SPDX-License-Identifier: GPL-3.0-or-later
 """
 
 import logging
+import sys
+import time
+from itertools import chain
 from typing import List
 
-from liquidctl.driver.usb import UsbHidDriver
+if sys.platform == "win32":
+    from winusbcdc import WinUsbPy
+
+from liquidctl.driver.usb import PyUsbDevice, UsbHidDriver
+from liquidctl.driver.asus_ryujin_lcd import (
+    _LCD_FRAME_SIZE,
+    _iter_lcd_animation,
+    _iter_lcd_background,
+    _load_lcd_static_background,
+    _load_lcd_stats_config,
+    _prepare_lcd_frame,
+    _read_lcd_custom_stats,
+    _render_lcd_stats,
+)
 from liquidctl.error import ExpectationNotMet, NotSupportedByDriver
 from liquidctl.util import clamp, u16le_from, rpadlist, fraction_of_byte
 
@@ -35,6 +51,11 @@ _STATUS_COOLER_FAN_SPEED = "Pump fan speed"
 _STATUS_COOLER_FAN_DUTY = "Pump fan duty"
 _STATUS_CONTROLLER_FAN_SPEED = "External fan {} speed"
 _STATUS_CONTROLLER_FAN_DUTY = "External fan duty"
+
+_LCD_PRODUCT_ID = 0x1BCB
+_LCD_RAW_FRAMEBUFFER_MODE = 0x20
+_LCD_BULK_OUT_ENDPOINT = 0x02
+_LCD_TRANSFER_TIMEOUT_MS = 10_000
 
 
 class AsusRyujin(UsbHidDriver):
@@ -112,6 +133,7 @@ class AsusRyujin(UsbHidDriver):
         pump_fan_speed_offset,
         temp_offset,
         duty_channel,
+        bulk_device=None,
         **kwargs,
     ):
         super().__init__(device, description, **kwargs)
@@ -121,6 +143,7 @@ class AsusRyujin(UsbHidDriver):
         self._pump_fan_speed_offset = pump_fan_speed_offset
         self._temp_offset = temp_offset
         self._duty_channel = duty_channel
+        self._bulk_device = bulk_device
 
     def initialize(self, **kwargs):
         msg = self._request(*_REQUEST_GET_FIRMWARE)
@@ -225,9 +248,200 @@ class AsusRyujin(UsbHidDriver):
         for handler in handlers:
             handler(duty)
 
-    def set_screen(self, channel, mode, value, **kwargs):
-        # Not yet reverse engineered / implemented
-        raise NotSupportedByDriver()
+    def set_screen(self, channel, mode, value, interval=None, **kwargs):
+        """Set the Ryujin III Extreme LCD image.
+
+        Supported channels, modes and values:
+
+        | Channel | Mode | Value |
+        | --- | --- | --- |
+        | `lcd` | `static` | path to image |
+        | `lcd` | `gif` | path to animated GIF (plays until interrupted) |
+        | `lcd` | `stats` | path to JSON configuration, or RGB hex shorthand |
+        """
+        if self.product_id != _LCD_PRODUCT_ID:
+            raise NotSupportedByDriver()
+        if channel.lower() != "lcd":
+            raise ValueError(f"invalid channel: {channel}")
+        mode = mode.lower()
+        if mode not in ("static", "gif", "stats"):
+            raise ValueError(f"invalid mode: {mode}")
+
+        content = self._prepare_lcd_content(mode, value, interval)
+        bulk_device = self._open_bulk_device()
+        try:
+            self._switch_to_raw_framebuffer_mode()
+            if mode == "static":
+                self._send_lcd_frame(bulk_device, content)
+            elif mode == "gif":
+                self._play_lcd_animation(bulk_device, content)
+            else:
+                self._display_lcd_statistics(bulk_device, *content)
+        finally:
+            self._close_bulk_device(bulk_device)
+
+    def _prepare_lcd_content(self, mode, value, interval):
+        try:
+            if mode == "static":
+                return _prepare_lcd_frame(value)
+            if mode == "gif":
+                return self._load_lcd_animation(value)
+
+            config = _load_lcd_stats_config(value, interval)
+            static_background = (
+                _load_lcd_static_background(config["background"])
+                if config["background"]
+                else None
+            )
+            if config["background"] and static_background is None:
+                return config, None, self._load_lcd_background(value=config["background"])
+            return config, static_background, None
+        except (OSError, StopIteration, ValueError) as err:
+            raise ValueError(f"invalid {mode} configuration: {err}") from err
+
+    @staticmethod
+    def _load_lcd_animation(path):
+        frames = _iter_lcd_animation(path)
+        first_frame = next(frames)
+        return chain((first_frame,), frames)
+
+    @staticmethod
+    def _load_lcd_background(value):
+        frames = _iter_lcd_background(value)
+        first_frame = next(frames)
+        return chain((first_frame,), frames)
+
+    def _play_lcd_animation(self, bulk_device, frames):
+        try:
+            for frame, duration in frames:
+                self._send_lcd_frame(bulk_device, frame)
+                time.sleep(duration)
+        except KeyboardInterrupt:
+            _LOGGER.debug("stopped Ryujin III Extreme LCD GIF playback")
+
+    def _display_lcd_statistics(self, bulk_device, config, static_background, background_frames):
+        try:
+            if background_frames is not None:
+                self._display_lcd_statistics_with_animation(bulk_device, config, background_frames)
+            else:
+                self._display_lcd_statistics_with_static_background(
+                    bulk_device, config, static_background
+                )
+        except KeyboardInterrupt:
+            _LOGGER.debug("stopped Ryujin III Extreme LCD statistics display")
+
+    def _display_lcd_statistics_with_animation(self, bulk_device, config, background_frames):
+        page = 0
+        status = self.get_status()
+        custom_values = _read_lcd_custom_stats(config, page)
+        next_page = time.monotonic() + config["interval"]
+
+        for background, duration in background_frames:
+            now = time.monotonic()
+            if now >= next_page:
+                page += 1
+                status = self.get_status()
+                custom_values = _read_lcd_custom_stats(config, page)
+                next_page += config["interval"]
+            self._send_lcd_frame(
+                bulk_device,
+                _render_lcd_stats(
+                    status,
+                    config,
+                    page,
+                    max(next_page - now, 0),
+                    background,
+                    custom_values,
+                ),
+            )
+            time.sleep(duration)
+
+    def _display_lcd_statistics_with_static_background(self, bulk_device, config, background):
+        page = 0
+        while True:
+            custom_values = _read_lcd_custom_stats(config, page)
+            next_page = time.monotonic() + config["interval"]
+            while True:
+                now = time.monotonic()
+                if now >= next_page:
+                    break
+                status = self.get_status()
+                self._send_lcd_frame(
+                    bulk_device,
+                    _render_lcd_stats(
+                        status,
+                        config,
+                        page,
+                        next_page - now,
+                        background,
+                        custom_values,
+                    ),
+                )
+                time.sleep(min(1, next_page - now))
+            page += 1
+
+    def _open_bulk_device(self):
+        if self._bulk_device is not None:
+            bulk_device = self._bulk_device
+        elif sys.platform == "win32":
+            bulk_device = WinUsbPy()
+            if not self._find_winusb_device(bulk_device):
+                raise NotSupportedByDriver("could not find the LCD bulk interface")
+        else:
+            bulk_device = next(
+                (
+                    candidate
+                    for candidate in PyUsbDevice.enumerate(self.vendor_id, self.product_id)
+                    if candidate.serial_number == self.serial_number
+                ),
+                None,
+            )
+            if bulk_device is None:
+                raise NotSupportedByDriver("could not find the LCD bulk interface")
+
+        if sys.platform != "win32":
+            bulk_device.open()
+            bulk_device.claim()
+        return bulk_device
+
+    def _close_bulk_device(self, bulk_device):
+        if sys.platform == "win32":
+            bulk_device.close_winusb_device()
+        else:
+            bulk_device.close()
+
+    def _find_winusb_device(self, bulk_device):
+        for candidate in bulk_device.list_usb_devices(
+            deviceinterface=True, present=True, findparent=True
+        ):
+            if (
+                f"vid_{self.vendor_id:x}&pid_{self.product_id:x}" in candidate.path
+                and candidate.parent
+                and self.serial_number in candidate.parent
+            ):
+                bulk_device.init_winusb_device_with_path(candidate.path)
+                return True
+        return False
+
+    def _switch_to_raw_framebuffer_mode(self):
+        reply = self._request(0xD0, 0x50)
+        # Reapply the mode even when it is already selected, avoiding display
+        # state carried over from an earlier raw-frame session.
+        time.sleep(0.1)
+        self._write([_PREFIX, 0x51, _LCD_RAW_FRAMEBUFFER_MODE, reply[6], reply[7]])
+        time.sleep(0.1)
+
+    def _announce_framebuffer_length(self, length):
+        self._write([_PREFIX, 0x7F, 0x03, *length.to_bytes(4, byteorder="little")])
+
+    def _send_lcd_frame(self, bulk_device, frame):
+        assert len(frame) == _LCD_FRAME_SIZE
+        self._announce_framebuffer_length(len(frame))
+        written = bulk_device.write(
+            _LCD_BULK_OUT_ENDPOINT, frame, timeout=_LCD_TRANSFER_TIMEOUT_MS
+        )
+        if written is not None and written != len(frame):
+            raise RuntimeError(f"short LCD bulk write: {written} of {len(frame)} bytes")
 
     def _request(self, request_header: int, response_header: int) -> List[int]:
         self.device.clear_enqueued_reports()

--- a/liquidctl/driver/asus_ryujin_lcd.py
+++ b/liquidctl/driver/asus_ryujin_lcd.py
@@ -1,0 +1,421 @@
+"""LCD asset handling and dashboard rendering for ASUS Ryujin devices.
+
+This module deliberately contains no USB or HID transport code.  Keeping the
+presentation layer separate makes the device driver easier to audit.
+
+Copyright Aenima4six2 and contributors
+SPDX-License-Identifier: GPL-3.0-or-later
+"""
+
+# uses the psf/black style
+
+import json
+import math
+import subprocess
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont, ImageSequence
+
+_LCD_RESOLUTION = (640, 480)
+_LCD_FRAME_SIZE = _LCD_RESOLUTION[0] * _LCD_RESOLUTION[1] * 3
+_LCD_STATS_DEFAULT_ACCENT = "#b300ff"
+_LCD_STATS_NAMES = {
+    "liquid_temperature": "Liquid temperature",
+    "pump_speed": "Pump speed",
+    "pump_duty": "Pump duty",
+    "pump_fan_speed": "Pump fan speed",
+    "pump_fan_duty": "Pump fan duty",
+}
+
+
+def _prepare_lcd_image(image):
+    """Convert a Pillow image to the Ryujin III Extreme's native frame format."""
+    return image.convert("RGB").resize(_LCD_RESOLUTION).tobytes("raw", "RGB")
+
+
+def _prepare_lcd_frame(path):
+    """Load an image file and convert it to the Ryujin III Extreme frame format."""
+    with Image.open(path) as image:
+        return _prepare_lcd_image(image)
+
+
+def _iter_lcd_animation(path):
+    """Yield converted GIF frames and their display durations in seconds."""
+    with Image.open(path) as animation:
+        if not getattr(animation, "is_animated", False):
+            raise ValueError("GIF mode requires an animated image")
+        while True:
+            for image in ImageSequence.Iterator(animation):
+                yield _prepare_lcd_image(image), max(image.info.get("duration", 100), 20) / 1000
+
+
+def _iter_lcd_background(path):
+    """Yield resized RGB background frames and their display durations."""
+    with Image.open(path) as animation:
+        if not getattr(animation, "is_animated", False):
+            raise ValueError("background is not animated")
+        while True:
+            for image in ImageSequence.Iterator(animation):
+                yield image.convert("RGB").resize(_LCD_RESOLUTION), max(
+                    image.info.get("duration", 100), 20
+                ) / 1000
+
+
+def _load_lcd_static_background(path):
+    """Load a non-animated background image, returning None for an animation."""
+    with Image.open(path) as image:
+        if getattr(image, "is_animated", False):
+            return None
+        return image.convert("RGB").resize(_LCD_RESOLUTION)
+
+
+def _lcd_font(size):
+    try:
+        return ImageFont.load_default(size=size)
+    except TypeError:
+        return ImageFont.load_default()
+
+
+def _parse_lcd_color(value):
+    value = str(_LCD_STATS_DEFAULT_ACCENT if value is None else value).lstrip("#")
+    if len(value) != 6:
+        raise ValueError("stats colour must be a six-digit RGB hex value")
+    try:
+        return tuple(int(value[index : index + 2], 16) for index in range(0, 6, 2))
+    except ValueError as err:
+        raise ValueError("stats colour must be a six-digit RGB hex value") from err
+
+
+def _parse_lcd_opacity(value):
+    try:
+        value = float(value)
+    except (TypeError, ValueError) as err:
+        raise ValueError("background opacity must be a number from 0.0 to 1.0") from err
+    if not 0 <= value <= 1:
+        raise ValueError("background opacity must be a number from 0.0 to 1.0")
+    return value
+
+
+def _scale_color(color, factor):
+    return tuple(round(component * factor) for component in color)
+
+
+def _lighten_color(color, amount):
+    return tuple(round(component + (255 - component) * amount) for component in color)
+
+
+def _read_lcd_custom_stat(config):
+    """Run a configured argv command and return its output as an LCD value."""
+    try:
+        result = subprocess.run(
+            config["command"], shell=False, capture_output=True, check=True, text=True, timeout=2
+        )
+    except (OSError, subprocess.SubprocessError) as err:
+        raise ValueError(f"custom statistic command failed: {config['command']}") from err
+    value = result.stdout.strip().replace("\n", " ")
+    if not value:
+        raise ValueError(f"custom statistic command returned no value: {config['command']}")
+    return value, config.get("unit", "")
+
+
+def _read_lcd_custom_stats(config, page):
+    return [
+        _read_lcd_custom_stat(selected) if selected["stat"] == "custom" else None
+        for card in config["layout"].values()
+        for selected in [card["stats"][page % len(card["stats"])]]
+    ]
+
+
+def _format_lcd_number(value, max_digits):
+    value = float(value)
+    magnitude, suffix = abs(value), ""
+    if magnitude >= 10**max_digits:
+        value, suffix = (value / 1_000_000, "M") if magnitude >= 1_000_000 else (value / 1_000, "k")
+        magnitude = abs(value)
+    places = max(0, min(2, max_digits - len(str(int(magnitude)))))
+    formatted = f"{value:.{places}f}"
+    return f"{formatted.rstrip('0').rstrip('.') if places else formatted}{suffix}"
+
+
+def _format_lcd_value(value, unit, max_digits):
+    if isinstance(value, str):
+        try:
+            value = float(value)
+        except ValueError:
+            return f"{value}{unit}".strip()
+    return f"{_format_lcd_number(value, max_digits)}{unit}"
+
+
+def _lcd_stats_cards(layout):
+    """Return balanced card positions and value font sizes for a card count."""
+    cards = {
+        1: [(32, 108, 576, 340, 128)],
+        2: [(32, 108, 268, 340, 58), (340, 108, 268, 340, 58)],
+        3: [(32, 108, 576, 162, 108), (32, 304, 268, 144, 52), (340, 304, 268, 144, 52)],
+        4: [
+            (32, 108, 268, 154, 50),
+            (340, 108, 268, 154, 50),
+            (32, 294, 268, 154, 50),
+            (340, 294, 268, 154, 50),
+        ],
+    }
+    return [
+        dict(zip(("x", "y", "width", "height", "font_size"), card)) for card in cards[len(layout)]
+    ]
+
+
+def _fit_lcd_label(draw, text, max_width, max_height):
+    words = text.upper().split()
+    for size in range(26, 11, -1):
+        font, lines, line = _lcd_font(size), [], ""
+        for word in words:
+            candidate = f"{line} {word}".strip()
+            if line and draw.textbbox((0, 0), candidate, font=font)[2] > max_width:
+                lines.append(line)
+                line = word
+            else:
+                line = candidate
+        if line:
+            lines.append(line)
+        line_height = draw.textbbox((0, 0), "Ag", font=font)[3]
+        if len(lines) <= 2 and len(lines) * line_height <= max_height:
+            return font, lines, line_height
+    return _lcd_font(12), [text.upper()], 14
+
+
+def _default_lcd_stats_config(
+    background_color="#100713", font_color=_LCD_STATS_DEFAULT_ACCENT, interval=5
+):
+    return {
+        "background_color": _parse_lcd_color(background_color),
+        "background_opacity": 1.0,
+        "font_color": _parse_lcd_color(font_color),
+        "interval": interval,
+        "title": "RYUJIN III EXTREME",
+        "background": None,
+        "layout": {
+            "liquid": {
+                "background_color": None,
+                "font_color": None,
+                "stats": [{"stat": "liquid_temperature", "indicator": "LIQUID"}],
+            },
+            "pump": {
+                "background_color": None,
+                "font_color": None,
+                "stats": [
+                    {"stat": "pump_speed", "indicator": "PUMP"},
+                    {"stat": "pump_duty", "indicator": "PUMP"},
+                ],
+            },
+            "pump_fan": {
+                "background_color": None,
+                "font_color": None,
+                "stats": [
+                    {"stat": "pump_fan_speed", "indicator": "PUMP FAN"},
+                    {"stat": "pump_fan_duty", "indicator": "PUMP FAN"},
+                ],
+            },
+        },
+    }
+
+
+def _validate_lcd_stats_config(config):
+    if not isinstance(config, dict):
+        raise ValueError("stats configuration must be a JSON object")
+    allowed = {
+        "background_color",
+        "background_opacity",
+        "font_color",
+        "interval",
+        "title",
+        "layout",
+        "background",
+    }
+    unknown = config.keys() - allowed
+    if unknown:
+        raise ValueError(f"unknown stats configuration key: {next(iter(unknown))}")
+    result = _default_lcd_stats_config()
+    for key, parser in (
+        ("background_color", _parse_lcd_color),
+        ("background_opacity", _parse_lcd_opacity),
+        ("font_color", _parse_lcd_color),
+    ):
+        if key in config:
+            result[key] = parser(config[key])
+    try:
+        result["interval"] = float(config.get("interval", result["interval"]))
+    except (TypeError, ValueError) as err:
+        raise ValueError("stats interval must be a number of seconds") from err
+    if result["interval"] <= 0:
+        raise ValueError("stats interval must be greater than zero")
+    if "title" in config:
+        if not isinstance(config["title"], str):
+            raise ValueError("stats title must be a string")
+        result["title"] = config["title"]
+    if "layout" in config:
+        layout = config["layout"]
+        if not isinstance(layout, dict) or not 1 <= len(layout) <= 4:
+            raise ValueError("layout must map one to four cards to stat lists")
+        for card_name, card in layout.items():
+            if not isinstance(card_name, str) or not isinstance(card, dict):
+                raise ValueError("each layout card must be a mapping")
+            allowed_card = {
+                "background_color",
+                "background_opacity",
+                "font_color",
+                "offset_x",
+                "offset_y",
+                "stats",
+            }
+            if (
+                set(card) - allowed_card
+                or not isinstance(card.get("stats"), list)
+                or not card["stats"]
+            ):
+                raise ValueError("each layout card needs a non-empty stats list")
+            for key in ("background_color", "font_color"):
+                if key in card and card[key] is not None:
+                    card[key] = _parse_lcd_color(card[key])
+            if "background_opacity" in card:
+                card["background_opacity"] = _parse_lcd_opacity(card["background_opacity"])
+            for key in ("offset_x", "offset_y"):
+                if key in card and not isinstance(card[key], int):
+                    raise ValueError(f"card {key} must be an integer number of pixels")
+            for stat in card["stats"]:
+                if not isinstance(stat, dict) or not isinstance(stat.get("indicator"), str):
+                    raise ValueError("card stat or indicator is invalid")
+                if stat.get("stat") == "custom":
+                    if set(stat) - {"stat", "indicator", "command", "unit"}:
+                        raise ValueError("custom card stats only support command and unit")
+                    command = stat.get("command")
+                    if (
+                        not isinstance(command, list)
+                        or not command
+                        or not all(isinstance(arg, str) and arg for arg in command)
+                    ):
+                        raise ValueError(
+                            "custom card stat command must be a non-empty list of strings"
+                        )
+                    if "unit" in stat and not isinstance(stat["unit"], str):
+                        raise ValueError("custom card stat unit must be a string")
+                elif set(stat) != {"stat", "indicator"} or stat["stat"] not in _LCD_STATS_NAMES:
+                    raise ValueError("card stat or indicator is invalid")
+        result["layout"] = layout
+    if "background" in config:
+        if config["background"] is not None and not isinstance(config["background"], str):
+            raise ValueError("background must be a path to an image or GIF")
+        result["background"] = config["background"]
+    return result
+
+
+def _load_lcd_stats_config(value, interval):
+    path = Path(value) if value else None
+    if path and path.is_file():
+        with path.open(encoding="utf-8") as config_file:
+            config = _validate_lcd_stats_config(json.load(config_file))
+        if config["background"]:
+            background = Path(config["background"])
+            config["background"] = (
+                background if background.is_absolute() else path.parent / background
+            )
+        if interval is not None:
+            config["interval"] = float(interval)
+            if config["interval"] <= 0:
+                raise ValueError("stats interval must be greater than zero")
+        return config
+    if value and path.suffix.lower() == ".json":
+        raise ValueError(f"could not read stats configuration: {value}")
+    shorthand_interval = float(interval) if interval is not None else 5
+    if shorthand_interval <= 0:
+        raise ValueError("stats interval must be greater than zero")
+    return _default_lcd_stats_config(font_color=value, interval=shorthand_interval)
+
+
+def _render_lcd_stats(
+    status, config, page, remaining_seconds, background_image=None, custom_values=None
+):
+    by_name, visible = {stat[0]: stat for stat in status}, []
+    for index, card_config in enumerate(config["layout"].values()):
+        selected = card_config["stats"][page % len(card_config["stats"])]
+        if selected["stat"] == "custom":
+            value, unit = (
+                custom_values[index]
+                if custom_values is not None
+                else _read_lcd_custom_stat(selected)
+            )
+        else:
+            stat = by_name.get(_LCD_STATS_NAMES[selected["stat"]])
+            if stat is None:
+                raise ValueError(f"configured statistic is unavailable: {selected['stat']}")
+            value, unit = stat[1:]
+        visible.append((selected["indicator"], value, unit))
+    font_color, background = config["font_color"], config["background_color"]
+    panel, border, muted = (
+        _scale_color(font_color, 0.14),
+        _scale_color(font_color, 0.55),
+        _lighten_color(font_color, 0.55),
+    )
+    image = (
+        background_image.convert("RGB").resize(_LCD_RESOLUTION)
+        if background_image is not None
+        else Image.new("RGB", _LCD_RESOLUTION, background)
+    )
+    if background_image is not None and config["background_opacity"] < 1:
+        image = Image.alpha_composite(
+            image.convert("RGBA"),
+            Image.new(
+                "RGBA", _LCD_RESOLUTION, (*background, round(config["background_opacity"] * 255))
+            ),
+        ).convert("RGB")
+    draw, title_font = ImageDraw.Draw(image), _lcd_font(28)
+    draw.text((32, 28), config["title"], font=title_font, fill=muted)
+    countdown = f"{math.ceil(remaining_seconds)}s"
+    draw.text(
+        (608 - draw.textbbox((0, 0), countdown, font=title_font)[2], 28),
+        countdown,
+        font=title_font,
+        fill=muted,
+    )
+    draw.line((32, 76, 608, 76), fill=border, width=2)
+    for card, card_config, (name, value, unit) in zip(
+        _lcd_stats_cards(config["layout"]), config["layout"].values(), visible
+    ):
+        x0, y0 = card["x"] + card_config.get("offset_x", 0), card["y"] + card_config.get(
+            "offset_y", 0
+        )
+        x1, y1 = x0 + card["width"], y0 + card["height"]
+        card_background = card_config.get("background_color") or panel
+        overlay = Image.new("RGBA", _LCD_RESOLUTION)
+        ImageDraw.Draw(overlay).rectangle(
+            (x0, y0, x1, y1),
+            fill=(*card_background, round(card_config.get("background_opacity", 1.0) * 255)),
+        )
+        image = Image.alpha_composite(image.convert("RGBA"), overlay).convert("RGB")
+        draw = ImageDraw.Draw(image)
+        draw.rectangle((x0, y0, x1, y1), outline=border, width=2)
+        label_font, lines, line_height = _fit_lcd_label(
+            draw, name, card["width"] - 40, card["height"] // 3
+        )
+        label_color = _lighten_color(card_config.get("font_color") or font_color, 0.55)
+        for line_index, line in enumerate(lines):
+            draw.text(
+                (x0 + 20, y0 + 20 + line_index * line_height),
+                line,
+                font=label_font,
+                fill=label_color,
+            )
+        value_text = _format_lcd_value(value, unit, 8 if card["width"] >= 500 else 5)
+        value_font = _lcd_font(card["font_size"])
+        while (
+            value_font.size > 12
+            and draw.textbbox((0, 0), value_text, font=value_font)[2] > card["width"] - 40
+        ):
+            value_font = _lcd_font(value_font.size - 1)
+        value_bottom = draw.textbbox((0, 0), value_text, font=value_font)[3]
+        draw.text(
+            (x0 + 20, y1 - 20 - value_bottom),
+            value_text,
+            font=value_font,
+            fill=card_config.get("font_color") or font_color,
+        )
+    return _prepare_lcd_image(image)

--- a/tests/test_asus_ryujin.py
+++ b/tests/test_asus_ryujin.py
@@ -1,7 +1,24 @@
 import pytest
 
-from _testutils import MockHidapiDevice
+from _testutils import MockHidapiDevice, MockPyusbDevice
+
+import json
+from types import SimpleNamespace
+
+from PIL import Image, ImageDraw
+
+import liquidctl.driver.asus_ryujin_lcd as asus_ryujin_lcd
 from liquidctl.driver.asus_ryujin import AsusRyujin
+from liquidctl.driver.asus_ryujin_lcd import (
+    _format_lcd_value,
+    _iter_lcd_animation,
+    _load_lcd_stats_config,
+    _load_lcd_static_background,
+    _parse_lcd_color,
+    _prepare_lcd_frame,
+    _read_lcd_custom_stats,
+    _render_lcd_stats,
+)
 
 PROTOCOL_HEADER = 0xEC
 CMD_GET_FIRMWARE = 0x82
@@ -11,6 +28,9 @@ CMD_GET_FAN_SPEEDS = 0xA0
 CMD_GET_FAN_DUTY = 0xA1
 CMD_SET_PUMP_DUTY = 0x1A
 CMD_SET_FAN_DUTY = 0x21
+CMD_GET_LCD_MODE = 0xD0
+CMD_SET_LCD_MODE = 0x51
+CMD_ANNOUNCE_LCD_FRAME = 0x7F
 DEVICE_CONFIGS = {
     0x1988: {
         "name": "Mock ASUS Ryujin II",
@@ -53,6 +73,7 @@ DEVICE_CONFIGS = {
             CMD_GET_FIRMWARE: "ec02004155524a332d533546392d30313034",
             CMD_GET_STATUS: "ec190000001d09ec041e6603",
             CMD_GET_PUMP_DUTY: "ec1a00011e1e",
+            CMD_GET_LCD_MODE: "ec50000131140000",
             CMD_SET_PUMP_DUTY: "ec1a",
         },
         "expected_firmware": "AURJ3-S5F9-0104",
@@ -164,9 +185,7 @@ class _MockRyujinDevice(MockHidapiDevice):
         return buf[:length]
 
 
-@pytest.fixture
-def mock_ryujin():
-    product_id = 0x1988
+def _create_mock_ryujin(product_id):
     config = DEVICE_CONFIGS[product_id]
     return AsusRyujin(
         _MockRyujinDevice(vendor_id=0x0B05, product_id=product_id),
@@ -177,35 +196,274 @@ def mock_ryujin():
         temp_offset=config["temp_offset"],
         duty_channel=config["duty_channel"],
     )
+
+
+def test_prepare_lcd_frame_preserves_pixel_positions_and_rgb_order(tmp_path):
+    width, height = 640, 480
+    image = Image.new("RGB", (width, height))
+    draw = ImageDraw.Draw(image)
+    draw.rectangle((0, 0, width // 2 - 1, height // 2 - 1), fill=(255, 0, 0))
+    draw.rectangle((width // 2, 0, width - 1, height // 2 - 1), fill=(0, 255, 0))
+    draw.rectangle((0, height // 2, width // 2 - 1, height - 1), fill=(0, 0, 255))
+    draw.rectangle((width // 2, height // 2, width - 1, height - 1), fill=(255, 255, 255))
+    path = tmp_path / "corners.png"
+    image.save(path)
+
+    frame = _prepare_lcd_frame(path)
+    row_size = width * 3
+
+    assert len(frame) == width * height * 3
+    assert frame[0:3] == bytes((255, 0, 0))
+    assert frame[row_size - 3 : row_size] == bytes((0, 255, 0))
+    assert frame[-row_size : -row_size + 3] == bytes((0, 0, 255))
+    assert frame[-3:] == bytes((255, 255, 255))
+
+
+def test_set_static_screen_uses_validated_lcd_sequence(mock_ryujin3, tmp_path):
+    image = Image.new("RGB", (640, 480), color=(255, 0, 0))
+    path = tmp_path / "red.png"
+    image.save(path)
+    bulk_device = MockPyusbDevice(vendor_id=0x0B05, product_id=0x1BCB)
+    mock_ryujin3._bulk_device = bulk_device
+
+    with mock_ryujin3.connect():
+        mock_ryujin3.set_screen(channel="lcd", mode="static", value=path)
+
+    assert [request[1] for request in mock_ryujin3.device.requests[-3:]] == [
+        CMD_GET_LCD_MODE,
+        CMD_SET_LCD_MODE,
+        CMD_ANNOUNCE_LCD_FRAME,
+    ]
+    assert mock_ryujin3.device.requests[-2][2:5] == [0x20, 0x00, 0x00]
+    assert mock_ryujin3.device.requests[-1][2:7] == [0x03, 0x00, 0x10, 0x0E, 0x00]
+    transfer, endpoint, frame = bulk_device._sent_xfers[-1]
+    assert transfer == "write"
+    assert endpoint == 0x02
+    assert len(frame) == 640 * 480 * 3
+    assert frame[:3] == bytes((255, 0, 0))
+
+
+@pytest.mark.parametrize("mode", ["static", "gif"])
+def test_invalid_lcd_asset_does_not_switch_to_raw_mode(mock_ryujin3, tmp_path, mode):
+    path = tmp_path / f"missing.{mode}"
+
+    with mock_ryujin3.connect():
+        with pytest.raises(ValueError, match=f"invalid {mode} configuration"):
+            mock_ryujin3.set_screen(channel="lcd", mode=mode, value=path)
+
+    assert not mock_ryujin3.device.requests
+
+
+def test_invalid_stats_background_does_not_switch_to_raw_mode(mock_ryujin3, tmp_path):
+    path = tmp_path / "stats.json"
+    path.write_text(json.dumps({"background": "missing.gif"}))
+
+    with mock_ryujin3.connect():
+        with pytest.raises(ValueError, match="invalid stats configuration"):
+            mock_ryujin3.set_screen(channel="lcd", mode="stats", value=path)
+
+    assert not mock_ryujin3.device.requests
+
+
+def test_lcd_animation_frames_are_converted_and_keep_their_duration(tmp_path):
+    path = tmp_path / "two-frames.gif"
+    Image.new("RGB", (640, 480), color=(255, 0, 0)).save(
+        path,
+        save_all=True,
+        append_images=[Image.new("RGB", (640, 480), color=(0, 0, 255))],
+        duration=[50, 100],
+        loop=0,
+    )
+
+    frames = _iter_lcd_animation(path)
+    first_frame, first_duration = next(frames)
+    second_frame, second_duration = next(frames)
+
+    assert first_frame[:3] == bytes((255, 0, 0))
+    assert first_duration == 0.05
+    assert second_frame[:3] == bytes((0, 0, 255))
+    assert second_duration == 0.1
+
+
+def test_lcd_statistics_renderer_returns_a_full_nonblank_frame(tmp_path):
+    background_path = tmp_path / "background.png"
+    Image.new("RGB", (640, 480), color=(1, 2, 3)).save(background_path)
+    path = tmp_path / "stats.json"
+    path.write_text(
+        json.dumps(
+            {
+                "background_color": "100713",
+                "font_color": "B300FF",
+                "background_opacity": 0.2,
+                "interval": 3,
+                "title": "COOLER",
+                "background": "background.png",
+                "layout": {
+                    "liquid": {
+                        "background_color": "210B2D",
+                        "background_opacity": 0.2,
+                        "offset_x": -4,
+                        "offset_y": 6,
+                        "font_color": "B300FF",
+                        "stats": [{"stat": "liquid_temperature", "indicator": "LIQUID"}],
+                    }
+                },
+            }
+        )
+    )
+    config = _load_lcd_stats_config(path, None)
+    background = _load_lcd_static_background(config["background"])
+    frame = _render_lcd_stats(
+        [
+            ("Liquid temperature", 29.9, "°C"),
+            ("Pump speed", 1260, "rpm"),
+            ("Pump fan speed", 870, "rpm"),
+        ],
+        config,
+        0,
+        3,
+        background,
+    )
+
+    assert config["background_color"] == (16, 7, 19)
+    assert config["font_color"] == (179, 0, 255)
+    assert config["background_opacity"] == 0.2
+    assert config["interval"] == 3
+    assert config["title"] == "COOLER"
+    assert list(config["layout"]) == ["liquid"]
+    assert config["layout"]["liquid"]["background_color"] == (33, 11, 45)
+    assert config["layout"]["liquid"]["background_opacity"] == 0.2
+    assert config["layout"]["liquid"]["offset_x"] == -4
+    assert config["layout"]["liquid"]["offset_y"] == 6
+    assert config["layout"]["liquid"]["font_color"] == (179, 0, 255)
+    assert config["background"] == background_path
+    assert len(frame) == 640 * 480 * 3
+    assert frame[:3] == bytes((4, 3, 6))
+    assert any(frame)
+
+
+def test_lcd_statistics_color_accepts_optional_hash_and_rejects_invalid_values():
+    assert _parse_lcd_color("B300FF") == (179, 0, 255)
+    assert _parse_lcd_color("#B300FF") == (179, 0, 255)
+    assert _parse_lcd_color(100713) == (16, 7, 19)
+    with pytest.raises(ValueError, match="six-digit RGB"):
+        _parse_lcd_color("purple")
+
+
+@pytest.mark.parametrize("interval", [0, -1])
+def test_lcd_statistics_shorthand_rejects_non_positive_intervals(interval):
+    with pytest.raises(ValueError, match="interval must be greater than zero"):
+        _load_lcd_stats_config("B300FF", interval)
+
+
+def test_contrib_lcd_dashboard_examples_only_use_cooler_telemetry():
+    examples = (
+        "extra/contrib/asus_ryujin/example_layouts/ryujin_extreme_stats.json",
+        "extra/contrib/asus_ryujin/example_layouts/ryujin_extreme_st4.json",
+    )
+
+    for path in examples:
+        config = _load_lcd_stats_config(path, None)
+        stats = [stat["stat"] for card in config["layout"].values() for stat in card["stats"]]
+        assert set(stats) <= {
+            "liquid_temperature",
+            "pump_duty",
+            "pump_speed",
+            "pump_fan_duty",
+            "pump_fan_speed",
+        }
+
+
+@pytest.mark.parametrize(
+    "value,unit,max_digits,expected",
+    [
+        (35.2, "°C", 5, "35.2°C"),
+        (1860, "rpm", 5, "1860rpm"),
+        (12_430, "MHz", 5, "12430MHz"),
+        (1_200_000, "", 5, "1.2M"),
+        ("4.25", "GHz", 5, "4.25GHz"),
+        ("N/A", "", 5, "N/A"),
+    ],
+)
+def test_lcd_statistics_values_fit_their_digit_budget(value, unit, max_digits, expected):
+    assert _format_lcd_value(value, unit, max_digits) == expected
+
+
+def test_lcd_custom_stat_runs_an_argv_command_without_a_shell(monkeypatch):
+    config = _load_lcd_stats_config(None, None)
+    config["layout"] = {
+        "custom": {
+            "background_color": None,
+            "font_color": None,
+            "stats": [
+                {
+                    "stat": "custom",
+                    "indicator": "TEST",
+                    "command": ["metric-tool", "--value"],
+                    "unit": "widgets",
+                }
+            ],
+        }
+    }
+    calls = []
+
+    def run(command, **kwargs):
+        calls.append((command, kwargs))
+        return SimpleNamespace(stdout="42\n")
+
+    monkeypatch.setattr(asus_ryujin_lcd.subprocess, "run", run)
+    custom_values = _read_lcd_custom_stats(config, 0)
+    frame = _render_lcd_stats([], config, 0, 5, custom_values=custom_values)
+
+    assert len(frame) == 640 * 480 * 3
+    assert calls == [
+        (
+            ["metric-tool", "--value"],
+            {
+                "shell": False,
+                "capture_output": True,
+                "check": True,
+                "text": True,
+                "timeout": 2,
+            },
+        )
+    ]
+
+
+def test_lcd_custom_stat_rejects_a_shell_command_string(tmp_path):
+    path = tmp_path / "stats.json"
+    path.write_text(
+        json.dumps(
+            {
+                "layout": {
+                    "custom": {
+                        "stats": [
+                            {"stat": "custom", "indicator": "TEST", "command": "echo 42"}
+                        ]
+                    }
+                }
+            }
+        )
+    )
+
+    with pytest.raises(ValueError, match="non-empty list of strings"):
+        _load_lcd_stats_config(path, None)
+
+
+@pytest.fixture
+def mock_ryujin():
+    return _create_mock_ryujin(0x1988)
 
 
 @pytest.fixture
 def mock_ryujin3():
-    product_id = 0x1BCB
-    config = DEVICE_CONFIGS[product_id]
-    return AsusRyujin(
-        _MockRyujinDevice(vendor_id=0x0B05, product_id=product_id),
-        config["name"],
-        fan_count=config["fan_count"],
-        pump_speed_offset=config["pump_speed_offset"],
-        pump_fan_speed_offset=config["pump_fan_speed_offset"],
-        temp_offset=config["temp_offset"],
-        duty_channel=config["duty_channel"],
-    )
+    return _create_mock_ryujin(0x1BCB)
 
 
 @pytest.mark.parametrize("product_id", [0x1988, 0x1BCB, 0x1ADE, 0x1AA2])
 def test_initialize(product_id):
     config = DEVICE_CONFIGS[product_id]
-    device = AsusRyujin(
-        _MockRyujinDevice(vendor_id=0x0B05, product_id=product_id),
-        config["name"],
-        fan_count=config["fan_count"],
-        pump_speed_offset=config["pump_speed_offset"],
-        pump_fan_speed_offset=config["pump_fan_speed_offset"],
-        temp_offset=config["temp_offset"],
-        duty_channel=config["duty_channel"],
-    )
+    device = _create_mock_ryujin(product_id)
 
     with device.connect():
         (firmware_status,) = device.initialize()
@@ -215,15 +473,7 @@ def test_initialize(product_id):
 @pytest.mark.parametrize("product_id", [0x1988, 0x1BCB, 0x1ADE, 0x1AA2])
 def test_status(product_id):
     config = DEVICE_CONFIGS[product_id]
-    device = AsusRyujin(
-        _MockRyujinDevice(vendor_id=0x0B05, product_id=product_id),
-        config["name"],
-        fan_count=config["fan_count"],
-        pump_speed_offset=config["pump_speed_offset"],
-        pump_fan_speed_offset=config["pump_fan_speed_offset"],
-        temp_offset=config["temp_offset"],
-        duty_channel=config["duty_channel"],
-    )
+    device = _create_mock_ryujin(product_id)
 
     with device.connect():
         actual = device.get_status()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,4 +1,5 @@
 import pytest
+
 from _testutils import VirtualBusDevice, VirtualControlMode
 
 import json
@@ -83,3 +84,27 @@ def test_json_status(main):
         }
     ]
     assert got == exp
+
+
+def test_set_screen_forwards_optional_interval():
+    class Device:
+        def __init__(self):
+            self.calls = []
+
+        def set_screen(self, *args, **kwargs):
+            self.calls.append((args, kwargs))
+
+    device = Device()
+    liquidctl.cli._device_set_screen(
+        device,
+        {
+            '<channel>': 'lcd',
+            '<mode>': 'stats',
+            '<value>': 'dashboard.json',
+            '<interval>': '5',
+        },
+    )
+
+    assert device.calls == [
+        (('lcd', 'stats', 'dashboard.json'), {'interval': '5'}),
+    ]


### PR DESCRIPTION
## Summary

Adds LCD support for the ASUS Ryujin III Extreme (USB ID `0b05:1bcb`):

- static RGB images
- host-streamed animated GIFs
- configurable JSON statistics dashboards with built-in cooler telemetry and optional trusted custom command values
- documented raw-framebuffer protocol and local-only Armoury asset setup

The implementation uses the LCD's bulk OUT endpoint with 640x480 RGB888 frames, while preserving the existing HID control interface.

## Example
https://github.com/user-attachments/assets/a66a92cd-29f0-4f4b-8d2c-4d12e7fa132b


## Validation

- Tested on an ASUS Ryujin III Extreme, firmware `AURJ3-S5F9-0104`
- Verified static images, GIF playback, dashboard rendering, and raw-mode recovery after invalid inputs
- `python -m pytest`: 554 passed, 2 skipped
- `python -m pip check`: passed

No Armoury Crate assets are included in this PR; the documented local asset directory is ignored by Git.

## AI assistance

AI-assisted during implementation; I reviewed the code, performed the hardware testing on a Ryujin III Extreme, and take responsibility for this contribution.